### PR TITLE
Don't print escaped strings for the default value of string

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -534,7 +534,7 @@ func (f *FlagSet) FlagUsages() string {
 		line += usage
 		if !flag.defaultIsZeroValue() {
 			if flag.Value.Type() == "string" {
-				line += fmt.Sprintf(" (default %q)", flag.DefValue)
+				line += fmt.Sprintf(" (default \"%s\")", flag.DefValue)
 			} else {
 				line += fmt.Sprintf(" (default %s)", flag.DefValue)
 			}


### PR DESCRIPTION
Sorry I missed the second instance in #100, this fixes the other quoted string.

cc @eparis 