### PR TITLE
Use flag's string type in usage

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -455,22 +455,19 @@ func UnquoteUsage(flag *Flag) (name string, usage string) {
 			break // Only one back quote; use type name.
 		}
 	}
-	// No explicit name, so use type if we can find one.
-	name = "value"
-	switch flag.Value.(type) {
-	case boolFlag:
+
+	name = flag.Value.Type()
+	switch name {
+	case "bool":
 		name = ""
-	case *durationValue:
-		name = "duration"
-	case *float64Value:
+	case "float64":
 		name = "float"
-	case *intValue, *int64Value:
+	case "int64":
 		name = "int"
-	case *stringValue:
-		name = "string"
-	case *uintValue, *uint64Value:
+	case "uint64":
 		name = "uint"
 	}
+
 	return
 }
 


### PR DESCRIPTION
I have my own values in go program and values in usage were showed before like that: 
![2016-08-14 13 58 40](https://cloud.githubusercontent.com/assets/13235519/17648236/26be8d4e-6227-11e6-98f0-c7583a196c3c.png)
It's fully informative, although my flags have type and return it in Type() method.

I think, with this PR library will be more flexible and everyone can see their own type. Now it looks like that:
![2016-08-14 14 02 10](https://cloud.githubusercontent.com/assets/13235519/17648252/a153cf74-6227-11e6-9d82-fda8b1f6ac67.png)

I hope, you will merge this PR. It's very important for applications to be informative.