### PR TITLE
Remove go 1.3 and 1.4 from travis; add 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ sudo: false
 language: go
 
 go:
-        - 1.3
-        - 1.4
         - 1.5
+        - 1.6
         - tip
 
 install:


### PR DESCRIPTION
Due to the age of 1.3 and 1.4, removing them from travis.  They
currently are incompatible with golint as well, meaning that we,
otherwise, need to remove golint in testing.