### PR TITLE
Support supressing error when parsing unknown flag

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -138,6 +138,9 @@ type FlagSet struct {
 	// help/usage messages.
 	SortFlags bool
 
+	// IgnoreUnknown suppresses the error when an unknown flag is found.
+	IgnoreUnknown bool
+
 	name              string
 	parsed            bool
 	actual            map[NormalizedName]*Flag
@@ -912,7 +915,10 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 			f.usage()
 			return a, ErrHelp
 		}
-		err = f.failf("unknown flag: --%s", name)
+
+		if !f.IgnoreUnknown {
+			err = f.failf("unknown flag: --%s", name)
+		}
 		return
 	}
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -111,6 +111,14 @@ func TestUsage(t *testing.T) {
 	}
 }
 
+func TestIgnoreUnknown(t *testing.T) {
+	cl := GetCommandLine()
+	cl.IgnoreUnknown = true
+	if cl.Parse([]string{"--x"}) != nil {
+		t.Error("parse did fail for unknown flag with IgnoreUnknown")
+	}
+}
+
 func TestAddFlagSet(t *testing.T) {
 	oldSet := NewFlagSet("old", ContinueOnError)
 	newSet := NewFlagSet("new", ContinueOnError)


### PR DESCRIPTION
Adds a variable `IgnoreUnknown` to the `FlagSet` struct to enable this.