### PR TITLE
Do not eat ALL of the args if we hit a -test. arg

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -990,11 +990,11 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 }
 
 func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parseFunc) (outShorts string, outArgs []string, err error) {
+	outArgs = args
 	if strings.HasPrefix(shorthands, "test.") {
 		return
 	}
 
-	outArgs = args
 	outShorts = shorthands[1:]
 	c := shorthands[0]
 


### PR DESCRIPTION
Right now if we hit a `-test.*` arg we swallow all remaining args. This causes
us to just eat that one arg and keep processing the rest. This does mean that
something like:
-test.coverprofile moo.cov myarg1
Will leave the moo.cov and myarg1 to be parsed by pflag. Previously neither
would be parsed by pflag. To get the 'expected' behavior use:
-test.coverprofile=moo.cov myarg1

resolves #597

My test program: main.go:
```go
package main

import (
	"fmt"
	"github.com/spf13/cobra"
	"os"
)

func main() {
	cmd := &cobra.Command{
		Use: "hello",
		RunE: func(cmd *cobra.Command, args []string) error {
			fmt.Printf("%#v\n", os.Args)
			fmt.Printf("%#v\n", args)
			return nil
		},
	}
	cmd.Execute()
}
```
main_test.go:
```go
package main

import (
	"testing"
)

func TestSomething(t *testing.T) {
	main()
}
```

Which results in:
```
$ go test --covermode=count -coverpkg  ./... -test.coverprofile cover.out -args hello
[]string{"/tmp/go-build071775493/b001/test.test", "-test.coverprofile=/tmp/go-build071775493/b001/_cover_.out", "hello"}
[]string{"hello"}
PASS
coverage: 100.0% of statements in ./...
ok  	_/tmp/test	0.002s
```

Or:
```
$ go test -covermode=count -coverpkg ./... -o test-bin
  [snip]
$ ./test-bin -test.coverprofile=moo.cov hello
[]string{"./test-bin", "-test.coverprofile=moo.cov", "hello"}
[]string{"hello"}
PASS
coverage: 100.0% of statements in ./...
```