### PR TITLE
Support bool= with shortnames

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -553,10 +553,13 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string) (outShor
 		return
 	}
 	var value string
-	if bv, ok := flag.Value.(boolFlag); ok && bv.IsBoolFlag() {
+	if len(shorthands) > 2 && shorthands[1] == '=' {
+		value = shorthands[2:]
+		outShorts = ""
+	} else if bv, ok := flag.Value.(boolFlag); ok && bv.IsBoolFlag() {
 		value = "true"
 	} else if len(shorthands) > 1 {
-		value = strings.TrimPrefix(shorthands[1:], "=")
+		value = shorthands[1:]
 		outShorts = ""
 	} else if len(args) > 0 {
 		value = args[0]

--- a/flag_test.go
+++ b/flag_test.go
@@ -184,6 +184,7 @@ func TestShorthand(t *testing.T) {
 	boolaFlag := f.BoolP("boola", "a", false, "bool value")
 	boolbFlag := f.BoolP("boolb", "b", false, "bool2 value")
 	boolcFlag := f.BoolP("boolc", "c", false, "bool3 value")
+	booldFlag := f.BoolP("boold", "d", false, "bool4 value")
 	stringaFlag := f.StringP("stringa", "s", "0", "string value")
 	stringzFlag := f.StringP("stringz", "z", "0", "string value")
 	extra := "interspersed-argument"
@@ -194,6 +195,7 @@ func TestShorthand(t *testing.T) {
 		"-cs",
 		"hello",
 		"-z=something",
+		"-d=true",
 		"--",
 		notaflag,
 	}
@@ -212,6 +214,9 @@ func TestShorthand(t *testing.T) {
 	}
 	if *boolcFlag != true {
 		t.Error("boolc flag should be true, is ", *boolcFlag)
+	}
+	if *booldFlag != true {
+		t.Error("boold flag should be true, is ", *booldFlag)
 	}
 	if *stringaFlag != "hello" {
 		t.Error("stringa flag should be `hello`, is ", *stringaFlag)


### PR DESCRIPTION
Currently a shortname bool variable b cannot use the -b=true -b=false
form because the -b is assumed to mean true and the = format is never
noticed.