### PR TITLE
not enough arguments in call to flag.BoolVarP and too many arguments in call to flag.VarP

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ that give one-letter shorthands for flags. You can use these by appending
 var ip = flag.IntP("flagname", "f", 1234, "help message")
 var flagvar bool
 func init() {
-    flag.BoolVarP("boolname", "b", true, "help message")
+	flag.BoolVarP(&flagvar, "boolname", "b", true, "help message")
 }
-flag.VarP(&flagVar, "varname", "v", 1234, "help message")
+flag.VarP(&flagVal, "varname", "v", "help message")
 ```
 
 Shorthand letters can be used with single dashes on the command line.


### PR DESCRIPTION
Signed-off-by: yuanxiao <yuan.xiao5@zte.com.cn>