### PR TITLE
Single dash long options if no shorthand defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,11 @@ Would result in something like
 
 Unlike the flag package, a single dash before an option means something
 different than a double dash. Single dashes signify a series of shorthand
-letters for flags. All but the last shorthand letter must be boolean flags
-or a flag with a default value
+letters for flags. If **no shorthand flags are defined**, then single dash
+options will be treated just like double dash options to maintain
+compatibility with the flag package. If shorthand options are used, then
+all but the last shorthand letter must be boolean flags or a flag with a
+default value
 
 ```
 // boolean or flags where the 'no option default value' is set

--- a/flag.go
+++ b/flag.go
@@ -895,6 +895,12 @@ func (f *FlagSet) usage() {
 func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []string, err error) {
 	a = args
 	name := s[2:]
+
+	// Check for shorthand arg used as long.
+	if s[0] == '-' && s[1] != '-' {
+		name = s[1:]
+	}
+
 	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
 		err = f.failf("bad flag syntax: %s", s)
 		return
@@ -990,6 +996,11 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 }
 
 func (f *FlagSet) parseShortArg(s string, args []string, fn parseFunc) (a []string, err error) {
+	// Treat shorthands as long if there are no shorthands defined.
+	if f.shorthands == nil || len(f.shorthands) == 0 {
+		return f.parseLongArg(s, args, fn)
+	}
+
 	a = args
 	shorthands := s[1:]
 


### PR DESCRIPTION
I have had issues migrating from https://github.com/koding/multiconfig or other https://golang.org/pkg/flag/ based configuration to pflag. This is because existing users were using the long options with a single dash (`-option` vs `--option`). The pflag package does not seem to support this and just errors trying to interpret these as shorthand options (e.g., `-option` => `-o -p -t -i -o -n`).

To allow easier migration when not using the shorthand option feature, I made a small change to interpret single dash options as double dash options when **no shorthand options are defined**. This seemed the least intrusive and did not seem to mess up anyone using shorthand options while truly making this a _drop-in replacement for the flag package_ which it was not really before due to this.