### PR TITLE
Fix a couple typos.

### DIFF
--- a/int_slice_test.go
+++ b/int_slice_test.go
@@ -13,13 +13,13 @@ import (
 
 func setUpISFlagSet(isp *[]int) *FlagSet {
 	f := NewFlagSet("test", ContinueOnError)
-	f.IntSliceVar(isp, "is", []int{}, "Command seperated list!")
+	f.IntSliceVar(isp, "is", []int{}, "Command separated list!")
 	return f
 }
 
 func setUpISFlagSetWithDefault(isp *[]int) *FlagSet {
 	f := NewFlagSet("test", ContinueOnError)
-	f.IntSliceVar(isp, "is", []int{0, 1}, "Command seperated list!")
+	f.IntSliceVar(isp, "is", []int{0, 1}, "Command separated list!")
 	return f
 }
 

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -12,13 +12,13 @@ import (
 
 func setUpSSFlagSet(ssp *[]string) *FlagSet {
 	f := NewFlagSet("test", ContinueOnError)
-	f.StringSliceVar(ssp, "ss", []string{}, "Command seperated list!")
+	f.StringSliceVar(ssp, "ss", []string{}, "Command separated list!")
 	return f
 }
 
 func setUpSSFlagSetWithDefault(ssp *[]string) *FlagSet {
 	f := NewFlagSet("test", ContinueOnError)
-	f.StringSliceVar(ssp, "ss", []string{"default", "values"}, "Command seperated list!")
+	f.StringSliceVar(ssp, "ss", []string{"default", "values"}, "Command separated list!")
 	return f
 }
 


### PR DESCRIPTION
This came up in a [codespell](https://github.com/lucasdemarchi/codespell) audit.