### PR TITLE
Allows any flag to expect optional arguments

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -37,23 +37,23 @@ func (b *boolValue) IsBoolFlag() bool { return true }
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
 func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {
-	f.VarP(newBoolValue(value, p), name, "", usage)
+	f.OVarP(newBoolValue(value, p), name, "", usage, true)
 }
 
 // Like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	f.VarP(newBoolValue(value, p), name, shorthand, usage)
+	f.OVarP(newBoolValue(value, p), name, shorthand, usage, true)
 }
 
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
 func BoolVar(p *bool, name string, value bool, usage string) {
-	CommandLine.VarP(newBoolValue(value, p), name, "", usage)
+	CommandLine.OVarP(newBoolValue(value, p), name, "", usage, true)
 }
 
 // Like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	CommandLine.VarP(newBoolValue(value, p), name, shorthand, usage)
+	CommandLine.OVarP(newBoolValue(value, p), name, shorthand, usage, true)
 }
 
 // Bool defines a bool flag with specified name, default value, and usage string.
@@ -61,6 +61,7 @@ func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
 func (f *FlagSet) Bool(name string, value bool, usage string) *bool {
 	p := new(bool)
 	f.BoolVarP(p, name, "", value, usage)
+	f.MarkOptional(name)
 	return p
 }
 
@@ -68,16 +69,21 @@ func (f *FlagSet) Bool(name string, value bool, usage string) *bool {
 func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string) *bool {
 	p := new(bool)
 	f.BoolVarP(p, name, shorthand, value, usage)
+	f.MarkOptional(name)
 	return p
 }
 
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
 func Bool(name string, value bool, usage string) *bool {
-	return CommandLine.BoolP(name, "", value, usage)
+	b := CommandLine.BoolP(name, "", value, usage)
+	CommandLine.MarkOptional(name)
+	return b
 }
 
 // Like Bool, but accepts a shorthand letter that can be used after a single dash.
 func BoolP(name, shorthand string, value bool, usage string) *bool {
-	return CommandLine.BoolP(name, shorthand, value, usage)
+	b := CommandLine.BoolP(name, shorthand, value, usage)
+	CommandLine.MarkOptional(name)
+	return b
 }

--- a/bool_test.go
+++ b/bool_test.go
@@ -60,6 +60,7 @@ func setUpFlagSet(tristate *triStateValue) *FlagSet {
 	f := NewFlagSet("test", ContinueOnError)
 	*tristate = triStateFalse
 	f.VarP(tristate, "tristate", "t", "tristate value (true, maybe or false)")
+	f.MarkOptional("tristate")
 	return f
 }
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -17,14 +17,15 @@ import (
 )
 
 var (
-	test_bool     = Bool("test_bool", false, "bool value")
-	test_int      = Int("test_int", 0, "int value")
-	test_int64    = Int64("test_int64", 0, "int64 value")
-	test_uint     = Uint("test_uint", 0, "uint value")
-	test_uint64   = Uint64("test_uint64", 0, "uint64 value")
-	test_string   = String("test_string", "0", "string value")
-	test_float64  = Float64("test_float64", 0, "float64 value")
-	test_duration = Duration("test_duration", 0, "time.Duration value")
+	test_bool         = Bool("test_bool", false, "bool value")
+	test_int          = Int("test_int", 0, "int value")
+	test_int64        = Int64("test_int64", 0, "int64 value")
+	test_uint         = Uint("test_uint", 0, "uint value")
+	test_uint64       = Uint64("test_uint64", 0, "uint64 value")
+	test_string       = String("test_string", "0", "string value")
+	test_float64      = Float64("test_float64", 0, "float64 value")
+	test_duration     = Duration("test_duration", 0, "time.Duration value")
+	test_optional_int = Int("test_optional_int", 0, "optional int value")
 )
 
 func boolString(s string) string {
@@ -55,7 +56,7 @@ func TestEverything(t *testing.T) {
 		}
 	}
 	VisitAll(visitor)
-	if len(m) != 8 {
+	if len(m) != 9 {
 		t.Error("VisitAll misses some flags")
 		for k, v := range m {
 			t.Log(k, *v)
@@ -78,9 +79,10 @@ func TestEverything(t *testing.T) {
 	Set("test_string", "1")
 	Set("test_float64", "1")
 	Set("test_duration", "1s")
+	Set("test_optional_int", "1")
 	desired = "1"
 	Visit(visitor)
-	if len(m) != 8 {
+	if len(m) != 9 {
 		t.Error("Visit fails after set")
 		for k, v := range m {
 			t.Log(k, *v)
@@ -119,6 +121,10 @@ func testParse(f *FlagSet, t *testing.T) {
 	stringFlag := f.String("string", "0", "string value")
 	float64Flag := f.Float64("float64", 0, "float64 value")
 	durationFlag := f.Duration("duration", 5*time.Second, "time.Duration value")
+	optionalIntNoValueFlag := f.Int("optional-int-no-value", 9, "int value")
+	optionalIntWithValueFlag := f.Int("optional-int-with-value", 9, "int value")
+	f.MarkOptional("optional-int-no-value")
+	f.MarkOptional("optional-int-with-value")
 	extra := "one-extra-argument"
 	args := []string{
 		"--bool",
@@ -131,6 +137,8 @@ func testParse(f *FlagSet, t *testing.T) {
 		"--string=hello",
 		"--float64=2718e28",
 		"--duration=2m",
+		"--optional-int-no-value",
+		"--optional-int-with-value=42",
 		extra,
 	}
 	if err := f.Parse(args); err != nil {
@@ -168,6 +176,12 @@ func testParse(f *FlagSet, t *testing.T) {
 	}
 	if *durationFlag != 2*time.Minute {
 		t.Error("duration flag should be 2m, is ", *durationFlag)
+	}
+	if *optionalIntNoValueFlag != 9 {
+		t.Error("optional int flag should be the default value, is ", *optionalIntNoValueFlag)
+	}
+	if *optionalIntWithValueFlag != 42 {
+		t.Error("optional int flag should be 42, is ", *optionalIntWithValueFlag)
 	}
 	if len(f.Args()) != 1 {
 		t.Error("expected one argument, got", len(f.Args()))


### PR DESCRIPTION
The motivation for this change is to allow any flag or flag type (not only boolean) to support optional arguments as long as they are declared to do so. Example:

```
git diff --stat[=<width>]
```

The logic around flags with empty arguments (e.g. `--debug`) were detached from the boolean type and moved to a separate attribute called `Optional`. This allows to mark *any* flag type as supporting optional arguments. 

The difference in comparison to not providing the flag at all is that the `Changed` attribute is set, so it allows to control the difference of not providing the flag or providing but without an argument.

A possible use case would be:

```
flag.IntVar(&flagvar, "list", 10, "list the number of items")
flag.MarkOptional("list")
```

So when using the flag users could either provide the number of items to display in the list, or not provide any argument to use the default `int` value:

```
deploy           // perform a deployment
deploy --list    // will list 10 deployments (default value)
deploy --list=20 // will list 20 deployments
```

The behavior for default types were not changed (the only flags that allow empty arguments by default are boolean). 