### PR TITLE
Add simple method to see if a flagset has available flags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -242,6 +242,17 @@ func (f *FlagSet) HasFlags() bool {
 	return len(f.formal) > 0
 }
 
+// HasAvailableFlags returns a bool to indicate if the FlagSet has any flags
+// definied that are not hidden or deprecated.
+func (f *FlagSet) HasAvailableFlags() bool {
+	for _, flag := range f.formal {
+		if !flag.Hidden && len(flag.Deprecated) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // VisitAll visits the command-line flags in lexicographical order, calling
 // fn for each.  It visits all flags, even those not set.
 func VisitAll(fn func(*Flag)) {


### PR DESCRIPTION
With the hidden and deprecated fields, it is useful to be able
to  ask if a flagset has any non-hdden, non-deprecated flags.

One example of this is to aid in writing help templates.