### PR TITLE
Fixing Count flag usage string

### DIFF
--- a/count.go
+++ b/count.go
@@ -11,13 +11,13 @@ func newCountValue(val int, p *int) *countValue {
 }
 
 func (i *countValue) Set(s string) error {
-	v, err := strconv.ParseInt(s, 0, 64)
-	// -1 means that no specific value was passed, so increment
-	if v == -1 {
+	// "+1" means that no specific value was passed, so increment
+	if s == "+1" {
 		*i = countValue(*i + 1)
-	} else {
-		*i = countValue(v)
+		return nil
 	}
+	v, err := strconv.ParseInt(s, 0, 0)
+	*i = countValue(v)
 	return err
 }
 
@@ -54,7 +54,7 @@ func (f *FlagSet) CountVar(p *int, name string, usage string) {
 // CountVarP is like CountVar only take a shorthand for the flag name.
 func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string) {
 	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage)
-	flag.NoOptDefVal = "-1"
+	flag.NoOptDefVal = "+1"
 }
 
 // CountVar like CountVar only the flag is placed on the CommandLine instead of a given flag set

--- a/count_test.go
+++ b/count_test.go
@@ -17,10 +17,14 @@ func TestCount(t *testing.T) {
 		success  bool
 		expected int
 	}{
+		{[]string{}, true, 0},
+		{[]string{"-v"}, true, 1},
 		{[]string{"-vvv"}, true, 3},
 		{[]string{"-v", "-v", "-v"}, true, 3},
 		{[]string{"-v", "--verbose", "-v"}, true, 3},
 		{[]string{"-v=3", "-v"}, true, 4},
+		{[]string{"--verbose=0"}, true, 0},
+		{[]string{"-v=0"}, true, 0},
 		{[]string{"-v=a"}, false, 0},
 	}
 
@@ -45,7 +49,7 @@ func TestCount(t *testing.T) {
 				t.Errorf("Got error trying to fetch the counter flag")
 			}
 			if c != tc.expected {
-				t.Errorf("expected %q, got %q", tc.expected, c)
+				t.Errorf("expected %d, got %d", tc.expected, c)
 			}
 		}
 	}

--- a/flag.go
+++ b/flag.go
@@ -672,6 +672,10 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 				if flag.NoOptDefVal != "true" {
 					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 				}
+			case "count":
+				if flag.NoOptDefVal != "+1" {
+					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+				}
 			default:
 				line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 			}

--- a/flag_test.go
+++ b/flag_test.go
@@ -1052,6 +1052,7 @@ const defaultOutput = `      --A                         for bootstrapping, allo
       --custom custom             custom Value implementation
       --customP custom            a VarP with default (default 10)
       --maxT timeout              set timeout for dial
+  -v, --verbose count             verbosity
 `
 
 // Custom value that satisfies the Value interface.
@@ -1092,6 +1093,7 @@ func TestPrintDefaults(t *testing.T) {
 	fs.ShorthandLookup("E").NoOptDefVal = "1234"
 	fs.StringSlice("StringSlice", []string{}, "string slice with zero default")
 	fs.StringArray("StringArray", []string{}, "string array with zero default")
+	fs.CountP("verbose", "v", "verbosity")
 
 	var cv customValue
 	fs.Var(&cv, "custom", "custom Value implementation")


### PR DESCRIPTION
Previously Count flag usage would look something like this:
```
  -v, --verbose count[=-1]        verbosity
```
This is  confusing as it seems that default value would be `-1` while in fact `-v` would result in value `1`.

Also I'd argue that `-1` as special value meaning "to increment" was just wrong. :-)
