### PR TITLE
Adds IgnoreOnError as an errorHandling strategy

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -117,6 +117,8 @@ type ErrorHandling int
 const (
 	// ContinueOnError will return an err from Parse() if an error is found
 	ContinueOnError ErrorHandling = iota
+	// IgnoreOnError will continue parsing on err, flags not parsed are considered args
+	IgnoreOnError
 	// ExitOnError will call os.Exit(2) if an error is found when parsing
 	ExitOnError
 	// PanicOnError will panic() if an error is found when parsing flags
@@ -1005,7 +1007,11 @@ func (f *FlagSet) parseArgs(args []string, fn parseFunc) (err error) {
 			args, err = f.parseShortArg(s, args, fn)
 		}
 		if err != nil {
-			return
+			if f.errorHandling != IgnoreOnError {
+				return
+			}
+			f.args = append(f.args, s)
+			err = nil
 		}
 	}
 	return

--- a/flag_test.go
+++ b/flag_test.go
@@ -1083,3 +1083,34 @@ func TestVisitFlagOrder(t *testing.T) {
 		i++
 	})
 }
+
+func TestIgnoreOnError(t *testing.T) {
+	f := NewFlagSet("ignorer", IgnoreOnError)
+	f.Bool("first", true, "first")
+	f.String("second", "2", "second")
+	f.String("third", "3", "third")
+
+	err := f.Parse([]string{"--first=false", "--second=222", "--fourth=isarg", "ARG", "--fifth=isarg"})
+	if err != nil {
+		t.Errorf("Unexpected error, IgnoreOnError should not error out on parsing")
+	}
+
+	if wanted := []string{"--fourth=isarg", "ARG", "--fifth=isarg"}; !reflect.DeepEqual(f.Args(), wanted) {
+		t.Errorf("Unexpected args, wanted %v got %v", wanted, f.Args())
+	}
+
+	flag := f.Lookup("first")
+	if wanted := "false"; flag.Value.String() != wanted {
+		t.Errorf("Unexpected flag value for %q, wanted %v got %v", flag.Name, wanted, flag.Value.String())
+	}
+
+	flag = f.Lookup("second")
+	if wanted := "222"; flag.Value.String() != wanted {
+		t.Errorf("Unexpected flag value for %q, wanted %v got %v", flag.Name, wanted, flag.Value.String())
+	}
+
+	flag = f.Lookup("third")
+	if wanted := "3"; flag.Value.String() != wanted {
+		t.Errorf("Unexpected flag value for %q, wanted %v got %v", flag.Name, wanted, flag.Value.String())
+	}
+}


### PR DESCRIPTION
The `IgnoreOnError` strategy allows the flag parser to continue parsing in case of error (e.g. flag provided but not declared). In that strategy, flags that fail to parse will just be considered arguments which can be retrieved by `Args()` in the flag set.

ptal @eparis @spf13 