### PR TITLE
Fix typo in bool_test.go

### DIFF
--- a/bool_test.go
+++ b/bool_test.go
@@ -51,7 +51,7 @@ func (v *triStateValue) String() string {
 	return fmt.Sprintf("%v", bool(*v == triStateTrue))
 }
 
-// The type of the flag as requred by the pflag.Value interface
+// The type of the flag as required by the pflag.Value interface
 func (v *triStateValue) Type() string {
 	return "version"
 }


### PR DESCRIPTION
(cherry picked from commit faf06f062514fcb3a92c325d15bf312d1be84f94)