### PR TITLE
Fix unit tests to include Type() method in custom types

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -29,6 +29,10 @@ func (i *interval) String() string {
 	return fmt.Sprint(*i)
 }
 
+func (i *interval) Type() string {
+	return "interval"
+}
+
 // Set is the method to set the flag value, part of the flag.Value interface.
 // Set's argument is a string to be parsed to set the flag.
 // It's a comma-separated list, so we split it.

--- a/flag_test.go
+++ b/flag_test.go
@@ -245,6 +245,10 @@ func (f *flagVar) Set(value string) error {
 	return nil
 }
 
+func (f *flagVar) Type() string {
+	return "flagVar"
+}
+
 func TestUserDefined(t *testing.T) {
 	var flags FlagSet
 	flags.Init("test", ContinueOnError)


### PR DESCRIPTION
This was broken by commit 463bdc838f2b35 ("Adding Type() method to the values.") which added the method to the interface but did not update the custom types in unit tests.

Signed-off-by: Filipe Brandenburger <filbranden@google.com>