### PR TITLE
Fix panic when parsing unknown flag followed by empty argument

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -925,13 +925,16 @@ func stripUnknownFlagValue(args []string) []string {
 	}
 
 	first := args[0]
-	if first[0] == '-' {
+	if len(first) > 0 && first[0] == '-' {
 		//--unknown --next-flag ...
 		return args
 	}
 
 	//--unknown arg ... (args will be arg ...)
-	return args[1:]
+	if len(args) > 1 {
+		return args[1:]
+	}
+	return nil
 }
 
 func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []string, err error) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -431,6 +431,11 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 		"--unknown8=unknown8value",
 		"--boole",
 		"--unknown6",
+		"",
+		"-uuuuu",
+		"",
+		"--unknown10",
+		"--unknown11",
 	}
 	want := []string{
 		"boola", "true",


### PR DESCRIPTION
Reproducing the panic:

```go
fset := pflag.NewFlagSet("", pflag.ContinueOnError)
fset.ParseErrorsWhitelist.UnknownFlags = true
fset.Parse([]string{"--unknown", ""})
```