### PR TITLE
Support terminating flag processing after # of args

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -140,6 +140,7 @@ type FlagSet struct {
 	formal            map[NormalizedName]*Flag
 	shorthands        map[byte]*Flag
 	args              []string // arguments after flags
+	maxArguments      int      // after this many arguments, do not process flags
 	exitOnError       bool     // does the program exit if there's an error?
 	errorHandling     ErrorHandling
 	output            io.Writer // nil means stderr; use out() accessor
@@ -478,6 +479,18 @@ func NArg() int { return len(CommandLine.args) }
 // Args returns the non-flag arguments.
 func (f *FlagSet) Args() []string { return f.args }
 
+// MaxArguments sets the maximum number of arguments processed - after receiving
+// i arguments no further flag processing is performed. This is the equivalent
+// of forcing a '--' after i arguments. Passing zero means process all flags
+// until '--' or the end of arguments are reached.
+//
+// Supports commands like 'ssh' and 'rsh' which accept a single argument and all
+// subsequent arguments or flags are considered part of the command to execute on
+// the remote system.
+func (f *FlagSet) MaxArguments(i int) {
+	f.maxArguments = i
+}
+
 // Args returns the non-flag command-line arguments.
 func Args() []string { return CommandLine.args }
 
@@ -714,6 +727,11 @@ func (f *FlagSet) parseShortArg(s string, args []string) (a []string, err error)
 
 func (f *FlagSet) parseArgs(args []string) (err error) {
 	for len(args) > 0 {
+		// terminate flag processing when we exceed maxArguments
+		if f.maxArguments > 0 && len(f.args) >= f.maxArguments {
+			f.args = append(f.args, args...)
+			return nil
+		}
 		s := args[0]
 		args = args[1:]
 		if len(s) == 0 || s[0] != '-' || len(s) == 1 {

--- a/flag_test.go
+++ b/flag_test.go
@@ -381,11 +381,67 @@ func TestShorthand(t *testing.T) {
 		t.Error("stringz flag should be `something`, is ", *stringzFlag)
 	}
 	if len(f.Args()) != 2 {
-		t.Error("expected one argument, got", len(f.Args()))
+		t.Error("expected two arguments, got", len(f.Args()))
 	} else if f.Args()[0] != extra {
 		t.Errorf("expected argument %q got %q", extra, f.Args()[0])
 	} else if f.Args()[1] != notaflag {
 		t.Errorf("expected argument %q got %q", notaflag, f.Args()[1])
+	}
+}
+
+func TestMaxArguments(t *testing.T) {
+	f := NewFlagSet("maxArgs", ContinueOnError)
+	if f.Parsed() {
+		t.Error("f.Parse() = true before Parse")
+	}
+	boolaFlag := f.BoolP("boola", "a", false, "bool value")
+	boolbFlag := f.BoolP("boolb", "b", false, "bool2 value")
+	boolcFlag := f.BoolP("boolc", "c", false, "bool3 value")
+	booldFlag := f.BoolP("boold", "d", false, "bool4 value")
+	stringaFlag := f.StringP("stringa", "s", "0", "string value")
+	stringzFlag := f.StringP("stringz", "z", "0", "string value")
+	extra := "interspersed-argument"
+	notaflag := "--i-look-like-a-flag"
+	args := []string{
+		"-ab",
+		extra,
+		"-cs",
+		"hello",
+		"-z=something",
+		"-d=true",
+		"--",
+		notaflag,
+	}
+	f.SetOutput(ioutil.Discard)
+	f.MaxArguments(1)
+	if err := f.Parse(args); err != nil {
+		t.Error("expected no error, got ", err)
+	}
+	if !f.Parsed() {
+		t.Error("f.Parse() = false after Parse")
+	}
+	if *boolaFlag != true {
+		t.Error("boola flag should be true, is ", *boolaFlag)
+	}
+	if *boolbFlag != true {
+		t.Error("boolb flag should be true, is ", *boolbFlag)
+	}
+	if *boolcFlag != false {
+		t.Error("boolc flag should be false, is ", *boolcFlag)
+	}
+	if *booldFlag != false {
+		t.Error("boold flag should be false, is ", *booldFlag)
+	}
+	if *stringaFlag != "0" {
+		t.Error("stringa flag should be `0`, is ", *stringaFlag)
+	}
+	if *stringzFlag != "0" {
+		t.Error("stringz flag should be `0`, is ", *stringzFlag)
+	}
+	if len(f.Args()) != 7 {
+		t.Error("expected six arguments, got", len(f.Args()))
+	} else if !reflect.DeepEqual(f.Args(), []string{extra, "-cs", "hello", "-z=something", "-d=true", "--", notaflag}) {
+		t.Errorf("unexpected arguments: %q", f.Args())
 	}
 }
 


### PR DESCRIPTION
Commands like "ssh" have specific behaviors around additional
arguments, where exactly one argument is allowed and subsequent
arguments are not processed for flags.  For example:

    ssh user@host cat --some -I value

executes the command "cat" with "--some", "-I", and "value". pflags
currently attempts to handle '--some' and '-I' as arguments on a
command structured like this.

This commit adds a MaxArguments flag to FlagSet which terminates
flag parsing after N arguments are read (similar to '--'). It is
intended for use by commands that emulate 'ssh' or other fixed
argument length commands that expect to receive flags for subcommands
after their fixed length.