### PR TITLE
Add multiline wrapping support

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -591,11 +591,10 @@ func wrapN(i, slop int, s string) (string, string) {
 		return s, ""
 	}
 	nlPos := strings.LastIndex(s[:i], "\n")
-	if nlPos <= 0 {
-		return s[:w], s[w+1:]
-	} else {
+	if nlPos > 0 && nlPos < w {
 		return s[:nlPos], s[nlPos+1:]
 	}
+	return s[:w], s[w+1:]
 }
 
 // Wraps the string `s` to a maximum width `w` with leading indent

--- a/flag.go
+++ b/flag.go
@@ -586,12 +586,16 @@ func wrapN(i, slop int, s string) (string, string) {
 		return s, ""
 	}
 
-	w := strings.LastIndexAny(s[:i], " \t")
+	w := strings.LastIndexAny(s[:i], " \t\n")
 	if w <= 0 {
 		return s, ""
 	}
-
-	return s[:w], s[w+1:]
+	nlPos := strings.LastIndex(s[:i], "\n")
+	if nlPos <= 0 {
+		return s[:w], s[w+1:]
+	} else {
+		return s[:nlPos], s[nlPos+1:]
+	}
 }
 
 // Wraps the string `s` to a maximum width `w` with leading indent
@@ -599,7 +603,7 @@ func wrapN(i, slop int, s string) (string, string) {
 // caller). Pass `w` == 0 to do no wrapping
 func wrap(i, w int, s string) string {
 	if w == 0 {
-		return s
+		return strings.Replace(s, "\n", "\n"+strings.Repeat(" ", i), -1)
 	}
 
 	// space between indent i and end of line width w into which
@@ -617,7 +621,7 @@ func wrap(i, w int, s string) string {
 	}
 	// If still not enough space then don't even try to wrap.
 	if wrap < 24 {
-		return s
+		return strings.Replace(s, "\n", r, -1)
 	}
 
 	// Try to avoid short orphan words on the final line, by
@@ -629,14 +633,14 @@ func wrap(i, w int, s string) string {
 	// Handle first line, which is indented by the caller (or the
 	// special case above)
 	l, s = wrapN(wrap, slop, s)
-	r = r + l
+	r = r + strings.Replace(l, "\n", "\n"+strings.Repeat(" ", i), -1)
 
 	// Now wrap the rest
 	for s != "" {
 		var t string
 
 		t, s = wrapN(wrap, slop, s)
-		r = r + "\n" + strings.Repeat(" ", i) + t
+		r = r + "\n" + strings.Repeat(" ", i) + strings.Replace(t, "\n", "\n"+strings.Repeat(" ", i), -1)
 	}
 
 	return r

--- a/printusage_test.go
+++ b/printusage_test.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+const expectedOutput = `      --long-form    Some description
+      --long-form2   Some description
+                       with multiline
+  -s, --long-name    Some description
+  -t, --long-name2   Some description with
+                       multiline
+`
+
+func setUpPFlagSet(buf io.Writer) *FlagSet {
+	f := NewFlagSet("test", ExitOnError)
+	f.Bool("long-form", false, "Some description")
+	f.Bool("long-form2", false, "Some description\n  with multiline")
+	f.BoolP("long-name", "s", false, "Some description")
+	f.BoolP("long-name2", "t", false, "Some description with\n  multiline")
+	f.SetOutput(buf)
+	return f
+}
+
+func TestPrintUsage(t *testing.T) {
+	buf := bytes.Buffer{}
+	f := setUpPFlagSet(&buf)
+	f.PrintDefaults()
+	res := buf.String()
+	if res != expectedOutput {
+		t.Errorf("Expected \n%s \nActual \n%s", expectedOutput, res)
+	}
+}
+
+func setUpPFlagSet2(buf io.Writer) *FlagSet {
+	f := NewFlagSet("test", ExitOnError)
+	f.Bool("long-form", false, "Some description")
+	f.Bool("long-form2", false, "Some description\n  with multiline")
+	f.BoolP("long-name", "s", false, "Some description")
+	f.BoolP("long-name2", "t", false, "Some description with\n  multiline")
+	f.StringP("some-very-long-arg", "l", "test", "Some very long description having break the limit")
+	f.StringP("other-very-long-arg", "o", "long-default-value", "Some very long description having break the limit")
+	f.String("some-very-long-arg2", "very long default value", "Some very long description\nwith line break\nmultiple")
+	f.SetOutput(buf)
+	return f
+}
+
+const expectedOutput2 = `      --long-form                    Some description
+      --long-form2                   Some description
+                                       with multiline
+  -s, --long-name                    Some description
+  -t, --long-name2                   Some description with
+                                       multiline
+  -o, --other-very-long-arg string   Some very long description having
+                                     break the limit (default
+                                     "long-default-value")
+  -l, --some-very-long-arg string    Some very long description having
+                                     break the limit (default "test")
+      --some-very-long-arg2 string   Some very long description
+                                     with line break
+                                     multiple (default "very long default
+                                     value")
+`
+
+func TestPrintUsage_2(t *testing.T) {
+	buf := bytes.Buffer{}
+	f := setUpPFlagSet2(&buf)
+	res := f.FlagUsagesWrapped(80)
+	if res != expectedOutput2 {
+		t.Errorf("Expected \n%q \nActual \n%q", expectedOutput2, res)
+	}
+}


### PR DESCRIPTION
With reference to golang/go#20799, pflag now will respect newline in usage string and do wrap accordingly. Also add test cases for testing.