### PR TITLE
Fix string_slice with empty value

### DIFF
--- a/string_slice.go
+++ b/string_slice.go
@@ -21,10 +21,17 @@ func newStringSliceValue(val []string, p *[]string) *stringSliceValue {
 	return ssv
 }
 
-func (s *stringSliceValue) Set(val string) error {
+func readAsCSV(val string) ([]string, error) {
+	if val == "" {
+		return []string{}, nil
+	}
 	stringReader := strings.NewReader(val)
 	csvReader := csv.NewReader(stringReader)
-	v, err := csvReader.Read()
+	return csvReader.Read()
+}
+
+func (s *stringSliceValue) Set(val string) error {
+	v, err := readAsCSV(val)
 	if err != nil {
 		return err
 	}

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -39,6 +39,23 @@ func TestEmptySS(t *testing.T) {
 	}
 }
 
+func TestEmptySSValue(t *testing.T) {
+	var ss []string
+	f := setUpSSFlagSet(&ss)
+	err := f.Parse([]string{"--ss="})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	getSS, err := f.GetStringSlice("ss")
+	if err != nil {
+		t.Fatal("got an error from GetStringSlice():", err)
+	}
+	if len(getSS) != 0 {
+		t.Fatalf("got ss %v with len=%d but expected length=0", getSS, len(getSS))
+	}
+}
+
 func TestSS(t *testing.T) {
 	var ss []string
 	f := setUpSSFlagSet(&ss)


### PR DESCRIPTION
Currently, if you don't set any value for a StringSliceVar, it will
end-up failing with an EOF error. It fails because the CSV parser for
the value can't read anything.

Special case when the string is empty to return an empty list.

cc @eparis @foxish