### PR TITLE
Omit default from usage if DefValue is empty

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -532,7 +532,7 @@ func (f *Flag) defaultIsZeroValue() bool {
 	case *intSliceValue, *stringSliceValue, *stringArrayValue:
 		return f.DefValue == "[]"
 	default:
-		switch f.Value.String() {
+		switch f.DefValue {
 		case "false":
 			return true
 		case "<nil>":


### PR DESCRIPTION
Fix #204

This change allows a user to set `Flag.DefValue` to an empty string to suppress the "(default %v)" printed in the usage line for custom `Value` types that have non-standard zero values.

For example
```
flags:=flag.NewFlagSet("",flag.ContinueOnError)
flags.VarPF(&myValue, "value", "", "usage").DefValue = ""
```
Will suppress the default message in the usage line.