### PR TITLE
Fixed usage printing name

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -519,8 +519,7 @@ func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) 
 	}
 	split := strings.SplitN(name, "=", 2)
 	name = split[0]
-	m := f.formal
-	flag, alreadythere := m[f.normalizeFlagName(name)] // BUG
+	flag, alreadythere := f.formal[f.normalizeFlagName(name)]
 	if !alreadythere {
 		if name == "help" { // special case for nice help message.
 			f.usage()

--- a/flag.go
+++ b/flag.go
@@ -184,7 +184,9 @@ func (f *FlagSet) SetNormalizeFunc(n func(f *FlagSet, name string) NormalizedNam
 	f.normalizeNameFunc = n
 	for k, v := range f.formal {
 		delete(f.formal, k)
-		f.formal[f.normalizeFlagName(string(k))] = v
+		nname := f.normalizeFlagName(string(k))
+		f.formal[nname] = v
+		v.Name = string(nname)
 	}
 }
 
@@ -433,6 +435,8 @@ func (f *FlagSet) AddFlag(flag *Flag) {
 	if f.formal == nil {
 		f.formal = make(map[NormalizedName]*Flag)
 	}
+
+	flag.Name = string(normalizedFlagName)
 	f.formal[normalizedFlagName] = flag
 
 	if len(flag.Shorthand) == 0 {

--- a/flag_test.go
+++ b/flag_test.go
@@ -349,6 +349,31 @@ func TestCustomNormalizedNames(t *testing.T) {
 	}
 }
 
+// Every flag we add, the name (displayed also in usage) should normalized
+func TestNormalizationFuncShouldChangeFlagName(t *testing.T) {
+	// Test normalization after addition
+	f := NewFlagSet("normalized", ContinueOnError)
+
+	f.Bool("valid_flag", false, "bool value")
+	if f.Lookup("valid_flag").Name != "valid_flag" {
+		t.Error("The new flag should have the name 'valid_flag' instead of ", f.Lookup("valid_flag").Name)
+	}
+
+	f.SetNormalizeFunc(wordSepNormalizeFunc)
+	if f.Lookup("valid_flag").Name != "valid.flag" {
+		t.Error("The new flag should have the name 'valid.flag' instead of ", f.Lookup("valid_flag").Name)
+	}
+
+	// Test normalization before addition
+	f = NewFlagSet("normalized", ContinueOnError)
+	f.SetNormalizeFunc(wordSepNormalizeFunc)
+
+	f.Bool("valid_flag", false, "bool value")
+	if f.Lookup("valid_flag").Name != "valid.flag" {
+		t.Error("The new flag should have the name 'valid.flag' instead of ", f.Lookup("valid_flag").Name)
+	}
+}
+
 // Declare a user-defined flag type.
 type flagVar []string
 


### PR DESCRIPTION
The name of the commands should also change when a Normalization function is provided. A case that this creates a problem is when we are trying to print usage and help information, as the names that are shown to the user are not normalized.