### PR TITLE
Single dash long options if no shorthand defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,11 @@ Would result in something like
 
 Unlike the flag package, a single dash before an option means something
 different than a double dash. Single dashes signify a series of shorthand
-letters for flags. All but the last shorthand letter must be boolean flags
-or a flag with a default value
+letters for flags. If **no shorthand flags are defined**, then single dash
+options will be treated just like double dash options to maintain
+compatibility with the flag package. If shorthand options are used, then
+all but the last shorthand letter must be boolean flags or a flag with a
+default value
 
 ```
 // boolean or flags where the 'no option default value' is set

--- a/flag.go
+++ b/flag.go
@@ -895,6 +895,12 @@ func (f *FlagSet) usage() {
 func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []string, err error) {
 	a = args
 	name := s[2:]
+
+	// Check for shorthand arg used as long.
+	if s[0] == '-' && s[1] != '-' {
+		name = s[1:]
+	}
+
 	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
 		err = f.failf("bad flag syntax: %s", s)
 		return
@@ -990,6 +996,11 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 }
 
 func (f *FlagSet) parseShortArg(s string, args []string, fn parseFunc) (a []string, err error) {
+	// Treat shorthands as long if there are no shorthands defined.
+	if f.shorthands == nil || len(f.shorthands) == 0 {
+		return f.parseLongArg(s, args, fn)
+	}
+
 	a = args
 	shorthands := s[1:]
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -490,6 +490,68 @@ func TestShorthandLookup(t *testing.T) {
 	t.Errorf("f.ShorthandLookup(\"ab\") did not panic")
 }
 
+func TestNoShorthand(t *testing.T) {
+	f := NewFlagSet("shorthand", ContinueOnError)
+	if f.Parsed() {
+		t.Error("f.Parse() = true before Parse")
+	}
+	boolaFlag := f.Bool("boola", false, "bool value")
+	boolbFlag := f.Bool("boolb", false, "bool2 value")
+	boolcFlag := f.Bool("boolc", false, "bool3 value")
+	booldFlag := f.Bool("boold", false, "bool4 value")
+	stringaFlag := f.String("stringa", "0", "string value")
+	stringzFlag := f.String("stringz", "0", "string value")
+	extra := "interspersed-argument"
+	notaflag := "--i-look-like-a-flag"
+	args := []string{
+		"-boola",
+		"-boolb",
+		extra,
+		"-boolc",
+		"-stringa",
+		"hello",
+		"-stringz=something",
+		"-boold=true",
+		"--",
+		notaflag,
+	}
+	f.SetOutput(ioutil.Discard)
+	if err := f.Parse(args); err != nil {
+		t.Error("expected no error, got ", err)
+	}
+	if !f.Parsed() {
+		t.Error("f.Parse() = false after Parse")
+	}
+	if *boolaFlag != true {
+		t.Error("boola flag should be true, is ", *boolaFlag)
+	}
+	if *boolbFlag != true {
+		t.Error("boolb flag should be true, is ", *boolbFlag)
+	}
+	if *boolcFlag != true {
+		t.Error("boolc flag should be true, is ", *boolcFlag)
+	}
+	if *booldFlag != true {
+		t.Error("boold flag should be true, is ", *booldFlag)
+	}
+	if *stringaFlag != "hello" {
+		t.Error("stringa flag should be `hello`, is ", *stringaFlag)
+	}
+	if *stringzFlag != "something" {
+		t.Error("stringz flag should be `something`, is ", *stringzFlag)
+	}
+	if len(f.Args()) != 2 {
+		t.Error("expected one argument, got", len(f.Args()))
+	} else if f.Args()[0] != extra {
+		t.Errorf("expected argument %q got %q", extra, f.Args()[0])
+	} else if f.Args()[1] != notaflag {
+		t.Errorf("expected argument %q got %q", notaflag, f.Args()[1])
+	}
+	if f.ArgsLenAtDash() != 1 {
+		t.Errorf("expected argsLenAtDash %d got %d", f.ArgsLenAtDash(), 1)
+	}
+}
+
 func TestParse(t *testing.T) {
 	ResetForTesting(func() { t.Error("bad parse") })
 	testParse(GetCommandLine(), t)


### PR DESCRIPTION
I have had issues migrating from https://github.com/koding/multiconfig or other https://golang.org/pkg/flag/ based configuration to pflag. This is because existing users were using the long options with a single dash (`-option` vs `--option`). The pflag package does not seem to support this and just errors trying to interpret these as shorthand options (e.g., `-option` => `-o -p -t -i -o -n`).

To allow easier migration when not using the shorthand option feature, I made a small change to interpret single dash options as double dash options when **no shorthand options are defined**. This seemed the least intrusive and did not seem to mess up anyone using shorthand options while truly making this a _drop-in replacement for the flag package_ which it was not really before due to this.