### PR TITLE
Remove IsBoolFlag entirely

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -5,13 +5,6 @@ import (
 	"strconv"
 )
 
-// optional interface to indicate boolean flags that can be
-// supplied without "=value" text
-type boolFlag interface {
-	Value
-	IsBoolFlag() bool
-}
-
 // -- bool Value
 type boolValue bool
 
@@ -31,8 +24,6 @@ func (b *boolValue) Type() string {
 }
 
 func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
-
-func (b *boolValue) IsBoolFlag() bool { return true }
 
 func boolConv(sval string) (interface{}, error) {
 	return strconv.ParseBool(sval)

--- a/bool_test.go
+++ b/bool_test.go
@@ -22,10 +22,6 @@ const (
 
 const strTriStateMaybe = "maybe"
 
-func (v *triStateValue) IsBoolFlag() bool {
-	return true
-}
-
 func (v *triStateValue) Get() interface{} {
 	return triStateValue(*v)
 }


### PR DESCRIPTION
We don't use it. We have sanity like "Type()" and "NoOptDefVal"