### PR TITLE
Allow flags with shorthand names only

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -452,7 +452,10 @@ func (f *FlagSet) Set(name, value string) error {
 	if err != nil {
 		var flagName string
 		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
-			flagName = fmt.Sprintf("-%s, --%s", flag.Shorthand, flag.Name)
+			flagName = fmt.Sprintf("-%s", flag.Shorthand)
+			if flag.Name != flag.Shorthand {
+				flagName += fmt.Sprintf(", --%s", flag.Name)
+			}
 		} else {
 			flagName = fmt.Sprintf("--%s", flag.Name)
 		}
@@ -470,7 +473,11 @@ func (f *FlagSet) Set(name, value string) error {
 	}
 
 	if flag.Deprecated != "" {
-		fmt.Fprintf(f.out(), "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
+		if flag.Name == flag.Shorthand {
+			fmt.Fprintf(f.out(), "Flag -%s has been deprecated, %s\n", flag.Shorthand, flag.Deprecated)
+		} else {
+			fmt.Fprintf(f.out(), "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
+		}
 	}
 	return nil
 }
@@ -673,11 +680,14 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 			return
 		}
 
-		line := ""
+		line := "  "
 		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
-			line = fmt.Sprintf("  -%s, --%s", flag.Shorthand, flag.Name)
+			line += fmt.Sprintf("-%s", flag.Shorthand)
+			if flag.Name != flag.Shorthand {
+				line += fmt.Sprintf(", --%s", flag.Name)
+			}
 		} else {
-			line = fmt.Sprintf("      --%s", flag.Name)
+			line += fmt.Sprintf("    --%s", flag.Name)
 		}
 
 		varname, usage := UnquoteUsage(flag)

--- a/printusage_test.go
+++ b/printusage_test.go
@@ -12,6 +12,7 @@ const expectedOutput = `      --long-form    Some description
   -s, --long-name    Some description
   -t, --long-name2   Some description with
                        multiline
+  -v                 Shorthand without long name
 `
 
 func setUpPFlagSet(buf io.Writer) *FlagSet {
@@ -20,6 +21,7 @@ func setUpPFlagSet(buf io.Writer) *FlagSet {
 	f.Bool("long-form2", false, "Some description\n  with multiline")
 	f.BoolP("long-name", "s", false, "Some description")
 	f.BoolP("long-name2", "t", false, "Some description with\n  multiline")
+	f.BoolP("v", "v", false, "Shorthand without long name")
 	f.SetOutput(buf)
 	return f
 }
@@ -40,6 +42,7 @@ func setUpPFlagSet2(buf io.Writer) *FlagSet {
 	f.Bool("long-form2", false, "Some description\n  with multiline")
 	f.BoolP("long-name", "s", false, "Some description")
 	f.BoolP("long-name2", "t", false, "Some description with\n  multiline")
+	f.BoolP("v", "v", false, "Shorthand without long name")
 	f.StringP("some-very-long-arg", "l", "test", "Some very long description having break the limit")
 	f.StringP("other-very-long-arg", "o", "long-default-value", "Some very long description having break the limit")
 	f.String("some-very-long-arg2", "very long default value", "Some very long description\nwith line break\nmultiple")
@@ -62,6 +65,7 @@ const expectedOutput2 = `      --long-form                    Some description
                                      with line break
                                      multiple (default "very long default
                                      value")
+  -v                                 Shorthand without long name
 `
 
 func TestPrintUsage_2(t *testing.T) {


### PR DESCRIPTION
Currently this library doesn't seem to support short flags without a long version counterpart.

A way to allow this would be like this :

  cmd.PersistentFlags().CountVarP(&verbose, "v", "v", "verbose (-v, or -vv)")

The fact that the long and short name are the same could have a special meaning, and print the following help usage :

    Usage:
    [...]

    Flags:
      -v count       verbose (-v, or -vv)
      -h, --help     help for dcos

This patch implements this.

https://github.com/spf13/cobra/issues/679