### PR TITLE
add float32 & float64 slice support

### DIFF
--- a/float32_slice.go
+++ b/float32_slice.go
@@ -1,0 +1,132 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// -- float32Slice Value
+type float32SliceValue struct {
+	value   *[]float32
+	changed bool
+}
+
+func newFloat32SliceValue(val []float32, p *[]float32) *float32SliceValue {
+	isv := new(float32SliceValue)
+	isv.value = p
+	*isv.value = val
+	return isv
+}
+
+func (s *float32SliceValue) Set(val string) error {
+	ss := strings.Split(val, ",")
+	out := make([]float32, len(ss))
+	for i, d := range ss {
+		var err error
+		var temp64 float64
+		temp64, err = strconv.ParseFloat(d, 32)
+		if err != nil {
+			return err
+		}
+		out[i] = float32(temp64)
+
+	}
+	if !s.changed {
+		*s.value = out
+	} else {
+		*s.value = append(*s.value, out...)
+	}
+	s.changed = true
+	return nil
+}
+
+func (s *float32SliceValue) Type() string {
+	return "float32Slice"
+}
+
+func (s *float32SliceValue) String() string {
+	out := make([]string, len(*s.value))
+	for i, d := range *s.value {
+		out[i] = fmt.Sprintf("%f", d)
+	}
+	return "[" + strings.Join(out, ",") + "]"
+}
+
+func float32SliceConv(val string) (interface{}, error) {
+	val = strings.Trim(val, "[]")
+	// Empty string would cause a slice with one (empty) entry
+	if len(val) == 0 {
+		return []float32{}, nil
+	}
+	ss := strings.Split(val, ",")
+	out := make([]float32, len(ss))
+	for i, d := range ss {
+		var err error
+		var temp64 float64
+		temp64, err = strconv.ParseFloat(d, 32)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = float32(temp64)
+
+	}
+	return out, nil
+}
+
+// GetFloat32Slice return the []float32 value of a flag with the given name
+func (f *FlagSet) GetFloat32Slice(name string) ([]float32, error) {
+	val, err := f.getFlagType(name, "float32Slice", float32SliceConv)
+	if err != nil {
+		return []float32{}, err
+	}
+	return val.([]float32), nil
+}
+
+// Float32SliceVar defines a float32Slice flag with specified name, default value, and usage string.
+// The argument p points to a []float32 variable in which to store the value of the flag.
+func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
+	f.VarP(newFloat32SliceValue(value, p), name, "", usage)
+}
+
+// Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string) {
+	f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
+}
+
+// Float32SliceVar defines a float32[] flag with specified name, default value, and usage string.
+// The argument p points to a float32[] variable in which to store the value of the flag.
+func Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
+	CommandLine.VarP(newFloat32SliceValue(value, p), name, "", usage)
+}
+
+// Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
+func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string) {
+	CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
+}
+
+// Float32Slice defines a []float32 flag with specified name, default value, and usage string.
+// The return value is the address of a []float32 variable that stores the value of the flag.
+func (f *FlagSet) Float32Slice(name string, value []float32, usage string) *[]float32 {
+	p := []float32{}
+	f.Float32SliceVarP(&p, name, "", value, usage)
+	return &p
+}
+
+// Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage string) *[]float32 {
+	p := []float32{}
+	f.Float32SliceVarP(&p, name, shorthand, value, usage)
+	return &p
+}
+
+// Float32Slice defines a []float32 flag with specified name, default value, and usage string.
+// The return value is the address of a []float32 variable that stores the value of the flag.
+func Float32Slice(name string, value []float32, usage string) *[]float32 {
+	return CommandLine.Float32SliceP(name, "", value, usage)
+}
+
+// Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
+func Float32SliceP(name, shorthand string, value []float32, usage string) *[]float32 {
+	return CommandLine.Float32SliceP(name, shorthand, value, usage)
+}

