### PR TITLE
Fix default values for custom fields

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -437,7 +437,17 @@ func (f *Flag) defaultIsZeroValue() bool {
 	case *intSliceValue, *stringSliceValue, *stringArrayValue:
 		return f.DefValue == "[]"
 	default:
-		return true
+		switch f.Value.String() {
+		case "false":
+			return true
+		case "<nil>":
+			return true
+		case "":
+			return true
+		case "0":
+			return true
+		}
+		return false
 	}
 }
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -891,6 +891,7 @@ const defaultOutput = `      --A                         for bootstrapping, allo
       --StringSlice stringSlice   string slice with zero default
       --Z int                     an int that defaults to zero
       --custom custom             custom Value implementation
+      --customP custom            a VarP with default (default 10)
       --maxT timeout              set timeout for dial
 `
 
@@ -933,6 +934,9 @@ func TestPrintDefaults(t *testing.T) {
 
 	var cv customValue
 	fs.Var(&cv, "custom", "custom Value implementation")
+
+	cv2 := customValue(10)
+	fs.VarP(&cv2, "customP", "", "a VarP with default")
 
 	fs.PrintDefaults()
 	got := buf.String()


### PR DESCRIPTION
Fallback to the original default detection logic if we have an unknown
type.

Fixes #91