### PR TITLE
Don't print escaped strings for the default value of string flags.

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -514,7 +514,7 @@ func (f *FlagSet) FlagUsages() string {
 		if len(flag.NoOptDefVal) > 0 {
 			switch flag.Value.Type() {
 			case "string":
-				line += fmt.Sprintf("[=%q]", flag.NoOptDefVal)
+				line += fmt.Sprintf("[=\"%s\"]", flag.NoOptDefVal)
 			case "bool":
 				if flag.NoOptDefVal != "true" {
 					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)


### PR DESCRIPTION
Issue reported here: https://github.com/docker/docker/issues/27461

Windows paths are being escaped because `%q` will escape backslasehs.

cc @eparis 