### PR TITLE
Add shorthand deprecator

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,25 @@ func aliasNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
 myFlagSet.SetNormalizeFunc(aliasNormalizeFunc)
 ```
 
+## Deprecating a flag or its shorthand 
+It is possible to deprecate a flag, or just its shorthand. Deprecating a flag/shorthand hides it from help text and prints a usage message when the deprecated flag/shorthand is used. 
+
+**Example #1**: You want to deprecate a flag named "badflag" as well as inform the users what flag they should use instead. 
+```go
+// deprecate a flag by specifying its name and a usage message 
+flags.MarkDeprecated("badflag", "please use --good-flag instead")
+```
+This hides "badflag" from help text, and prints `Flag --badflag has been deprecated, please use --good-flag instead` when "badflag" is used. 
+
+**Example #2**: You want to keep a flag name "noshorthandflag" but deprecate its shortname "n". 
+```go
+// deprecate a flag shorthand by specifying its flag name and a usage message 
+flags.MarkShorthandDeprecated("noshorthandflag", "please use --noshorthandflag only")
+```
+This hides the shortname "n" from help text, and prints `Flag shorthand -n has been deprecated, please use --noshorthandflag only` when the shorthand "n" is used. 
+
+Note that usage message is essential here, and it should not be empty. 
+
 ## More info
 
 You can see the full reference documentation of the pflag package

--- a/flag_test.go
+++ b/flag_test.go
@@ -729,6 +729,21 @@ func TestDeprecatedFlagInDocs(t *testing.T) {
 	}
 }
 
+func TestDeprecatedFlagShorthandInDocs(t *testing.T) {
+	f := NewFlagSet("bob", ContinueOnError)
+	name := "noshorthandflag"
+	f.BoolP(name, "n", true, "always true")
+	f.MarkShorthandDeprecated("noshorthandflag", fmt.Sprintf("use --%s instead", name))
+
+	out := new(bytes.Buffer)
+	f.SetOutput(out)
+	f.PrintDefaults()
+
+	if strings.Contains(out.String(), "-n,") {
+		t.Errorf("found deprecated flag shorthand in usage!")
+	}
+}
+
 func parseReturnStderr(t *testing.T, f *FlagSet, args []string) (string, error) {
 	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
@@ -758,6 +773,24 @@ func TestDeprecatedFlagUsage(t *testing.T) {
 	f.MarkDeprecated("badflag", usageMsg)
 
 	args := []string{"--badflag"}
+	out, err := parseReturnStderr(t, f, args)
+	if err != nil {
+		t.Fatal("expected no error; got ", err)
+	}
+
+	if !strings.Contains(out, usageMsg) {
+		t.Errorf("usageMsg not printed when using a deprecated flag!")
+	}
+}
+
+func TestDeprecatedFlagShorthandUsage(t *testing.T) {
+	f := NewFlagSet("bob", ContinueOnError)
+	name := "noshorthandflag"
+	f.BoolP(name, "n", true, "always true")
+	usageMsg := fmt.Sprintf("use --%s instead", name)
+	f.MarkShorthandDeprecated(name, usageMsg)
+
+	args := []string{"-n"}
 	out, err := parseReturnStderr(t, f, args)
 	if err != nil {
 		t.Fatal("expected no error; got ", err)


### PR DESCRIPTION
Add flag shorthand deprecator, which hides shorthand in help text and prints usage message when the deprecated shorthand is used. 
This supports https://github.com/kubernetes/kubernetes/pull/12813. 

cc @eparis @deads2k