### PR TITLE
Do not append to default values in {String,Int}Slice

### DIFF
--- a/int_slice.go
+++ b/int_slice.go
@@ -7,11 +7,16 @@ import (
 )
 
 // -- intSlice Value
-type intSliceValue []int
+type intSliceValue struct {
+	value   *[]int
+	changed bool
+}
 
 func newIntSliceValue(val []int, p *[]int) *intSliceValue {
-	*p = val
-	return (*intSliceValue)(p)
+	isv := new(intSliceValue)
+	isv.value = p
+	*isv.value = val
+	return isv
 }
 
 func (s *intSliceValue) Set(val string) error {
@@ -25,7 +30,12 @@ func (s *intSliceValue) Set(val string) error {
 		}
 
 	}
-	*s = append(*s, out...)
+	if !s.changed {
+		*s.value = out
+	} else {
+		*s.value = append(*s.value, out...)
+	}
+	s.changed = true
 	return nil
 }
 
@@ -34,8 +44,8 @@ func (s *intSliceValue) Type() string {
 }
 
 func (s *intSliceValue) String() string {
-	out := make([]string, len(*s))
-	for i, d := range *s {
+	out := make([]string, len(*s.value))
+	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%d", d)
 	}
 	return "[" + strings.Join(out, ",") + "]"

--- a/int_slice_test.go
+++ b/int_slice_test.go
@@ -17,6 +17,12 @@ func setUpISFlagSet(isp *[]int) *FlagSet {
 	return f
 }
 
+func setUpISFlagSetWithDefault(isp *[]int) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.IntSliceVar(isp, "is", []int{0, 1}, "Command seperated list!")
+	return f
+}
+
 func TestEmptyIS(t *testing.T) {
 	var is []int
 	f := setUpISFlagSet(&is)
@@ -27,7 +33,7 @@ func TestEmptyIS(t *testing.T) {
 
 	getIS, err := f.GetIntSlice("is")
 	if err != nil {
-		t.Fatal("got an error from GetStringSlice():", err)
+		t.Fatal("got an error from GetIntSlice():", err)
 	}
 	if len(getIS) != 0 {
 		t.Fatalf("got is %v with len=%d but expected length=0", getIS, len(getIS))
@@ -65,6 +71,76 @@ func TestIS(t *testing.T) {
 	}
 }
 
+func TestISDefault(t *testing.T) {
+	var is []int
+	f := setUpISFlagSetWithDefault(&is)
+
+	vals := []string{"0", "1"}
+
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range is {
+		d, err := strconv.Atoi(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected is[%d] to be %s but got: %s", i, d, v)
+		}
+	}
+
+	getIS, err := f.GetIntSlice("is")
+	if err != nil {
+		t.Fatal("got an error from GetIntSlice():", err)
+	}
+	for i, v := range getIS {
+		d, err := strconv.Atoi(vals[i])
+		if err != nil {
+			t.Fatal("got an error from GetIntSlice():", err)
+		}
+		if d != v {
+			t.Fatalf("expected is[%d] to be %s from GetIntSlice but got: %s", i, d, v)
+		}
+	}
+}
+
+func TestISWithDefault(t *testing.T) {
+	var is []int
+	f := setUpISFlagSetWithDefault(&is)
+
+	vals := []string{"1", "2"}
+	arg := fmt.Sprintf("--is=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range is {
+		d, err := strconv.Atoi(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected is[%d] to be %s but got: %s", i, d, v)
+		}
+	}
+
+	getIS, err := f.GetIntSlice("is")
+	if err != nil {
+		t.Fatal("got an error from GetIntSlice():", err)
+	}
+	for i, v := range getIS {
+		d, err := strconv.Atoi(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected is[%d] to be %s from GetIntSlice but got: %s", i, d, v)
+		}
+	}
+}
+
 func TestISCalledTwice(t *testing.T) {
 	var is []int
 	f := setUpISFlagSet(&is)
@@ -80,7 +156,7 @@ func TestISCalledTwice(t *testing.T) {
 	}
 	for i, v := range is {
 		if expected[i] != v {
-			t.Fatalf("expected ss[%d] to be %s but got: %s", i, expected[i], v)
+			t.Fatalf("expected is[%d] to be %s but got: %s", i, expected[i], v)
 		}
 	}
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -1,27 +1,41 @@
 package pflag
 
 import (
+	"fmt"
 	"strings"
 )
 
+var _ = fmt.Fprint
+
 // -- stringSlice Value
-type stringSliceValue []string
+type stringSliceValue struct {
+	value   *[]string
+	changed bool
+}
 
 func newStringSliceValue(val []string, p *[]string) *stringSliceValue {
-	*p = val
-	return (*stringSliceValue)(p)
+	ssv := new(stringSliceValue)
+	ssv.value = p
+	*ssv.value = val
+	return ssv
 }
 
 func (s *stringSliceValue) Set(val string) error {
 	v := strings.Split(val, ",")
-	*s = append(*s, v...)
+	if !s.changed {
+		*s.value = v
+	} else {
+		*s.value = append(*s.value, v...)
+	}
+	s.changed = true
 	return nil
 }
+
 func (s *stringSliceValue) Type() string {
 	return "stringSlice"
 }
 
-func (s *stringSliceValue) String() string { return "[" + strings.Join(*s, ",") + "]" }
+func (s *stringSliceValue) String() string { return "[" + strings.Join(*s.value, ",") + "]" }
 
 func stringSliceConv(sval string) (interface{}, error) {
 	sval = strings.Trim(sval, "[]")

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -16,6 +16,12 @@ func setUpSSFlagSet(ssp *[]string) *FlagSet {
 	return f
 }
 
+func setUpSSFlagSetWithDefault(ssp *[]string) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.StringSliceVar(ssp, "ss", []string{"default", "values"}, "Command seperated list!")
+	return f
+}
+
 func TestEmptySS(t *testing.T) {
 	var ss []string
 	f := setUpSSFlagSet(&ss)
@@ -36,6 +42,60 @@ func TestEmptySS(t *testing.T) {
 func TestSS(t *testing.T) {
 	var ss []string
 	f := setUpSSFlagSet(&ss)
+
+	vals := []string{"one", "two", "4", "3"}
+	arg := fmt.Sprintf("--ss=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ss {
+		if vals[i] != v {
+			t.Fatalf("expected ss[%d] to be %s but got: %s", i, vals[i], v)
+		}
+	}
+
+	getSS, err := f.GetStringSlice("ss")
+	if err != nil {
+		t.Fatal("got an error from GetStringSlice():", err)
+	}
+	for i, v := range getSS {
+		if vals[i] != v {
+			t.Fatalf("expected ss[%d] to be %s from GetStringSlice but got: %s", i, vals[i], v)
+		}
+	}
+}
+
+func TestSSDefault(t *testing.T) {
+	var ss []string
+	f := setUpSSFlagSetWithDefault(&ss)
+
+	vals := []string{"default", "values"}
+
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ss {
+		if vals[i] != v {
+			t.Fatalf("expected ss[%d] to be %s but got: %s", i, vals[i], v)
+		}
+	}
+
+	getSS, err := f.GetStringSlice("ss")
+	if err != nil {
+		t.Fatal("got an error from GetStringSlice():", err)
+	}
+	for i, v := range getSS {
+		if vals[i] != v {
+			t.Fatalf("expected ss[%d] to be %s from GetStringSlice but got: %s", i, vals[i], v)
+		}
+	}
+}
+
+func TestSSWithDefault(t *testing.T) {
+	var ss []string
+	f := setUpSSFlagSetWithDefault(&ss)
 
 	vals := []string{"one", "two", "4", "3"}
 	arg := fmt.Sprintf("--ss=%s", strings.Join(vals, ","))


### PR DESCRIPTION
I added the ability to do: `-s=bob -s=john` and get `[]string{"bob", "john"}`

But if a default value was set to say `[]string{"eric"}` the above
operation was mistakenly resulting in: `[]string{"eric", "bob", "john"}`
which was obviously not what was intended.

This is fixed by tracking if a value was parsed and overwriting the
default on the first time -s is found, but we append the 2+ time.