### PR TITLE
Add exported functions to preserve `pkg/flag` compatibility

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -264,6 +264,11 @@ func (f *FlagSet) Output() io.Writer {
 	return f.output
 }
 
+// Name returns the name of the flag set.
+func (f *FlagSet) Name() string {
+	return f.name
+}
+
 // SetOutput sets the destination for usage and error messages.
 // If output is nil, os.Stderr is used.
 func (f *FlagSet) SetOutput(output io.Writer) {

--- a/flag.go
+++ b/flag.go
@@ -160,7 +160,7 @@ type FlagSet struct {
 	args              []string // arguments after flags
 	argsLenAtDash     int      // len(args) when a '--' was located when parsing, or -1 if no --
 	errorHandling     ErrorHandling
-	output            io.Writer // nil means stderr; use out() accessor
+	output            io.Writer // nil means stderr; use Output() accessor
 	interspersed      bool      // allow interspersed option/non-option args
 	normalizeNameFunc func(f *FlagSet, name string) NormalizedName
 
@@ -255,7 +255,9 @@ func (f *FlagSet) normalizeFlagName(name string) NormalizedName {
 	return n(f, name)
 }
 
-func (f *FlagSet) out() io.Writer {
+// Output returns the destination for usage and error messages. os.Stderr is returned if
+// output was not set or was set to nil.
+func (f *FlagSet) Output() io.Writer {
 	if f.output == nil {
 		return os.Stderr
 	}
@@ -358,7 +360,7 @@ func (f *FlagSet) ShorthandLookup(name string) *Flag {
 	}
 	if len(name) > 1 {
 		msg := fmt.Sprintf("can not look up shorthand which is more than one ASCII character: %q", name)
-		fmt.Fprintf(f.out(), msg)
+		fmt.Fprintf(f.Output(), msg)
 		panic(msg)
 	}
 	c := name[0]
@@ -482,7 +484,7 @@ func (f *FlagSet) Set(name, value string) error {
 	}
 
 	if flag.Deprecated != "" {
-		fmt.Fprintf(f.out(), "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
+		fmt.Fprintf(f.Output(), "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
 	}
 	return nil
 }
@@ -523,7 +525,7 @@ func Set(name, value string) error {
 // otherwise, the default values of all defined flags in the set.
 func (f *FlagSet) PrintDefaults() {
 	usages := f.FlagUsages()
-	fmt.Fprint(f.out(), usages)
+	fmt.Fprint(f.Output(), usages)
 }
 
 // defaultIsZeroValue returns true if the default value for this flag represents
@@ -758,7 +760,7 @@ func PrintDefaults() {
 
 // defaultUsage is the default function to print a usage message.
 func defaultUsage(f *FlagSet) {
-	fmt.Fprintf(f.out(), "Usage of %s:\n", f.name)
+	fmt.Fprintf(f.Output(), "Usage of %s:\n", f.name)
 	f.PrintDefaults()
 }
 
@@ -844,7 +846,7 @@ func (f *FlagSet) AddFlag(flag *Flag) {
 	_, alreadyThere := f.formal[normalizedFlagName]
 	if alreadyThere {
 		msg := fmt.Sprintf("%s flag redefined: %s", f.name, flag.Name)
-		fmt.Fprintln(f.out(), msg)
+		fmt.Fprintln(f.Output(), msg)
 		panic(msg) // Happens only if flags are declared with identical names
 	}
 	if f.formal == nil {
@@ -860,7 +862,7 @@ func (f *FlagSet) AddFlag(flag *Flag) {
 	}
 	if len(flag.Shorthand) > 1 {
 		msg := fmt.Sprintf("%q shorthand is more than one ASCII character", flag.Shorthand)
-		fmt.Fprintf(f.out(), msg)
+		fmt.Fprintf(f.Output(), msg)
 		panic(msg)
 	}
 	if f.shorthands == nil {
@@ -870,7 +872,7 @@ func (f *FlagSet) AddFlag(flag *Flag) {
 	used, alreadyThere := f.shorthands[c]
 	if alreadyThere {
 		msg := fmt.Sprintf("unable to redefine %q shorthand in %q flagset: it's already used for %q flag", c, f.name, used.Name)
-		fmt.Fprintf(f.out(), msg)
+		fmt.Fprintf(f.Output(), msg)
 		panic(msg)
 	}
 	f.shorthands[c] = flag
@@ -909,7 +911,7 @@ func VarP(value Value, name, shorthand, usage string) {
 func (f *FlagSet) failf(format string, a ...interface{}) error {
 	err := fmt.Errorf(format, a...)
 	if f.errorHandling != ContinueOnError {
-		fmt.Fprintln(f.out(), err)
+		fmt.Fprintln(f.Output(), err)
 		f.usage()
 	}
 	return err
@@ -1060,7 +1062,7 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 	}
 
 	if flag.ShorthandDeprecated != "" {
-		fmt.Fprintf(f.out(), "Flag shorthand -%s has been deprecated, %s\n", flag.Shorthand, flag.ShorthandDeprecated)
+		fmt.Fprintf(f.Output(), "Flag shorthand -%s has been deprecated, %s\n", flag.Shorthand, flag.ShorthandDeprecated)
 	}
 
 	err = fn(flag, value)

--- a/flag_test.go
+++ b/flag_test.go
@@ -115,13 +115,6 @@ func TestAddFlagSet(t *testing.T) {
 	oldSet := NewFlagSet("old", ContinueOnError)
 	newSet := NewFlagSet("new", ContinueOnError)
 
-	if oldSet.Name() != "old" {
-		t.Errorf("When reading a flagset's name, expected %s, but found %s", "old", oldSet.Name())
-	}
-	if newSet.Name() != "new" {
-		t.Errorf("When reading a flagset's name, expected %s, but found %s", "new", newSet.Name())
-	}
-
 	oldSet.String("flag1", "flag1", "flag1")
 	oldSet.String("flag2", "flag2", "flag2")
 
@@ -163,6 +156,16 @@ func TestAnnotation(t *testing.T) {
 	}
 	if annotation := f.Lookup("stringb").Annotations["key"]; !reflect.DeepEqual(annotation, []string{"value2"}) {
 		t.Errorf("Unexpected annotation: %v", annotation)
+	}
+}
+
+func TestName(t *testing.T) {
+	flagSetName := "bob"
+	f := NewFlagSet(flagSetName, ContinueOnError)
+
+	givenName := f.Name()
+	if givenName != flagSetName {
+		t.Errorf("Unexpected result when retrieving a FlagSet's name: expected %s, but found %s", flagSetName, givenName)
 	}
 }
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -115,6 +115,13 @@ func TestAddFlagSet(t *testing.T) {
 	oldSet := NewFlagSet("old", ContinueOnError)
 	newSet := NewFlagSet("new", ContinueOnError)
 
+	if oldSet.Name() != "old" {
+		t.Errorf("When reading a flagset's name, expected %s, but found %s", "old", oldSet.Name())
+	}
+	if newSet.Name() != "new" {
+		t.Errorf("When reading a flagset's name, expected %s, but found %s", "new", newSet.Name())
+	}
+
 	oldSet.String("flag1", "flag1", "flag1")
 	oldSet.String("flag2", "flag2", "flag2")
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -854,6 +854,17 @@ func TestSetOutput(t *testing.T) {
 	}
 }
 
+func TestOutput(t *testing.T) {
+	var flags FlagSet
+	var buf bytes.Buffer
+	expect := "an example string"
+	flags.SetOutput(&buf)
+	fmt.Fprint(flags.Output(), expect)
+	if out := buf.String(); !strings.Contains(out, expect) {
+		t.Errorf("expected output %q; got %q", expect, out)
+	}
+}
+
 // This tests that one can reset the flags. This still works but not well, and is
 // superseded by FlagSet.
 func TestChangingArgs(t *testing.T) {


### PR DESCRIPTION
These changes bring behavior inline with go's [`flag`](https://golang.org/src/flag/flag.go) library, and allows for printing output directly to whatever the current FlagSet is using for output and retrieving a given FlagSet's name. These changes will make it easier to correctly emit output to stdout or stderr (e.g. a user has requested a help screen, which should emit to stdout since it's the desired outcome).

(This PR has also pulled in #241, since @5paceToast and I were clearly working in the same direction here)

example for `Out()`:
```go
import (
  "fmt"
  flag "github.com/spf13/pflag"
)

func init() {
  var helpFlag bool
  whoami := path.Base(os.Args[0])
  flag.BoolVarP(&helpFlag, "help", "h", false, "show this help")

  flag.Usage = func() {
    fmt.Fprintf(flag.CommandLine.Output(), "%s: print example help\n\n", whoami)
    fmt.Fprintf(flag.CommandLine.Output(), "usage: %s [-h]\n", whoami)
    flag.PrintDefaults()
  }

  flag.Parse()

  if helpFlag {
    flag.CommandLine.SetOutput(os.Stdout)
    flag.Usage()
    os.Exit(0)
  }
}
```

example for `Name()`:
```go
import (
  "fmt"
  flag "github.com/spf13/pflag"
)

func init() {
  versionNumber := "123.456.789"
  myFlagSet := flag.NewFlagSet("Megumin", flag.ExitOnError)

  fmt.Printf("%s\t%s\n", myFlagSet.Name(), versionNumber)
}

