### PR TITLE
Fix check for empty arguments array

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -1116,7 +1116,7 @@ func (f *FlagSet) Parse(arguments []string) error {
 	}
 	f.parsed = true
 
-	if len(arguments) < 0 {
+	if len(arguments) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
In practice this doesn't make a difference, since `parseArgs` checks the length again and does so correctly.