### PR TITLE
fix mixed named and positional argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Would result in something like
 
 ```
 --flag    // boolean flags, or flags with no option default values
---flag x  // only on flags without a default value
+--flag x
 --flag=x
 ```
 

--- a/flag.go
+++ b/flag.go
@@ -582,13 +582,13 @@ func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) 
 	if len(split) == 2 {
 		// '--flag=arg'
 		value = split[1]
-	} else if len(flag.NoOptDefVal) > 0 {
-		// '--flag' (arg was optional)
-		value = flag.NoOptDefVal
-	} else if len(a) > 0 {
+	} else if flag.Value.Type() != "bool" && len(a) > 1 && !strings.HasPrefix(a[0], "-") {
 		// '--flag arg'
 		value = a[0]
 		a = a[1:]
+	} else if len(flag.NoOptDefVal) > 0 {
+		// '--flag' (arg was optional)
+		value = flag.NoOptDefVal
 	} else {
 		// '--flag' (arg was required)
 		err = f.failf("flag needs an argument: %s", s)

--- a/flag_test.go
+++ b/flag_test.go
@@ -753,3 +753,21 @@ func TestMultipleNormalizeFlagNameInvocations(t *testing.T) {
 		t.Fatal("Expected normalizeFlagNameInvocations to be 1; got ", normalizeFlagNameInvocations)
 	}
 }
+
+func TestInterspersedWithNoOptDefVal(t *testing.T) {
+	var flags FlagSet
+
+	var b bool
+	flags.BoolVar(&b, "b", false, "b flag")
+
+	var s string
+	flags.StringVar(&s, "s", "", "s flag")
+	flags.Lookup("s").NoOptDefVal = "s"
+
+	if err := flags.Parse([]string{"--s", "S", "--b", "positional"}); err != nil {
+		t.Error(err)
+	}
+	if s != "S" {
+		t.Fatalf("Could not override named argument. Still: %v", s)
+	}
+}


### PR DESCRIPTION
- Prefer a given argument over the default value
- Look ahead to detect given arguments that are not specified with the
  connectint `=` to the argument name

Fixes #32.