### PR TITLE
Declare Flag{ by name instead of order

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -141,12 +141,12 @@ type FlagSet struct {
 
 // A Flag represents the state of a flag.
 type Flag struct {
-	Name      string // name as it appears on command line
-	Shorthand string // one-letter abbreviated flag
-	Usage     string // help message
-	Value     Value  // value as set
-	DefValue  string // default value (as text); for usage message
-	Changed   bool   // If the user set the value (or if left to default)
+	Name        string              // name as it appears on command line
+	Shorthand   string              // one-letter abbreviated flag
+	Usage       string              // help message
+	Value       Value               // value as set
+	DefValue    string              // default value (as text); for usage message
+	Changed     bool                // If the user set the value (or if left to default)
 	Annotations map[string][]string // used by cobra.Command  bash autocomple code
 }
 
@@ -359,7 +359,13 @@ func (f *FlagSet) Var(value Value, name string, usage string) {
 // Like Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) VarP(value Value, name, shorthand, usage string) {
 	// Remember the default value as a string; it won't change.
-	flag := &Flag{name, shorthand, usage, value, value.String(), false, make(map[string][]string)}
+	flag := &Flag{
+		Name:      name,
+		Shorthand: shorthand,
+		Usage:     usage,
+		Value:     value,
+		DefValue:  value.String(),
+	}
 	f.AddFlag(flag)
 }
 
@@ -554,7 +560,7 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 			args, err = f.parseShortArg(s, args)
 		}
 		if err != nil {
-		   return
+			return
 		}
 	}
 	return


### PR DESCRIPTION
In order to be able to add new (unitialized) fields to Flags{} declare
fields by name instead of order