### PR TITLE
Allow bubbling up of -test.* flags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -990,11 +990,12 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 }
 
 func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parseFunc) (outShorts string, outArgs []string, err error) {
+	outArgs = args
+
 	if strings.HasPrefix(shorthands, "test.") {
 		return
 	}
 
-	outArgs = args
 	outShorts = shorthands[1:]
 	c := shorthands[0]
 


### PR DESCRIPTION
Based on patch suggested by @eparis here: https://github.com/spf13/cobra/issues/597#issuecomment-385984076

Fixes spf13/cobra#597