### PR TITLE
Use encoding/csv to parse string slices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: go
 go:
         - 1.3
         - 1.4
+        - 1.5
         - tip
 
 install:

--- a/string_slice.go
+++ b/string_slice.go
@@ -1,6 +1,7 @@
 package pflag
 
 import (
+	"encoding/csv"
 	"fmt"
 	"strings"
 )
@@ -21,7 +22,12 @@ func newStringSliceValue(val []string, p *[]string) *stringSliceValue {
 }
 
 func (s *stringSliceValue) Set(val string) error {
-	v := strings.Split(val, ",")
+	stringReader := strings.NewReader(val)
+	csvReader := csv.NewReader(stringReader)
+	v, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
 	if !s.changed {
 		*s.value = v
 	} else {

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -139,3 +139,23 @@ func TestSSCalledTwice(t *testing.T) {
 		}
 	}
 }
+
+func TestSSWithComma(t *testing.T) {
+	var ss []string
+	f := setUpSSFlagSet(&ss)
+
+	in := []string{`"one,two"`, `"three"`}
+	expected := []string{"one,two", "three"}
+	argfmt := "--ss=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ss {
+		if expected[i] != v {
+			t.Fatalf("expected ss[%d] to be %s but got: %s", i, expected[i], v)
+		}
+	}
+}


### PR DESCRIPTION
There was no way to escape or use a , in a string slice so use the
encoding/csv library, rather than string.split() and let golang take
care of the encoding issues.