### PR TITLE
Added optional params

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -168,6 +168,7 @@ type Flag struct {
 	Hidden              bool                // used by cobra.Command to allow flags to be hidden from help/usage text
 	ShorthandDeprecated string              // If the shorthand of this flag is deprecated, this string is the new or now thing to use
 	Annotations         map[string][]string // used by cobra.Command bash autocomple code
+	Optional            bool
 }
 
 // Value is the interface to the dynamic value stored in a flag.
@@ -928,9 +929,17 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 		outShorts = ""
 	} else if len(args) > 0 {
 		// '-f arg'
-		value = args[0]
-		outArgs = args[1:]
-	} else {
+		if strings.HasPrefix(args[0], "-") {
+			if !flag.Optional {
+				err = f.failf("flag needs an argument: %q in -%s", c, shorthands)
+				return
+			}
+			outArgs = args
+		} else {
+			value = args[0]
+			outArgs = args[1:]
+		}
+	} else if !flag.Optional {
 		// '-f' (arg was required)
 		err = f.failf("flag needs an argument: %q in -%s", c, shorthands)
 		return

--- a/flag_test.go
+++ b/flag_test.go
@@ -396,7 +396,9 @@ func TestShorthand(t *testing.T) {
 	boolcFlag := f.BoolP("boolc", "c", false, "bool3 value")
 	booldFlag := f.BoolP("boold", "d", false, "bool4 value")
 	stringaFlag := f.StringP("stringa", "s", "0", "string value")
+	stringpFlag := f.StringP("stringp", "p", "", "string value (optional)")
 	stringzFlag := f.StringP("stringz", "z", "0", "string value")
+	f.Lookup("stringp").Optional = true
 	extra := "interspersed-argument"
 	notaflag := "--i-look-like-a-flag"
 	args := []string{
@@ -405,6 +407,7 @@ func TestShorthand(t *testing.T) {
 		"-cs",
 		"hello",
 		"-z=something",
+		"-p",
 		"-d=true",
 		"--",
 		notaflag,
@@ -430,6 +433,13 @@ func TestShorthand(t *testing.T) {
 	}
 	if *stringaFlag != "hello" {
 		t.Error("stringa flag should be `hello`, is ", *stringaFlag)
+	}
+	if *stringpFlag != "" {
+		t.Error("stringp flag should be empty, is ", *stringpFlag)
+	}
+	sp := f.Lookup("stringp")
+	if sp.Changed != true {
+		t.Error("stringp was specified but not marked as changed")
 	}
 	if *stringzFlag != "something" {
 		t.Error("stringz flag should be `something`, is ", *stringzFlag)


### PR DESCRIPTION
This PR is an attempt to implement optional parameters.
Use case: I have an argument that can be empty, but I need to check if the parameter was specified in the command line or not.
Example:
1) Using `command -ppassword` will set the variable associated with the `-p` parameter to `password`. Flag.Changed = true.
2) Using `command -p` will leave empty the variable associated with `-p` but Flag.Changed=true
3) Using `command` (without `-p`) will leave empty the variable associated with `-p` and Flag.Changed=false
