### PR TITLE
Fix '--flag arg' and Allow flags to take optional arguments

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -50,31 +50,31 @@ func (f *FlagSet) GetBool(name string) (bool, error) {
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
 func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {
-	f.VarP(newBoolValue(value, p), name, "", usage)
+	f.BoolVarP(p, name, "", value, usage)
 }
 
 // Like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	f.VarP(newBoolValue(value, p), name, shorthand, usage)
+	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage)
+	flag.NoOptDefVal = "true"
 }
 
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
 func BoolVar(p *bool, name string, value bool, usage string) {
-	CommandLine.VarP(newBoolValue(value, p), name, "", usage)
+	BoolVarP(p, name, "", value, usage)
 }
 
 // Like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	CommandLine.VarP(newBoolValue(value, p), name, shorthand, usage)
+	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage)
+	flag.NoOptDefVal = "true"
 }
 
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
 func (f *FlagSet) Bool(name string, value bool, usage string) *bool {
-	p := new(bool)
-	f.BoolVarP(p, name, "", value, usage)
-	return p
+	return f.BoolP(name, "", value, usage)
 }
 
 // Like Bool, but accepts a shorthand letter that can be used after a single dash.
@@ -87,10 +87,11 @@ func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string) *bool 
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
 func Bool(name string, value bool, usage string) *bool {
-	return CommandLine.BoolP(name, "", value, usage)
+	return BoolP(name, "", value, usage)
 }
 
 // Like Bool, but accepts a shorthand letter that can be used after a single dash.
 func BoolP(name, shorthand string, value bool, usage string) *bool {
-	return CommandLine.BoolP(name, shorthand, value, usage)
+	b := CommandLine.BoolP(name, shorthand, value, usage)
+	return b
 }

--- a/bool_test.go
+++ b/bool_test.go
@@ -59,7 +59,8 @@ func (v *triStateValue) Type() string {
 func setUpFlagSet(tristate *triStateValue) *FlagSet {
 	f := NewFlagSet("test", ContinueOnError)
 	*tristate = triStateFalse
-	f.VarP(tristate, "tristate", "t", "tristate value (true, maybe or false)")
+	flag := f.VarPF(tristate, "tristate", "t", "tristate value (true, maybe or false)")
+	flag.NoOptDefVal = "true"
 	return f
 }
 
@@ -160,5 +161,20 @@ func TestInvalidValue(t *testing.T) {
 	err := f.Parse([]string{"--tristate=invalid"})
 	if err == nil {
 		t.Fatal("expected an error but did not get any, tristate has value", tristate)
+	}
+}
+
+func TestBoolP(t *testing.T) {
+	b := BoolP("bool", "b", false, "bool value in CommandLine")
+	c := BoolP("c", "c", false, "other bool value")
+	args := []string{"--bool"}
+	if err := CommandLine.Parse(args); err != nil {
+		t.Error("expected no error, got ", err)
+	}
+	if *b != true {
+		t.Errorf("expected b=true got b=%s", b)
+	}
+	if *c != false {
+		t.Errorf("expect c=false got c=%s", c)
 	}
 }

--- a/flag.go
+++ b/flag.go
@@ -152,6 +152,7 @@ type Flag struct {
 	Value       Value               // value as set
 	DefValue    string              // default value (as text); for usage message
 	Changed     bool                // If the user set the value (or if left to default)
+	NoOptDefVal string              //default value (as text); if the flag is on the command line without any options
 	Deprecated  string              // If this flag is deprecated, this string is the new or now thing to use
 	Annotations map[string][]string // used by cobra.Command  bash autocomple code
 }
@@ -341,16 +342,25 @@ func (f *FlagSet) PrintDefaults() {
 		if len(flag.Deprecated) > 0 {
 			return
 		}
-		format := "--%s=%s: %s\n"
-		if _, ok := flag.Value.(*stringValue); ok {
-			// put quotes on the value
-			format = "--%s=%q: %s\n"
-		}
+		format := ""
+		// ex: w/ option string argument '-%s, --%s[=%q]: %s\n'
 		if len(flag.Shorthand) > 0 {
-			format = "  -%s, " + format
+			format = "  -%s, --%s"
 		} else {
-			format = "   %s   " + format
+			format = "   %s   --%s"
 		}
+		if len(flag.NoOptDefVal) > 0 {
+			format = format + "["
+		}
+		if _, ok := flag.Value.(*stringValue); ok {
+			format = format + "=%q"
+		} else {
+			format = format + "=%s"
+		}
+		if len(flag.NoOptDefVal) > 0 {
+			format = format + "]"
+		}
+		format = format + ": %s\n"
 		fmt.Fprintf(f.out(), format, flag.Shorthand, flag.Name, flag.DefValue, flag.Usage)
 	})
 }
