### PR TITLE
Use strconv instead of fmt in some values' String funcs

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // optional interface to indicate boolean flags that can be
 // supplied without "=value" text
@@ -30,7 +27,7 @@ func (b *boolValue) Type() string {
 	return "bool"
 }
 
-func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
+func (b *boolValue) String() string { return strconv.FormatBool(bool(*b)) }
 
 func (b *boolValue) IsBoolFlag() bool { return true }
 

--- a/count.go
+++ b/count.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- count Value
 type countValue int
@@ -28,7 +25,7 @@ func (i *countValue) Type() string {
 	return "count"
 }
 
-func (i *countValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *countValue) String() string { return strconv.Itoa(int(*i)) }
 
 func countConv(sval string) (interface{}, error) {
 	i, err := strconv.Atoi(sval)

--- a/float32.go
+++ b/float32.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- float32 Value
 type float32Value float32
@@ -23,7 +20,7 @@ func (f *float32Value) Type() string {
 	return "float32"
 }
 
-func (f *float32Value) String() string { return fmt.Sprintf("%v", *f) }
+func (f *float32Value) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 32) }
 
 func float32Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseFloat(sval, 32)

--- a/float64.go
+++ b/float64.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- float64 Value
 type float64Value float64
@@ -23,7 +20,7 @@ func (f *float64Value) Type() string {
 	return "float64"
 }
 
-func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
+func (f *float64Value) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 64) }
 
 func float64Conv(sval string) (interface{}, error) {
 	return strconv.ParseFloat(sval, 64)

--- a/int.go
+++ b/int.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- int Value
 type intValue int
@@ -23,7 +20,7 @@ func (i *intValue) Type() string {
 	return "int"
 }
 
-func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *intValue) String() string { return strconv.Itoa(int(*i)) }
 
 func intConv(sval string) (interface{}, error) {
 	return strconv.Atoi(sval)

--- a/int32.go
+++ b/int32.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- int32 Value
 type int32Value int32
@@ -23,7 +20,7 @@ func (i *int32Value) Type() string {
 	return "int32"
 }
 
-func (i *int32Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *int32Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int32Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseInt(sval, 0, 32)

--- a/int64.go
+++ b/int64.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- int64 Value
 type int64Value int64
@@ -23,7 +20,7 @@ func (i *int64Value) Type() string {
 	return "int64"
 }
 
-func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *int64Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int64Conv(sval string) (interface{}, error) {
 	return strconv.ParseInt(sval, 0, 64)

--- a/int8.go
+++ b/int8.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- int8 Value
 type int8Value int8
@@ -23,7 +20,7 @@ func (i *int8Value) Type() string {
 	return "int8"
 }
 
-func (i *int8Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *int8Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int8Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseInt(sval, 0, 8)

--- a/string.go
+++ b/string.go
@@ -1,7 +1,5 @@
 package pflag
 
-import "fmt"
-
 // -- string Value
 type stringValue string
 
@@ -18,7 +16,7 @@ func (s *stringValue) Type() string {
 	return "string"
 }
 
-func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
+func (s *stringValue) String() string { return string(*s) }
 
 func stringConv(sval string) (interface{}, error) {
 	return sval, nil

--- a/uint.go
+++ b/uint.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- uint Value
 type uintValue uint
@@ -23,7 +20,7 @@ func (i *uintValue) Type() string {
 	return "uint"
 }
 
-func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
+func (i *uintValue) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uintConv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 0)

--- a/uint16.go
+++ b/uint16.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- uint16 value
 type uint16Value uint16
@@ -12,7 +9,7 @@ func newUint16Value(val uint16, p *uint16) *uint16Value {
 	*p = val
 	return (*uint16Value)(p)
 }
-func (i *uint16Value) String() string { return fmt.Sprintf("%d", *i) }
+
 func (i *uint16Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 16)
 	*i = uint16Value(v)
@@ -22,6 +19,8 @@ func (i *uint16Value) Set(s string) error {
 func (i *uint16Value) Type() string {
 	return "uint16"
 }
+
+func (i *uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint16Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 16)

--- a/uint32.go
+++ b/uint32.go
@@ -1,18 +1,15 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
-// -- uint16 value
+// -- uint32 value
 type uint32Value uint32
 
 func newUint32Value(val uint32, p *uint32) *uint32Value {
 	*p = val
 	return (*uint32Value)(p)
 }
-func (i *uint32Value) String() string { return fmt.Sprintf("%d", *i) }
+
 func (i *uint32Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 32)
 	*i = uint32Value(v)
@@ -22,6 +19,8 @@ func (i *uint32Value) Set(s string) error {
 func (i *uint32Value) Type() string {
 	return "uint32"
 }
+
+func (i *uint32Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint32Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 32)

--- a/uint64.go
+++ b/uint64.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- uint64 Value
 type uint64Value uint64
@@ -23,7 +20,7 @@ func (i *uint64Value) Type() string {
 	return "uint64"
 }
 
-func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *uint64Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint64Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 64)

--- a/uint8.go
+++ b/uint8.go
@@ -1,9 +1,6 @@
 package pflag
 
-import (
-	"fmt"
-	"strconv"
-)
+import "strconv"
 
 // -- uint8 Value
 type uint8Value uint8
@@ -23,7 +20,7 @@ func (i *uint8Value) Type() string {
 	return "uint8"
 }
 
-func (i *uint8Value) String() string { return fmt.Sprintf("%v", *i) }
+func (i *uint8Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint8Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 8)


### PR DESCRIPTION
The existing implementation of flag values with fmt package uses
more memory and works slower than the implementation with strconv
package.