### PR TITLE
Removed unnecessary conditional test in `FlagSet#parseLongArg(…)`.

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -742,7 +742,7 @@ func containsShorthand(arg, shorthand string) bool {
 func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) {
 	a = args
 	name := s[2:]
-	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
+	if name[0] == '-' || name[0] == '=' {
 		err = f.failf("bad flag syntax: %s", s)
 		return
 	}


### PR DESCRIPTION
It’s basically impossible for `len(name) == 0` to be `true`, because `FlagSet#parseLongArg(…)` [can’t be reached](https://github.com/spf13/pflag/blob/367864438f1b1a3c7db4da06a2f55b144e6784e0/flag.go#L848-L852) with that condition.
