### PR TITLE
Add a method to expose unknown flags back to the user

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -399,6 +399,8 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 		t.Error("f.Parse() = true before Parse")
 	}
 	f.ParseErrorsWhitelist.UnknownFlags = true
+	var unknownFlags []string
+	f.SetUnknownFlagsSlice(&unknownFlags)
 
 	f.BoolP("boola", "a", false, "bool value")
 	f.BoolP("boolb", "b", false, "bool2 value")
@@ -449,6 +451,19 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 		"stringo", "ovalue",
 		"boole", "true",
 	}
+	wantUnknowns := []string{
+		"--unknown1", "unknown1Value",
+		"--unknown2=unknown2Value",
+		"-u=unknown3Value",
+		"-p", "unknown4Value",
+		"-q",
+		"--unknown7=unknown7value",
+		"--unknown8=unknown8value",
+		"--unknown6", "",
+		"-u", "-u", "-u", "-u", "-u", "",
+		"--unknown10",
+		"--unknown11",
+	}
 	got := []string{}
 	store := func(flag *Flag, value string) error {
 		got = append(got, flag.Name)
@@ -464,9 +479,14 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
 		t.Errorf("f.Parse() = false after Parse")
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("f.ParseAll() fail to restore the args")
+		t.Errorf("f.Parse() failed to parse with unknown args")
 		t.Errorf("Got:  %v", got)
 		t.Errorf("Want: %v", want)
+	}
+	if !reflect.DeepEqual(unknownFlags, wantUnknowns) {
+		t.Errorf("f.Parse() failed to enumerate the unknown args args")
+		t.Errorf("Got:  %v", unknownFlags)
+		t.Errorf("Want: %v", wantUnknowns)
 	}
 }
 


### PR DESCRIPTION
Currently it is possible to ignore unknown flags (with
`FlagSet.ParseErrorsWhitelist.UnknownFlags`) but there is no way to find out
what they were after the fact.

Add a method which registers a slice into which all unknown arguments will be
accumulated.

Note that unknown short arguments which appear in a group (e.g. `-uuu`) will be
exploded (e.g. into `-u -u -u`) in this slice. Also any following value is
associated with the final option, e.g. `["-uuu", "foo"]` is interpreted as
`["-u", "-u", "-u", "foo"]`. This is consistent with the statement:

    Single dashes signify a series of shorthand letters for flags. All but the
    last shorthand letter must be boolean flags.

This is the reason why the call to `stripUnknownFlagValue` in
`parseSingleShortArg` becomes conditional on this being the last short arg in
the batch.

Add code to the existing `TestIgnoreUnknownFlags` (which already has
comprehensive set of the varities of possible unknown flags) to check this.

Also fixed a small cut-and-paste-o in the failure message of the test (use of
`f.ParseAll`).

Signed-off-by: Ian Campbell <ijc@docker.com>

For my use I'm actually only interested in the first unknown argument but this seemed like a more flexible approach which might be more widely usable. (I could probably get away with a flag "there were unknown args", although that wouldn't be so nice).