### PR TITLE
Add FlagSet.DisableBuiltinHelp for disabling builtin handling of help flags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -148,6 +148,9 @@ type FlagSet struct {
 	// ParseErrorsWhitelist is used to configure a whitelist of errors
 	ParseErrorsWhitelist ParseErrorsWhitelist
 
+	// DisableBuiltinHelp toggles the built-in convention of handling -h and --help
+	DisableBuiltinHelp bool
+
 	name              string
 	parsed            bool
 	actual            map[NormalizedName]*Flag
@@ -970,9 +973,10 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 
 	if !exists {
 		switch {
-		case name == "help":
+		case !f.DisableBuiltinHelp && name == "help":
 			f.usage()
-			return a, ErrHelp
+			err = ErrHelp
+			return
 		case f.ParseErrorsWhitelist.UnknownFlags:
 			// --unknown=unknownval arg ...
 			// we do not want to lose arg in this case
@@ -1024,7 +1028,7 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 	flag, exists := f.shorthands[c]
 	if !exists {
 		switch {
-		case c == 'h':
+		case !f.DisableBuiltinHelp && c == 'h':
 			f.usage()
 			err = ErrHelp
 			return

--- a/flag_test.go
+++ b/flag_test.go
@@ -899,45 +899,110 @@ func TestChangingArgs(t *testing.T) {
 
 // Test that -help invokes the usage message and returns ErrHelp.
 func TestHelp(t *testing.T) {
+
 	var helpCalled = false
 	fs := NewFlagSet("help test", ContinueOnError)
 	fs.Usage = func() { helpCalled = true }
+
 	var flag bool
 	fs.BoolVar(&flag, "flag", false, "regular flag")
+
 	// Regular flag invocation should work
 	err := fs.Parse([]string{"--flag=true"})
 	if err != nil {
 		t.Fatal("expected no error; got ", err)
 	}
 	if !flag {
-		t.Error("flag was not set by --flag")
+		t.Fatal("flag was not set by --flag")
 	}
 	if helpCalled {
-		t.Error("help called for regular flag")
-		helpCalled = false // reset for next test
+		t.Fatal("help called for regular flag")
 	}
+
 	// Help flag should work as expected.
-	err = fs.Parse([]string{"--help"})
-	if err == nil {
-		t.Fatal("error expected")
+	for _, f := range []string{"--help", "-h", "-help", "-helpxyz", "-hxyz"} {
+		err = fs.Parse([]string{f})
+		if err == nil {
+			t.Fatalf("while passing %s, error expected\n", f)
+		}
+		if err != ErrHelp {
+			t.Fatalf("while passing %s, expected ErrHelp; got %s\n", f, err)
+		}
+		if !helpCalled {
+			t.Fatalf("while passing %s, help was not called\n", f)
+		}
+		helpCalled = false
 	}
-	if err != ErrHelp {
-		t.Fatal("expected ErrHelp; got ", err)
+
+	// Help flag should not work when disabled
+	fs.DisableBuiltinHelp = true
+	for _, f := range []string{"--help", "-h"} {
+		err = fs.Parse([]string{f})
+		if err == nil {
+			t.Fatalf("an error should have been returned, got nil")
+		}
+		if err.Error() != "unknown flag: --help" &&
+			err.Error() != "unknown shorthand flag: 'h' in -h" {
+			t.Fatalf("while passing %s, expected unknown flag error, got %s\n", f, err)
+		}
+		if helpCalled {
+			t.Fatalf("while passing %s, help was called\n", f)
+		}
 	}
-	if !helpCalled {
-		t.Fatal("help was not called")
-	}
+	fs.DisableBuiltinHelp = false
+
 	// If we define a help flag, that should override.
 	var help bool
-	fs.BoolVar(&help, "help", false, "help flag")
-	helpCalled = false
+	fs.BoolVarP(&help, "help", "h", false, "help flag")
 	err = fs.Parse([]string{"--help"})
 	if err != nil {
 		t.Fatal("expected no error for defined --help; got ", err)
 	}
+	if !help {
+		t.Fatal("help should be true for defined --help")
+	}
 	if helpCalled {
 		t.Fatal("help was called; should not have been for defined help flag")
 	}
+	help = false
+	// ... including the shorthand
+	err = fs.Parse([]string{"-h"})
+	if err != nil {
+		t.Fatal("expected no error for defined -h; got ", err)
+	}
+	if !help {
+		t.Fatal("help should be true for defined -h")
+	}
+	if helpCalled {
+		t.Fatal("help was called; should not have been for defined help flag")
+	}
+	help = false
+
+	// If we define a help flag, that should override when the built in help flag is disabled.
+	fs.DisableBuiltinHelp = true
+	err = fs.Parse([]string{"--help"})
+	if err != nil {
+		t.Fatal("expected no error for defined --help; got ", err)
+	}
+	if !help {
+		t.Fatal("help should be true for defined --help")
+	}
+	if helpCalled {
+		t.Fatal("help was called; should not have been for defined help flag")
+	}
+	help = false
+	// ... including the shorthand
+	err = fs.Parse([]string{"-h"})
+	if err != nil {
+		t.Fatal("expected no error for defined -h; got ", err)
+	}
+	if !help {
+		t.Fatal("help should be true for defined -h")
+	}
+	if helpCalled {
+		t.Fatal("help was called; should not have been for defined help flag")
+	}
+
 }
 
 func TestNoInterspersed(t *testing.T) {


### PR DESCRIPTION
This PR adds the option to disable builtin handling of help flags, and includes updated tests.