--- a/float32_slice_test.go
+++ b/float32_slice_test.go
@@ -1,0 +1,177 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func setUpF32SFlagSet(f32sp *[]float32) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.Float32SliceVar(f32sp, "f32s", []float32{}, "Command separated list!")
+	return f
+}
+
+func setUpF32SFlagSetWithDefault(f32sp *[]float32) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.Float32SliceVar(f32sp, "f32s", []float32{0.0, 1.0}, "Command separated list!")
+	return f
+}
+
+func TestEmptyF32S(t *testing.T) {
+	var f32s []float32
+	f := setUpF32SFlagSet(&f32s)
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	getF32S, err := f.GetFloat32Slice("f32s")
+	if err != nil {
+		t.Fatal("got an error from GetFloat32Slice():", err)
+	}
+	if len(getF32S) != 0 {
+		t.Fatalf("got f32s %v with len=%d but expected length=0", getF32S, len(getF32S))
+	}
+}
+
+func TestF32S(t *testing.T) {
+	var f32s []float32
+	f := setUpF32SFlagSet(&f32s)
+
+	vals := []string{"1.0", "2.0", "4.0", "3.0"}
+	arg := fmt.Sprintf("--f32s=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f32s {
+		d64, err := strconv.ParseFloat(vals[i], 32)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+
+		d := float32(d64)
+		if d != v {
+			t.Fatalf("expected f32s[%d] to be %s but got: %f", i, vals[i], v)
+		}
+	}
+	getF32S, err := f.GetFloat32Slice("f32s")
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+	for i, v := range getF32S {
+		d64, err := strconv.ParseFloat(vals[i], 32)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+
+		d := float32(d64)
+		if d != v {
+			t.Fatalf("expected f32s[%d] to be %s but got: %f from GetFloat32Slice", i, vals[i], v)
+		}
+	}
+}
+
+func TestF32SDefault(t *testing.T) {
+	var f32s []float32
+	f := setUpF32SFlagSetWithDefault(&f32s)
+
+	vals := []string{"0.0", "1.0"}
+
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f32s {
+		d64, err := strconv.ParseFloat(vals[i], 32)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+
+		d := float32(d64)
+		if d != v {
+			t.Fatalf("expected f32s[%d] to be %f but got: %f", i, d, v)
+		}
+	}
+
+	getF32S, err := f.GetFloat32Slice("f32s")
+	if err != nil {
+		t.Fatal("got an error from GetFloat32Slice():", err)
+	}
+	for i, v := range getF32S {
+		d64, err := strconv.ParseFloat(vals[i], 32)
+		if err != nil {
+			t.Fatal("got an error from GetFloat32Slice():", err)
+		}
+
+		d := float32(d64)
+		if d != v {
+			t.Fatalf("expected f32s[%d] to be %f from GetFloat32Slice but got: %f", i, d, v)
+		}
+	}
+}
+
+func TestF32SWithDefault(t *testing.T) {
+	var f32s []float32
+	f := setUpF32SFlagSetWithDefault(&f32s)
+
+	vals := []string{"1.0", "2.0"}
+	arg := fmt.Sprintf("--f32s=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f32s {
+		d64, err := strconv.ParseFloat(vals[i], 32)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+
+		d := float32(d64)
+		if d != v {
+			t.Fatalf("expected f32s[%d] to be %f but got: %f", i, d, v)
+		}
+	}
+
+	getF32S, err := f.GetFloat32Slice("f32s")
+	if err != nil {
+		t.Fatal("got an error from GetFloat32Slice():", err)
+	}
+	for i, v := range getF32S {
+		d64, err := strconv.ParseFloat(vals[i], 32)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+
+		d := float32(d64)
+		if d != v {
+			t.Fatalf("expected f32s[%d] to be %f from GetFloat32Slice but got: %f", i, d, v)
+		}
+	}
+}
+
+func TestF32SCalledTwice(t *testing.T) {
+	var f32s []float32
+	f := setUpF32SFlagSet(&f32s)
+
+	in := []string{"1.0,2.0", "3.0"}
+	expected := []float32{1.0, 2.0, 3.0}
+	argfmt := "--f32s=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f32s {
+		if expected[i] != v {
+			t.Fatalf("expected f32s[%d] to be %f but got: %f", i, expected[i], v)
+		}
+	}
+}

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -1,0 +1,128 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// -- float64Slice Value
+type float64SliceValue struct {
+	value   *[]float64
+	changed bool
+}
+
+func newFloat64SliceValue(val []float64, p *[]float64) *float64SliceValue {
+	isv := new(float64SliceValue)
+	isv.value = p
+	*isv.value = val
+	return isv
+}
+
+func (s *float64SliceValue) Set(val string) error {
+	ss := strings.Split(val, ",")
+	out := make([]float64, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = strconv.ParseFloat(d, 64)
+		if err != nil {
+			return err
+		}
+
+	}
+	if !s.changed {
+		*s.value = out
+	} else {
+		*s.value = append(*s.value, out...)
+	}
+	s.changed = true
+	return nil
+}
+
+func (s *float64SliceValue) Type() string {
+	return "float64Slice"
+}
+
+func (s *float64SliceValue) String() string {
+	out := make([]string, len(*s.value))
+	for i, d := range *s.value {
+		out[i] = fmt.Sprintf("%f", d)
+	}
+	return "[" + strings.Join(out, ",") + "]"
+}
+
+func float64SliceConv(val string) (interface{}, error) {
+	val = strings.Trim(val, "[]")
+	// Empty string would cause a slice with one (empty) entry
+	if len(val) == 0 {
+		return []float64{}, nil
+	}
+	ss := strings.Split(val, ",")
+	out := make([]float64, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = strconv.ParseFloat(d, 64)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	return out, nil
+}
+
+// GetFloat64Slice return the []float64 value of a flag with the given name
+func (f *FlagSet) GetFloat64Slice(name string) ([]float64, error) {
+	val, err := f.getFlagType(name, "float64Slice", float64SliceConv)
+	if err != nil {
+		return []float64{}, err
+	}
+	return val.([]float64), nil
+}
+
+// Float64SliceVar defines a float64Slice flag with specified name, default value, and usage string.
+// The argument p points to a []float64 variable in which to store the value of the flag.
+func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
+	f.VarP(newFloat64SliceValue(value, p), name, "", usage)
+}
+
+// Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string) {
+	f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
+}
+
+// Float64SliceVar defines a float64[] flag with specified name, default value, and usage string.
+// The argument p points to a float64[] variable in which to store the value of the flag.
+func Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
+	CommandLine.VarP(newFloat64SliceValue(value, p), name, "", usage)
+}
+
+// Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
+func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string) {
+	CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
+}
+
+// Float64Slice defines a []float64 flag with specified name, default value, and usage string.
+// The return value is the address of a []float64 variable that stores the value of the flag.
+func (f *FlagSet) Float64Slice(name string, value []float64, usage string) *[]float64 {
+	p := []float64{}
+	f.Float64SliceVarP(&p, name, "", value, usage)
+	return &p
+}
+
+// Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage string) *[]float64 {
+	p := []float64{}
+	f.Float64SliceVarP(&p, name, shorthand, value, usage)
+	return &p
+}
+
+// Float64Slice defines a []float64 flag with specified name, default value, and usage string.
+// The return value is the address of a []float64 variable that stores the value of the flag.
+func Float64Slice(name string, value []float64, usage string) *[]float64 {
+	return CommandLine.Float64SliceP(name, "", value, usage)
+}
+
+// Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
+func Float64SliceP(name, shorthand string, value []float64, usage string) *[]float64 {
+	return CommandLine.Float64SliceP(name, shorthand, value, usage)
+}

