### PR TITLE
String and Int slices called twice should append not overwrite

### DIFF
--- a/int_slice.go
+++ b/int_slice.go
@@ -25,7 +25,7 @@ func (s *intSliceValue) Set(val string) error {
 		}
 
 	}
-	*s = intSliceValue(out)
+	*s = append(*s, out...)
 	return nil
 }
 
@@ -38,10 +38,11 @@ func (s *intSliceValue) String() string {
 	for i, d := range *s {
 		out[i] = fmt.Sprintf("%d", d)
 	}
-	return strings.Join(out, ",")
+	return "[" + strings.Join(out, ",") + "]"
 }
 
 func intSliceConv(val string) (interface{}, error) {
+	val = strings.Trim(val, "[]")
 	ss := strings.Split(val, ",")
 	out := make([]int, len(ss))
 	for i, d := range ss {

--- a/int_slice_test.go
+++ b/int_slice_test.go
@@ -47,3 +47,23 @@ func TestIS(t *testing.T) {
 		}
 	}
 }
+
+func TestISCalledTwice(t *testing.T) {
+	var is []int
+	f := setUpISFlagSet(&is)
+
+	in := []string{"1,2", "3"}
+	expected := []int{1, 2, 3}
+	argfmt := "--is=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range is {
+		if expected[i] != v {
+			t.Fatalf("expected ss[%d] to be %s but got: %s", i, expected[i], v)
+		}
+	}
+}

--- a/string_slice.go
+++ b/string_slice.go
@@ -14,7 +14,7 @@ func newStringSliceValue(val []string, p *[]string) *stringSliceValue {
 
 func (s *stringSliceValue) Set(val string) error {
 	v := strings.Split(val, ",")
-	*s = stringSliceValue(v)
+	*s = append(*s, v...)
 	return nil
 }
 func (s *stringSliceValue) Type() string {

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -28,17 +28,37 @@ func TestSS(t *testing.T) {
 	}
 	for i, v := range ss {
 		if vals[i] != v {
-			t.Fatal("expected ss[%d] to be %s but got: %s", i, vals[i], v)
+			t.Fatalf("expected ss[%d] to be %s but got: %s", i, vals[i], v)
 		}
 	}
 
 	getSS, err := f.GetStringSlice("ss")
 	if err != nil {
-		t.Fatal("got an error from GetStringSlice(): %v", err)
+		t.Fatal("got an error from GetStringSlice():", err)
 	}
 	for i, v := range getSS {
 		if vals[i] != v {
-			t.Fatal("expected ss[%d] to be %s from GetStringSlice but got: %s", i, vals[i], v)
+			t.Fatalf("expected ss[%d] to be %s from GetStringSlice but got: %s", i, vals[i], v)
+		}
+	}
+}
+
+func TestSSCalledTwice(t *testing.T) {
+	var ss []string
+	f := setUpSSFlagSet(&ss)
+
+	in := []string{"one,two", "three"}
+	expected := []string{"one", "two", "three"}
+	argfmt := "--ss=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ss {
+		if expected[i] != v {
+			t.Fatalf("expected ss[%d] to be %s but got: %s", i, expected[i], v)
 		}
 	}
 }


### PR DESCRIPTION
This allows users to do things like
```
cmd --filename=file1 --filename=file2 --filename=file3,file4
```
And internally we will get
```
[]string{"file1", "file2", "file3", "file4"}
```