### PR TITLE
Add a go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/spf13/pflag
+
+go 1.12


### PR DESCRIPTION
pflag shows as an // indirect dependency in go.mod files for every projects
which imports spf13/cobra for instance.
Adding a go.mod file (which list no dependencies) fixes it, as this is
the design from the golang author.
(https://github.com/golang/go/wiki/Modules#why-does-go-mod-tidy-record-indirect-and-test-dependencies-in-my-gomod)