--- a/float64_slice_test.go
+++ b/float64_slice_test.go
@@ -1,0 +1,165 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func setUpF64SFlagSet(f64sp *[]float64) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.Float64SliceVar(f64sp, "f64s", []float64{}, "Command separated list!")
+	return f
+}
+
+func setUpF64SFlagSetWithDefault(f64sp *[]float64) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.Float64SliceVar(f64sp, "f64s", []float64{0.0, 1.0}, "Command separated list!")
+	return f
+}
+
+func TestEmptyF64S(t *testing.T) {
+	var f64s []float64
+	f := setUpF64SFlagSet(&f64s)
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	getF64S, err := f.GetFloat64Slice("f64s")
+	if err != nil {
+		t.Fatal("got an error from GetFloat64Slice():", err)
+	}
+	if len(getF64S) != 0 {
+		t.Fatalf("got f64s %v with len=%d but expected length=0", getF64S, len(getF64S))
+	}
+}
+
+func TestF64S(t *testing.T) {
+	var f64s []float64
+	f := setUpF64SFlagSet(&f64s)
+
+	vals := []string{"1.0", "2.0", "4.0", "3.0"}
+	arg := fmt.Sprintf("--f64s=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f64s {
+		d, err := strconv.ParseFloat(vals[i], 64)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %s but got: %f", i, vals[i], v)
+		}
+	}
+	getF64S, err := f.GetFloat64Slice("f64s")
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+	for i, v := range getF64S {
+		d, err := strconv.ParseFloat(vals[i], 64)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %s but got: %f from GetFloat64Slice", i, vals[i], v)
+		}
+	}
+}
+
+func TestF64SDefault(t *testing.T) {
+	var f64s []float64
+	f := setUpF64SFlagSetWithDefault(&f64s)
+
+	vals := []string{"0.0", "1.0"}
+
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f64s {
+		d, err := strconv.ParseFloat(vals[i], 64)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %f but got: %f", i, d, v)
+		}
+	}
+
+	getF64S, err := f.GetFloat64Slice("f64s")
+	if err != nil {
+		t.Fatal("got an error from GetFloat64Slice():", err)
+	}
+	for i, v := range getF64S {
+		d, err := strconv.ParseFloat(vals[i], 64)
+		if err != nil {
+			t.Fatal("got an error from GetFloat64Slice():", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %f from GetFloat64Slice but got: %f", i, d, v)
+		}
+	}
+}
+
+func TestF64SWithDefault(t *testing.T) {
+	var f64s []float64
+	f := setUpF64SFlagSetWithDefault(&f64s)
+
+	vals := []string{"1.0", "2.0"}
+	arg := fmt.Sprintf("--f64s=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f64s {
+		d, err := strconv.ParseFloat(vals[i], 64)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %f but got: %f", i, d, v)
+		}
+	}
+
+	getF64S, err := f.GetFloat64Slice("f64s")
+	if err != nil {
+		t.Fatal("got an error from GetFloat64Slice():", err)
+	}
+	for i, v := range getF64S {
+		d, err := strconv.ParseFloat(vals[i], 64)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %f from GetFloat64Slice but got: %f", i, d, v)
+		}
+	}
+}
+
+func TestF64SCalledTwice(t *testing.T) {
+	var f64s []float64
+	f := setUpF64SFlagSet(&f64s)
+
+	in := []string{"1.0,2.0", "3.0"}
+	expected := []float64{1.0, 2.0, 3.0}
+	argfmt := "--f64s=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f64s {
+		if expected[i] != v {
+			t.Fatalf("expected f64s[%d] to be %f but got: %f", i, expected[i], v)
+		}
+	}
+}


### PR DESCRIPTION
Fix #149 

This PR adds support for `float32` and `float64` slices.

I just copied a lot of the existing slice impl/tests and refactored it for usage with `float*`.