### PR TITLE
add ability to ignore unknown flags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -968,8 +968,6 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 }
 
 func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parseFunc) (outShorts string, outArgs []string, err error) {
-	fmt.Printf("inside short - flagset %s - %v", shorthands, args)
-
 	if strings.HasPrefix(shorthands, "test.") {
 		return
 	}
@@ -986,7 +984,11 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 			err = ErrHelp
 			return
 		case f.IgnoreUnknownFlags:
-			args = stripUnknownFlagValue(args)
+			outArgs = stripUnknownFlagValue(outArgs)
+			if len(shorthands) > 2 && shorthands[1] == '=' {
+				// '-f=arg'
+				outShorts = ""
+			}
 			return
 		default:
 			err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)

--- a/flag.go
+++ b/flag.go
@@ -123,6 +123,12 @@ const (
 	PanicOnError
 )
 
+// ParseErrorsWhitelist defines the parsing errors that can be ignored
+type ParseErrorsWhitelist struct {
+	// UnknownFlags will ignore unknown flags errors and continue parsing rest of the flags
+	UnknownFlags bool
+}
+
 // NormalizedName is a flag name that has been normalized according to rules
 // for the FlagSet (e.g. making '-' and '_' equivalent).
 type NormalizedName string
@@ -138,8 +144,8 @@ type FlagSet struct {
 	// help/usage messages.
 	SortFlags bool
 
-	// IgnoreUnknownFlags is used to indicate to ignore unknown flags
-	IgnoreUnknownFlags bool
+	// ParseErrorsWhitelist is used to configure a whitelist of errors
+	ParseErrorsWhitelist ParseErrorsWhitelist
 
 	name              string
 	parsed            bool
@@ -935,7 +941,7 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 		case name == "help":
 			f.usage()
 			return a, ErrHelp
-		case f.IgnoreUnknownFlags:
+		case f.ParseErrorsWhitelist.UnknownFlags:
 			// --unknown=unknownval arg ...
 			// we do not want to lose arg in this case
 			if len(split) >= 2 {
@@ -989,7 +995,7 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 			f.usage()
 			err = ErrHelp
 			return
-		case f.IgnoreUnknownFlags:
+		case f.ParseErrorsWhitelist.UnknownFlags:
 			// '-f=arg arg ...'
 			// we do not want to lose arg in this case
 			if len(shorthands) > 2 && shorthands[1] == '=' {

--- a/flag.go
+++ b/flag.go
@@ -936,6 +936,12 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 			f.usage()
 			return a, ErrHelp
 		case f.IgnoreUnknownFlags:
+			// --unknown=unknownval arg ...
+			// we do not want to lose arg in this case
+			if len(split) >= 2 {
+				return a, nil
+			}
+
 			return stripUnknownFlagValue(a), nil
 		default:
 			err = f.failf("unknown flag: --%s", name)
@@ -984,11 +990,14 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 			err = ErrHelp
 			return
 		case f.IgnoreUnknownFlags:
-			outArgs = stripUnknownFlagValue(outArgs)
+			// '-f=arg arg ...'
+			// we do not want to lose arg in this case
 			if len(shorthands) > 2 && shorthands[1] == '=' {
-				// '-f=arg'
 				outShorts = ""
+				return
 			}
+
+			outArgs = stripUnknownFlagValue(outArgs)
 			return
 		default:
 			err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)

--- a/flag_test.go
+++ b/flag_test.go
@@ -398,7 +398,7 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 	if f.Parsed() {
 		t.Error("f.Parse() = true before Parse")
 	}
-	f.IgnoreUnknownFlags = true
+	f.ParseErrorsWhitelist.UnknownFlags = true
 
 	f.BoolP("boola", "a", false, "bool value")
 	f.BoolP("boolb", "b", false, "bool2 value")

--- a/flag_test.go
+++ b/flag_test.go
@@ -404,10 +404,12 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 	f.BoolP("boolb", "b", false, "bool2 value")
 	f.BoolP("boolc", "c", false, "bool3 value")
 	f.BoolP("boold", "d", false, "bool4 value")
+	f.BoolP("boole", "e", false, "bool4 value")
 	f.StringP("stringa", "s", "0", "string value")
 	f.StringP("stringz", "z", "0", "string value")
 	f.StringP("stringx", "x", "0", "string value")
 	f.StringP("stringy", "y", "0", "string value")
+	f.StringP("stringo", "o", "0", "string value")
 	f.Lookup("stringx").NoOptDefVal = "1"
 	args := []string{
 		"-ab",
@@ -424,6 +426,10 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 		"-q", //another unknown with bool value
 		"-y",
 		"ee",
+		"--unknown7=unknown7value",
+		"--stringo=ovalue",
+		"--unknown8=unknown8value",
+		"--boole",
 		"--unknown6",
 	}
 	want := []string{
@@ -435,6 +441,8 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 		"boold", "true",
 		"stringx", "1",
 		"stringy", "ee",
+		"stringo", "ovalue",
+		"boole", "true",
 	}
 	got := []string{}
 	store := func(flag *Flag, value string) error {

--- a/flag_test.go
+++ b/flag_test.go
@@ -389,7 +389,7 @@ func testParseAll(f *FlagSet, t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("f.ParseAll() fail to restore the args")
-		t.Errorf("Got: %v", got)
+		t.Errorf("Got:  %v", got)
 		t.Errorf("Want: %v", want)
 	}
 }
@@ -419,9 +419,12 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 		"-x",
 		"--unknown2=unknown2Value",
 		"-u=unknown3Value",
+		"-p",
+		"unknown4Value",
+		"-q", //another unknown with bool value
 		"-y",
 		"ee",
-		"--unknown4",
+		"--unknown6",
 	}
 	want := []string{
 		"boola", "true",
@@ -449,7 +452,7 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("f.ParseAll() fail to restore the args")
-		t.Errorf("Got: %v", got)
+		t.Errorf("Got:  %v", got)
 		t.Errorf("Want: %v", want)
 	}
 }
@@ -562,7 +565,7 @@ func TestParseAll(t *testing.T) {
 
 func TestIgnoreUnknownFlags(t *testing.T) {
 	ResetForTesting(func() { t.Error("bad parse") })
-	testParseAll(GetCommandLine(), t)
+	testParseWithUnknownFlags(GetCommandLine(), t)
 }
 
 func TestFlagSetParse(t *testing.T) {


### PR DESCRIPTION
It will be nice if we can add ability to ignore unknown flags. This can be useful when writing wrappers on other commands where exposing all downstream flags is un-necessary.