### PR TITLE
Allow WordSeparators to be set after flags are added

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -621,9 +621,14 @@ func SetInterspersed(interspersed bool) {
 // SetWordSeparators sets a list of strings to be considerered as word
 // separators and normalized for the pruposes of lookups.  For example, if this
 // is set to {"-", "_", "."} then --foo_bar, --foo-bar, and --foo.bar are
-// considered equivalent flags.
+// considered equivalent flags.  This must be called before flags are parsed,
+// and may only be called once.
 func (f *FlagSet) SetWordSeparators(separators []string) {
 	f.wordSeparators = separators
+	for k, v := range f.formal {
+		delete(f.formal, k)
+		f.formal[f.normalizeFlagName(string(k))] = v
+	}
 }
 
 // Parsed returns true if the command-line flags have been parsed.

--- a/flag_test.go
+++ b/flag_test.go
@@ -238,8 +238,9 @@ func testNormalizedNames(args []string, t *testing.T) {
 	if f.Parsed() {
 		t.Error("f.Parse() = true before Parse")
 	}
-	f.SetWordSeparators([]string{"-", "_"})
 	withDashFlag := f.Bool("with-dash-flag", false, "bool value")
+	// Set this after some flags have been added and before others.
+	f.SetWordSeparators([]string{"-", "_"})
 	withUnderFlag := f.Bool("with_under_flag", false, "bool value")
 	withBothFlag := f.Bool("with-both_flag", false, "bool value")
 	if err := f.Parse(args); err != nil {


### PR DESCRIPTION
This stems from our own code layout where a bunch of binaries fan-in to a central lib which calls pflag.Parse() - it's WAY simpler to call this once there than in all the places that allocate a new FlagSet (and nobody allocates CommandLine).  That said, we COULD do this rewriting in that lib with VisitAll, I guess, if you hate this PR.

