### PR TITLE
Merge ogier/pflag and enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
+sudo: false
+
 language: go
+
+go:
+        - 1.3
+        - 1.4
+        - tip

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/ogier/pflag.png?branch=master)](https://travis-ci.org/ogier/pflag)
+
 ## Description
 
 pflag is a drop-in replacement for Go's flag package, implementing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/ogier/pflag.png?branch=master)](https://travis-ci.org/ogier/pflag)
+[![Build Status](https://travis-ci.org/spf13/pflag.svg?branch=master)](https://travis-ci.org/spf13/pflag)
 
 ## Description
 

--- a/bool_test.go
+++ b/bool_test.go
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package pflag_test
+package pflag
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"testing"
-
-	. "github.com/spf13/pflag"
 )
 
 // This value can be a boolean ("true", "false") or "maybe"
@@ -156,8 +155,9 @@ func TestImplicitFalse(t *testing.T) {
 func TestInvalidValue(t *testing.T) {
 	var tristate triStateValue
 	f := setUpFlagSet(&tristate)
-	args := []string{"--tristate=invalid"}
-	_, err := parseReturnStderr(t, f, args)
+	var buf bytes.Buffer
+	f.SetOutput(&buf)
+	err := f.Parse([]string{"--tristate=invalid"})
 	if err == nil {
 		t.Fatal("expected an error but did not get any, tristate has value", tristate)
 	}

--- a/flag_test.go
+++ b/flag_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package pflag_test
+package pflag
 
 import (
 	"bytes"
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	. "github.com/spf13/pflag"
 )
 
 var (


### PR DESCRIPTION
This patch merges ogier/pflag/master into spf13/master.

It has very few actual changes. But it has one go test fix and it turns on travis. It also shows that we aren't "behind" at all in the github fork graph. So everyone who looks will know we are the best   :)

@spf13 would have to turn on travis, doesn't look like I can....