### PR TITLE
allow lookup by shorthand

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -278,6 +278,18 @@ func (f *FlagSet) Lookup(name string) *Flag {
 	return f.lookup(f.normalizeFlagName(name))
 }
 
+// ShorthandLookup returns the Flag structure of the short handed flag, returning nil if none exists.
+func (f *FlagSet) ShorthandLookup(name string) *Flag {
+	if name == "" {
+		return nil
+	}
+	if len(name) > 1 {
+		panic("can't look up for a shorthand with name more than one character")
+	}
+	c := name[0]
+	return f.shorthands[c]
+}
+
 // lookup returns the Flag structure of the named flag, returning nil if none exists.
 func (f *FlagSet) lookup(name NormalizedName) *Flag {
 	return f.formal[name]
@@ -356,6 +368,12 @@ func (f *FlagSet) MarkHidden(name string) error {
 // returning nil if none exists.
 func Lookup(name string) *Flag {
 	return CommandLine.Lookup(name)
+}
+
+// ShorthandLookup returns the Flag structure of the short handed flag,
+// returning nil if none exists.
+func ShorthandLookup(name string) *Flag {
+	return CommandLine.ShorthandLookup(name)
 }
 
 // Set sets the value of the named flag.

--- a/flag_test.go
+++ b/flag_test.go
@@ -878,6 +878,7 @@ const defaultOutput = `      --A                         for bootstrapping, allo
       --Alongflagname             disable bounds checking
   -C, --CCC                       a boolean defaulting to true (default true)
       --D path                    set relative path for local imports
+  -E, --EEE num[=1234]            a num with NoOptDefVal (default 4321)
       --F number                  a non-zero number (default 2.7)
       --G float                   a float that defaults to zero
       --IP ip                     IP address with no default
@@ -929,6 +930,8 @@ func TestPrintDefaults(t *testing.T) {
 	fs.Lookup("ND1").NoOptDefVal = "bar"
 	fs.Int("ND2", 1234, "a `num` with NoOptDefVal")
 	fs.Lookup("ND2").NoOptDefVal = "4321"
+	fs.IntP("EEE", "E", 4321, "a `num` with NoOptDefVal")
+	fs.ShorthandLookup("E").NoOptDefVal = "1234"
 	fs.StringSlice("StringSlice", []string{}, "string slice with zero default")
 	fs.StringArray("StringArray", []string{}, "string array with zero default")
 


### PR DESCRIPTION
@eparis I take your advice at https://github.com/kubernetes/kubernetes/pull/35030, I found that it's simple to parse long flag using flags.Lookup() , but there is no method for short flag.  I can't get flag.NoOptDefVal to make a distinction between "--flag" and "--flag arg". Would we add a new function for short flag?