### PR TITLE
Allow Users To Show Deprecated Flags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -285,10 +285,10 @@ func (f *FlagSet) HasFlags() bool {
 }
 
 // HasAvailableFlags returns a bool to indicate if the FlagSet has any flags
-// definied that are not hidden or deprecated.
+// that are not hidden.
 func (f *FlagSet) HasAvailableFlags() bool {
 	for _, flag := range f.formal {
-		if !flag.Hidden && len(flag.Deprecated) == 0 {
+		if !flag.Hidden {
 			return true
 		}
 	}
@@ -398,6 +398,7 @@ func (f *FlagSet) MarkDeprecated(name string, usageMessage string) error {
 		return fmt.Errorf("deprecated message for flag %q must be set", name)
 	}
 	flag.Deprecated = usageMessage
+	flag.Hidden = true
 	return nil
 }
 
@@ -668,7 +669,7 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 
 	maxlen := 0
 	f.VisitAll(func(flag *Flag) {
-		if flag.Deprecated != "" || flag.Hidden {
+		if flag.Hidden {
 			return
 		}
 
@@ -714,6 +715,9 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 			} else {
 				line += fmt.Sprintf(" (default %s)", flag.DefValue)
 			}
+		}
+		if len(flag.Deprecated) != 0 {
+			line += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
 		}
 
 		lines = append(lines, line)

--- a/flag_test.go
+++ b/flag_test.go
@@ -966,10 +966,14 @@ func TestTermination(t *testing.T) {
 	}
 }
 
-func TestDeprecatedFlagInDocs(t *testing.T) {
+func getDeprecatedFlagSet() *FlagSet {
 	f := NewFlagSet("bob", ContinueOnError)
 	f.Bool("badflag", true, "always true")
 	f.MarkDeprecated("badflag", "use --good-flag instead")
+	return f
+}
+func TestDeprecatedFlagInDocs(t *testing.T) {
+	f := getDeprecatedFlagSet()
 
 	out := new(bytes.Buffer)
 	f.SetOutput(out)
@@ -977,6 +981,27 @@ func TestDeprecatedFlagInDocs(t *testing.T) {
 
 	if strings.Contains(out.String(), "badflag") {
 		t.Errorf("found deprecated flag in usage!")
+	}
+}
+
+func TestUnHiddenDeprecatedFlagInDocs(t *testing.T) {
+	f := getDeprecatedFlagSet()
+	flg := f.Lookup("badflag")
+	if flg == nil {
+		t.Fatalf("Unable to lookup 'bob' in TestUnHiddenDeprecatedFlagInDocs")
+	}
+	flg.Hidden = false
+
+	out := new(bytes.Buffer)
+	f.SetOutput(out)
+	f.PrintDefaults()
+
+	defaults := out.String()
+	if !strings.Contains(defaults, "badflag") {
+		t.Errorf("Did not find deprecated flag in usage!")
+	}
+	if !strings.Contains(defaults, "use --good-flag instead") {
+		t.Errorf("Did not find 'use --good-flag instead' in defaults")
 	}
 }
 


### PR DESCRIPTION
They have to explicitly unhide a deprecated flag to keep the current behavior. Most people don't want their users to discover the deprecated flags. But some people may want to use a deprecation policy where they show them in help for a while with a deprecation notice, then stop showing them, then remove them.

My example program:
```go
package main

import (
	"fmt"
	"github.com/spf13/cobra"
)

func main() {
	cmd := &cobra.Command{
		Use: "runme",
		Run: func(_ *cobra.Command, _ []string) {
			fmt.Printf("DONE!\n")
		},
	}
	cmd.Flags().Bool("deprecated-flag", true, "always true")
	cmd.Flags().MarkDeprecated("deprecated-flag", "use --good-flag instead")

	cmd.Flags().Bool("visable-deprecated-flag", true, "always true")
	cmd.Flags().MarkDeprecated("visable-deprecated-flag", "use --good-flag instead")
	flg := cmd.Flags().Lookup("visable-deprecated-flag")
	if flg == nil {
		fmt.Printf("Unable to lookup 'visable-deprecated-flag'")
	}
	flg.Hidden = false

	cmd.Execute()
}
```
Results in the following:
```
$ ./test --help
Usage:
  runme [flags]

Flags:
  -h, --help                      help for runme
      --visable-deprecated-flag   always true (default true) (DEPRECATED: use --good-flag instead)
```