### PR TITLE
Generate flag error output for errors returned from the parseFunc

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -912,6 +912,9 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 	}
 
 	err = fn(flag, value)
+	if err != nil {
+		f.failf(err.Error())
+	}
 	return
 }
 
@@ -962,6 +965,9 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 	}
 
 	err = fn(flag, value)
+	if err != nil {
+		f.failf(err.Error())
+	}
 	return
 }
 


### PR DESCRIPTION
I'm not sure if it was intentional (or simply an oversight), but I encountered an issue when attempting to handle a custom flag value format via a type that implemented `Value`, namely that errors returned from `Value#Set` don't trigger the usage message including the error; the execution would simply halt (when using the default `ExitOnError`).

This pull request triggers `failf` with the error text, if an error is returned from `parseFunc`.