### PR TITLE
golangflag: use goflag.DefValue

### DIFF
--- a/golangflag.go
+++ b/golangflag.go
@@ -67,9 +67,7 @@ func PFlagFromGoFlag(goflag *goflag.Flag) *Flag {
 		Name:  goflag.Name,
 		Usage: goflag.Usage,
 		Value: wrapFlagValue(goflag.Value),
-		// Looks like golang flags don't set DefValue correctly  :-(
-		//DefValue: goflag.DefValue,
-		DefValue: goflag.Value.String(),
+		DefValue: goflag.DefValue,
 	}
 	// Ex: if the golang flag was -v, allow both -v and --v to work
 	if len(flag.Name) == 1 {


### PR DESCRIPTION
The piece of code in question breaks priority behavior for spf13/viper, because the flag/env precedence order in viper is actually flag, env, default flag.

```
func main() {
	var s string
	flag.StringVar(&s, "param", "def value", "")
	flag.Parse()
	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
	viper.BindPFlags(pflag.CommandLine)
	viper.AutomaticEnv()
	log.Println(viper.GetString("param"))
}
```

```
PARAM=foo go run ./main.go -param bar // expecting flag param to have higher priority than env param
9/03/14 20:02:06 foo
```