@@ -443,8 +453,8 @@ func (f *FlagSet) Var(value Value, name string, usage string) {
 	f.VarP(value, name, "", usage)
 }
 
-// Like Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) VarP(value Value, name, shorthand, usage string) {
+// Like VarP, but returns the flag created
+func (f *FlagSet) VarPF(value Value, name, shorthand, usage string) *Flag {
 	// Remember the default value as a string; it won't change.
 	flag := &Flag{
 		Name:      name,
@@ -454,6 +464,12 @@ func (f *FlagSet) VarP(value Value, name, shorthand, usage string) {
 		DefValue:  value.String(),
 	}
 	f.AddFlag(flag)
+	return flag
+}
+
+// Like Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) VarP(value Value, name, shorthand, usage string) {
+	_ = f.VarPF(value, name, shorthand, usage)
 }
 
 func (f *FlagSet) AddFlag(flag *Flag) {
@@ -566,11 +582,11 @@ func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) 
 	if len(split) == 2 {
 		// '--flag=arg'
 		value = split[1]
-	} else if bv, ok := flag.Value.(boolFlag); ok && bv.IsBoolFlag() {
-		// '--flag' (where flag is a bool)
-		value = "true"
+	} else if len(flag.NoOptDefVal) > 0 {
+		// '--flag' (arg was optional)
+		value = flag.NoOptDefVal
 	} else {
-		// '--flag' (where flag was not a bool)
+		// '--flag' (arg was required)
 		err = f.failf("flag needs an argument: %s", s)
 		return
 	}
@@ -598,8 +614,8 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string) (outShor
 	if len(shorthands) > 2 && shorthands[1] == '=' {
 		value = shorthands[2:]
 		outShorts = ""
-	} else if bv, ok := flag.Value.(boolFlag); ok && bv.IsBoolFlag() {
-		value = "true"
+	} else if len(flag.NoOptDefVal) > 0 {
+		value = flag.NoOptDefVal
 	} else if len(shorthands) > 1 {
 		value = shorthands[1:]
 		outShorts = ""

--- a/flag.go
+++ b/flag.go
@@ -585,6 +585,10 @@ func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) 
 	} else if len(flag.NoOptDefVal) > 0 {
 		// '--flag' (arg was optional)
 		value = flag.NoOptDefVal
+	} else if len(a) > 0 {
+		// '--flag arg'
+		value = a[0]
+		a = a[1:]
 	} else {
 		// '--flag' (arg was required)
 		err = f.failf("flag needs an argument: %s", s)

--- a/flag_test.go
+++ b/flag_test.go
@@ -176,7 +176,7 @@ func testParse(f *FlagSet, t *testing.T) {
 		"--int8=-8",
 		"--int32=-32",
 		"--int64=0x23",
-		"--uint=24",
+		"--uint", "24",
 		"--uint8=8",
 		"--uint16=16",
 		"--uint32=32",


### PR DESCRIPTION
Today `--flag arg` does not work. It just fails to parse. So fix that.

At the same time allow flags to specify that their args are 'optional'.  Much as with a bool =true =false are optional. So one could do

```
var flagvar int
flag.IntVar(&flagvar, "list", 0, "list the number of items")
flag.Lookup("list").NoOptDefVal = 10
```

In which case `--flag` and `--flag=20` would be valid, but `--flag 20` would not work.