### PR TITLE
Make slice values symmetric for get/set.

### DIFF
--- a/bool_slice.go
+++ b/bool_slice.go
@@ -22,6 +22,7 @@ func newBoolSliceValue(val []bool, p *[]bool) *boolSliceValue {
 // Set converts, and assigns, the comma-separated boolean argument string representation as the []bool value of this flag.
 // If Set is called on a flag that already has a []bool assigned, the newly converted values will be appended.
 func (s *boolSliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
 
 	// remove all quote characters
 	rmQuote := strings.NewReplacer(`"`, "", `'`, "", "`", "")

--- a/bool_slice_test.go
+++ b/bool_slice_test.go
@@ -68,6 +68,34 @@ func TestBS(t *testing.T) {
 			t.Fatalf("expected bs[%d] to be %s but got: %t from GetBoolSlice", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestBSBraces(t *testing.T) {
+	var bs []bool
+	f := setUpBSFlagSet(&bs)
+
+	vals := []string{"1", "F", "TRUE", "0"}
+	arg := fmt.Sprintf("--bs=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range bs {
+		b, err := strconv.ParseBool(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if b != v {
+			t.Fatalf("expected is[%d] to be %s but got: %t", i, vals[i], v)
+		}
+	}
 }
 
 func TestBSDefault(t *testing.T) {

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -20,6 +20,8 @@ func newDurationSliceValue(val []time.Duration, p *[]time.Duration) *durationSli
 }
 
 func (s *durationSliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
+
 	ss := strings.Split(val, ",")
 	out := make([]time.Duration, len(ss))
 	for i, d := range ss {

--- a/duration_slice_test.go
+++ b/duration_slice_test.go
@@ -72,6 +72,34 @@ func TestDS(t *testing.T) {
 			t.Fatalf("expected ds[%d] to be %s but got: %d from GetDurationSlice", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestDSBraces(t *testing.T) {
+	var ds []time.Duration
+	f := setUpDSFlagSet(&ds)
+
+	vals := []string{"1ns", "2ms", "3m", "4h"}
+	arg := fmt.Sprintf("--ds=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ds {
+		d, err := time.ParseDuration(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected ds[%d] to be %s but got: %d", i, vals[i], v)
+		}
+	}
 }
 
 func TestDSDefault(t *testing.T) {

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -20,6 +20,8 @@ func newFloat32SliceValue(val []float32, p *[]float32) *float32SliceValue {
 }
 
 func (s *float32SliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
+
 	ss := strings.Split(val, ",")
 	out := make([]float32, len(ss))
 	for i, d := range ss {

--- a/float32_slice_test.go
+++ b/float32_slice_test.go
@@ -76,6 +76,36 @@ func TestF32S(t *testing.T) {
 			t.Fatalf("expected f32s[%d] to be %s but got: %f from GetFloat32Slice", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestF32SBraces(t *testing.T) {
+	var f32s []float32
+	f := setUpF32SFlagSet(&f32s)
+
+	vals := []string{"1.0", "2.0", "4.0", "3.0"}
+	arg := fmt.Sprintf("--f32s=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f32s {
+		d64, err := strconv.ParseFloat(vals[i], 32)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+
+		d := float32(d64)
+		if d != v {
+			t.Fatalf("expected f32s[%d] to be %s but got: %f", i, vals[i], v)
+		}
+	}
 }
 
 func TestF32SDefault(t *testing.T) {

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -20,6 +20,8 @@ func newFloat64SliceValue(val []float64, p *[]float64) *float64SliceValue {
 }
 
 func (s *float64SliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
+
 	ss := strings.Split(val, ",")
 	out := make([]float64, len(ss))
 	for i, d := range ss {

--- a/float64_slice_test.go
+++ b/float64_slice_test.go
@@ -72,6 +72,34 @@ func TestF64S(t *testing.T) {
 			t.Fatalf("expected f64s[%d] to be %s but got: %f from GetFloat64Slice", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestF64SBraces(t *testing.T) {
+	var f64s []float64
+	f := setUpF64SFlagSet(&f64s)
+
+	vals := []string{"1.0", "2.0", "4.0", "3.0"}
+	arg := fmt.Sprintf("--f64s=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f64s {
+		d, err := strconv.ParseFloat(vals[i], 64)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %s but got: %f", i, vals[i], v)
+		}
+	}
 }
 
 func TestF64SDefault(t *testing.T) {

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -20,6 +20,8 @@ func newInt32SliceValue(val []int32, p *[]int32) *int32SliceValue {
 }
 
 func (s *int32SliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
+
 	ss := strings.Split(val, ",")
 	out := make([]int32, len(ss))
 	for i, d := range ss {

--- a/int32_slice_test.go
+++ b/int32_slice_test.go
@@ -74,6 +74,35 @@ func TestI32S(t *testing.T) {
 			t.Fatalf("expected is[%d] to be %s but got: %d from GetInt32Slice", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestI32SBraces(t *testing.T) {
+	var is []int32
+	f := setUpI32SFlagSet(&is)
+
+	vals := []string{"1", "2", "4", "3"}
+	arg := fmt.Sprintf("--is=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range is {
+		d64, err := strconv.ParseInt(vals[i], 0, 32)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		d := int32(d64)
+		if d != v {
+			t.Fatalf("expected is[%d] to be %s but got: %d", i, vals[i], v)
+		}
+	}
 }
 
 func TestI32SDefault(t *testing.T) {

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -20,6 +20,8 @@ func newInt64SliceValue(val []int64, p *[]int64) *int64SliceValue {
 }
 
 func (s *int64SliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
+
 	ss := strings.Split(val, ",")
 	out := make([]int64, len(ss))
 	for i, d := range ss {

--- a/int64_slice_test.go
+++ b/int64_slice_test.go
@@ -72,6 +72,34 @@ func TestI64S(t *testing.T) {
 			t.Fatalf("expected is[%d] to be %s but got: %d from GetInt64Slice", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestI64SBraces(t *testing.T) {
+	var is []int64
+	f := setUpI64SFlagSet(&is)
+
+	vals := []string{"1", "2", "4", "3"}
+	arg := fmt.Sprintf("--is=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range is {
+		d, err := strconv.ParseInt(vals[i], 0, 64)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected is[%d] to be %s but got: %d", i, vals[i], v)
+		}
+	}
 }
 
 func TestI64SDefault(t *testing.T) {

--- a/int_slice.go
+++ b/int_slice.go
@@ -20,6 +20,8 @@ func newIntSliceValue(val []int, p *[]int) *intSliceValue {
 }
 
 func (s *intSliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
+
 	ss := strings.Split(val, ",")
 	out := make([]int, len(ss))
 	for i, d := range ss {

--- a/int_slice_test.go
+++ b/int_slice_test.go
@@ -72,6 +72,34 @@ func TestIS(t *testing.T) {
 			t.Fatalf("expected is[%d] to be %s but got: %d from GetIntSlice", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestISBraces(t *testing.T) {
+	var is []int
+	f := setUpISFlagSet(&is)
+
+	vals := []string{"1", "2", "4", "3"}
+	arg := fmt.Sprintf("--is=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range is {
+		d, err := strconv.Atoi(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected is[%d] to be %s but got: %d", i, vals[i], v)
+		}
+	}
 }
 
 func TestISDefault(t *testing.T) {

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -23,6 +23,7 @@ func newIPSliceValue(val []net.IP, p *[]net.IP) *ipSliceValue {
 // Set converts, and assigns, the comma-separated IP argument string representation as the []net.IP value of this flag.
 // If Set is called on a flag that already has a []net.IP assigned, the newly converted values will be appended.
 func (s *ipSliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
 
 	// remove all quote characters
 	rmQuote := strings.NewReplacer(`"`, "", `'`, "", "`", "")

--- a/ip_slice_test.go
+++ b/ip_slice_test.go
@@ -58,6 +58,32 @@ func TestIPS(t *testing.T) {
 			t.Fatalf("expected ips[%d] to be %s but got: %s from GetIPSlice", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestIPSBraces(t *testing.T) {
+	var ips []net.IP
+	f := setUpIPSFlagSet(&ips)
+
+	vals := []string{"192.168.1.1", "10.0.0.1", "0:0:0:0:0:0:0:2"}
+	arg := fmt.Sprintf("--ips=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ips {
+		if ip := net.ParseIP(vals[i]); ip == nil {
+			t.Fatalf("invalid string being converted to IP address: %s", vals[i])
+		} else if !ip.Equal(v) {
+			t.Fatalf("expected ips[%d] to be %s but got: %s from GetIPSlice", i, vals[i], v)
+		}
+	}
 }
 
 func TestIPSDefault(t *testing.T) {

--- a/string_slice.go
+++ b/string_slice.go
@@ -40,6 +40,8 @@ func writeAsCSV(vals []string) (string, error) {
 }
 
 func (s *stringSliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
+
 	v, err := readAsCSV(val)
 	if err != nil {
 		return err

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -81,6 +81,30 @@ func TestSS(t *testing.T) {
 			t.Fatalf("expected ss[%d] to be %s from GetStringSlice but got: %s", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestSSBraces(t *testing.T) {
+	var ss []string
+	f := setUpSSFlagSet(&ss)
+
+	vals := []string{"one", "two", "4", "3"}
+	arg := fmt.Sprintf("--ss=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ss {
+		if vals[i] != v {
+			t.Fatalf("expected ss[%d] to be %s but got: %s", i, vals[i], v)
+		}
+	}
 }
 
 func TestSSDefault(t *testing.T) {

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -20,6 +20,8 @@ func newUintSliceValue(val []uint, p *[]uint) *uintSliceValue {
 }
 
 func (s *uintSliceValue) Set(val string) error {
+	val = strings.Trim(val, "[]")
+
 	ss := strings.Split(val, ",")
 	out := make([]uint, len(ss))
 	for i, d := range ss {

--- a/uint_slice_test.go
+++ b/uint_slice_test.go
@@ -68,6 +68,34 @@ func TestUIS(t *testing.T) {
 			t.Fatalf("expected uis[%d] to be %s but got: %d from GetUintSlice", i, vals[i], v)
 		}
 	}
+
+	f.Visit(func(flag *Flag) {
+		err := flag.Value.Set(flag.Value.String())
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+	})
+}
+
+func TestUISBraces(t *testing.T) {
+	var uis []uint
+	f := setUpUISFlagSet(&uis)
+
+	vals := []string{"1", "2", "4", "3"}
+	arg := fmt.Sprintf("--uis=[%s]", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range uis {
+		u, err := strconv.ParseUint(vals[i], 10, 0)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if uint(u) != v {
+			t.Fatalf("expected uis[%d] to be %s but got %d", i, vals[i], v)
+		}
+	}
 }
 
 func TestUISDefault(t *testing.T) {


### PR DESCRIPTION
This is intended to make the use of slices symmetric between the use of their String() and Set() methods. It should address an issue where flags that contain a leading and trailing brace are not parsed (e.g. `[1,2,3]` is not parsed, but `1,2,3` is).

~This is currently a work in progress and I am seeking feedback on the approach.~

TODO:

- [x] Handle string slices
- [x] Tests