### PR TITLE
Better support golang flag short values

### DIFF
--- a/golangflag.go
+++ b/golangflag.go
@@ -61,6 +61,9 @@ func (v *flagValueWrapper) Type() string {
 }
 
 // PFlagFromGoFlag will return a *pflag.Flag given a *flag.Flag
+// If the *flag.Flag.Name was a single character (ex: `v`) it will be accessiblei
+// with both `-v` and `--v` in flags. If the golang flag was more than a single
+// character (ex: `verbose`) it will only be accessible via `--verbose`
 func PFlagFromGoFlag(goflag *goflag.Flag) *Flag {
 	// Remember the default value as a string; it won't change.
 	flag := &Flag{
@@ -70,6 +73,10 @@ func PFlagFromGoFlag(goflag *goflag.Flag) *Flag {
 		// Looks like golang flags don't set DefValue correctly  :-(
 		//DefValue: goflag.DefValue,
 		DefValue: goflag.Value.String(),
+	}
+	// Ex: if the golang flag was -v, allow both -v and --v to work
+	if len(flag.Name) == 1 {
+		flag.Shorthand = flag.Name
 	}
 	if fv, ok := goflag.Value.(goBoolFlag); ok && fv.IsBoolFlag() {
 		flag.NoOptDefVal = "true"


### PR DESCRIPTION
In golang flags -bob and --bob are the same thing. Not so in pflags. But
when a golang flag was just -b or --b we would still only support --b.
This was a little awkward to users.

If a golang flag was declared as a single character, support both the -b
and --b versions in the pflag version.