### PR TITLE
Fix handling of -- termination

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -543,6 +543,11 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 
 		if s[1] == '-' {
 			args, err = f.parseLongArg(s, args)
+
+			if len(s) == 2 {
+				// stop parsing after --
+				break
+			}
 		} else {
 			args, err = f.parseShortArg(s, args)
 		}

--- a/flag_test.go
+++ b/flag_test.go
@@ -197,8 +197,8 @@ func TestShorthand(t *testing.T) {
 		notaflag,
 	}
 	f.SetOutput(ioutil.Discard)
-	if err := f.Parse(args); err == nil {
-		t.Error("--i-look-like-a-flag should throw an error")
+	if err := f.Parse(args); err != nil {
+		t.Error("expected no error, got ", err)
 	}
 	if !f.Parsed() {
 		t.Error("f.Parse() = false after Parse")
@@ -354,5 +354,39 @@ func TestNoInterspersed(t *testing.T) {
 	args := f.Args()
 	if len(args) != 2 || args[0] != "break" || args[1] != "--false" {
 		t.Fatal("expected interspersed options/non-options to fail")
+	}
+}
+
+func TestTermination(t *testing.T) {
+	f := NewFlagSet("termination", ContinueOnError)
+	boolFlag := f.BoolP("bool", "l", false, "bool value")
+	if f.Parsed() {
+		t.Error("f.Parse() = true before Parse")
+	}
+	arg1 := "ls"
+	arg2 := "-l"
+	args := []string{
+		"--",
+		arg1,
+		arg2,
+	}
+	f.SetOutput(ioutil.Discard)
+	if err := f.Parse(args); err != nil {
+		t.Fatal("expected no error; got ", err)
+	}
+	if !f.Parsed() {
+		t.Error("f.Parse() = false after Parse")
+	}
+	if *boolFlag {
+		t.Error("expected boolFlag=false, got true")
+	}
+	if len(f.Args()) != 2 {
+		t.Errorf("expected 2 arguments, got %d: %v", len(f.Args()), f.Args())
+	}
+	if f.Args()[0] != arg1 {
+		t.Errorf("expected argument %q got %q", arg1, f.Args()[0])
+	}
+	if f.Args()[1] != arg2 {
+		t.Errorf("expected argument %q got %q", arg2, f.Args()[1])
 	}
 }


### PR DESCRIPTION
Fix handling of -- termination. Previously, if you ran

    $command -flag1 -etc -- some args after

the command's args would be doubled (some args after some args after).
Additionally, if there were items after the -- termination that looked
like flags, the parser would throw an error. It's better to terminate
parsing when -- is seen, because that usually indicates the caller wants
to pass the remainder of the arguments (including flags) as-is to
something else.