### PR TITLE
Use Type() instead of internal .(*stringValue)

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -387,7 +387,7 @@ func (f *FlagSet) FlagUsages() string {
 		if len(flag.NoOptDefVal) > 0 {
 			format = format + "["
 		}
-		if _, ok := flag.Value.(*stringValue); ok {
+		if flag.Value.Type() == "string" {
 			// put quotes on the value
 			format = format + "=%q"
 		} else {


### PR DESCRIPTION
This makes things easier to read/understand and it also means that users
who declare their own flags and call them "string" will get quotes as
well.