### PR TITLE
make Value implementations public

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -12,7 +12,7 @@ type boolFlag interface {
 // -- bool Value
 type boolValue bool
 
-func newBoolValue(val bool, p *bool) *boolValue {
+func NewBoolValue(val bool, p *bool) *boolValue {
 	*p = val
 	return (*boolValue)(p)
 }
@@ -52,7 +52,7 @@ func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage)
+	flag := f.VarPF(NewBoolValue(value, p), name, shorthand, usage)
 	flag.NoOptDefVal = "true"
 }
 
@@ -64,7 +64,7 @@ func BoolVar(p *bool, name string, value bool, usage string) {
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage)
+	flag := CommandLine.VarPF(NewBoolValue(value, p), name, shorthand, usage)
 	flag.NoOptDefVal = "true"
 }
 

--- a/bool_slice.go
+++ b/bool_slice.go
@@ -12,7 +12,7 @@ type boolSliceValue struct {
 	changed bool
 }
 
-func newBoolSliceValue(val []bool, p *[]bool) *boolSliceValue {
+func NewBoolSliceValue(val []bool, p *[]bool) *boolSliceValue {
 	bsv := new(boolSliceValue)
 	bsv.value = p
 	*bsv.value = val
@@ -139,23 +139,23 @@ func (f *FlagSet) GetBoolSlice(name string) ([]bool, error) {
 // BoolSliceVar defines a boolSlice flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
 func (f *FlagSet) BoolSliceVar(p *[]bool, name string, value []bool, usage string) {
-	f.VarP(newBoolSliceValue(value, p), name, "", usage)
+	f.VarP(NewBoolSliceValue(value, p), name, "", usage)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string) {
-	f.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewBoolSliceValue(value, p), name, shorthand, usage)
 }
 
 // BoolSliceVar defines a []bool flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
 func BoolSliceVar(p *[]bool, name string, value []bool, usage string) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewBoolSliceValue(value, p), name, "", usage)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewBoolSliceValue(value, p), name, shorthand, usage)
 }
 
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.

--- a/bytes.go
+++ b/bytes.go
@@ -33,7 +33,7 @@ func (*bytesHexValue) Type() string {
 	return "bytesHex"
 }
 
-func newBytesHexValue(val []byte, p *[]byte) *bytesHexValue {
+func NewBytesHexValue(val []byte, p *[]byte) *bytesHexValue {
 	*p = val
 	return (*bytesHexValue)(p)
 }
@@ -63,23 +63,23 @@ func (f *FlagSet) GetBytesHex(name string) ([]byte, error) {
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
 func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string) {
-	f.VarP(newBytesHexValue(value, p), name, "", usage)
+	f.VarP(NewBytesHexValue(value, p), name, "", usage)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	f.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+	f.VarP(NewBytesHexValue(value, p), name, shorthand, usage)
 }
 
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
 func BytesHexVar(p *[]byte, name string, value []byte, usage string) {
-	CommandLine.VarP(newBytesHexValue(value, p), name, "", usage)
+	CommandLine.VarP(NewBytesHexValue(value, p), name, "", usage)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
 func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewBytesHexValue(value, p), name, shorthand, usage)
 }
 
 // BytesHex defines an []byte flag with specified name, default value, and usage string.

--- a/count.go
+++ b/count.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- count Value
 type countValue int
 
-func newCountValue(val int, p *int) *countValue {
+func NewCountValue(val int, p *int) *countValue {
 	*p = val
 	return (*countValue)(p)
 }
@@ -53,7 +53,7 @@ func (f *FlagSet) CountVar(p *int, name string, usage string) {
 
 // CountVarP is like CountVar only take a shorthand for the flag name.
 func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string) {
-	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage)
+	flag := f.VarPF(NewCountValue(0, p), name, shorthand, usage)
 	flag.NoOptDefVal = "+1"
 }
 

--- a/duration.go
+++ b/duration.go
@@ -7,7 +7,7 @@ import (
 // -- time.Duration Value
 type durationValue time.Duration
 
-func newDurationValue(val time.Duration, p *time.Duration) *durationValue {
+func NewDurationValue(val time.Duration, p *time.Duration) *durationValue {
 	*p = val
 	return (*durationValue)(p)
 }
@@ -40,23 +40,23 @@ func (f *FlagSet) GetDuration(name string) (time.Duration, error) {
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
 func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
-	f.VarP(newDurationValue(value, p), name, "", usage)
+	f.VarP(NewDurationValue(value, p), name, "", usage)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
-	f.VarP(newDurationValue(value, p), name, shorthand, usage)
+	f.VarP(NewDurationValue(value, p), name, shorthand, usage)
 }
 
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
 func DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
-	CommandLine.VarP(newDurationValue(value, p), name, "", usage)
+	CommandLine.VarP(NewDurationValue(value, p), name, "", usage)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
 func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
-	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewDurationValue(value, p), name, shorthand, usage)
 }
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -12,7 +12,7 @@ type durationSliceValue struct {
 	changed bool
 }
 
-func newDurationSliceValue(val []time.Duration, p *[]time.Duration) *durationSliceValue {
+func NewDurationSliceValue(val []time.Duration, p *[]time.Duration) *durationSliceValue {
 	dsv := new(durationSliceValue)
 	dsv.value = p
 	*dsv.value = val
@@ -120,23 +120,23 @@ func (f *FlagSet) GetDurationSlice(name string) ([]time.Duration, error) {
 // DurationSliceVar defines a durationSlice flag with specified name, default value, and usage string.
 // The argument p points to a []time.Duration variable in which to store the value of the flag.
 func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
-	f.VarP(newDurationSliceValue(value, p), name, "", usage)
+	f.VarP(NewDurationSliceValue(value, p), name, "", usage)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
-	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewDurationSliceValue(value, p), name, shorthand, usage)
 }
 
 // DurationSliceVar defines a duration[] flag with specified name, default value, and usage string.
 // The argument p points to a duration[] variable in which to store the value of the flag.
 func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
-	CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewDurationSliceValue(value, p), name, "", usage)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
-	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewDurationSliceValue(value, p), name, shorthand, usage)
 }
 
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.

--- a/float32.go
+++ b/float32.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- float32 Value
 type float32Value float32
 
-func newFloat32Value(val float32, p *float32) *float32Value {
+func NewFloat32Value(val float32, p *float32) *float32Value {
 	*p = val
 	return (*float32Value)(p)
 }
@@ -42,23 +42,23 @@ func (f *FlagSet) GetFloat32(name string) (float32, error) {
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
 func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string) {
-	f.VarP(newFloat32Value(value, p), name, "", usage)
+	f.VarP(NewFloat32Value(value, p), name, "", usage)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
-	f.VarP(newFloat32Value(value, p), name, shorthand, usage)
+	f.VarP(NewFloat32Value(value, p), name, shorthand, usage)
 }
 
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
 func Float32Var(p *float32, name string, value float32, usage string) {
-	CommandLine.VarP(newFloat32Value(value, p), name, "", usage)
+	CommandLine.VarP(NewFloat32Value(value, p), name, "", usage)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
 func Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
-	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewFloat32Value(value, p), name, shorthand, usage)
 }
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -12,7 +12,7 @@ type float32SliceValue struct {
 	changed bool
 }
 
-func newFloat32SliceValue(val []float32, p *[]float32) *float32SliceValue {
+func NewFloat32SliceValue(val []float32, p *[]float32) *float32SliceValue {
 	isv := new(float32SliceValue)
 	isv.value = p
 	*isv.value = val
@@ -128,23 +128,23 @@ func (f *FlagSet) GetFloat32Slice(name string) ([]float32, error) {
 // Float32SliceVar defines a float32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float32 variable in which to store the value of the flag.
 func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
-	f.VarP(newFloat32SliceValue(value, p), name, "", usage)
+	f.VarP(NewFloat32SliceValue(value, p), name, "", usage)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string) {
-	f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewFloat32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float32SliceVar defines a float32[] flag with specified name, default value, and usage string.
 // The argument p points to a float32[] variable in which to store the value of the flag.
 func Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
-	CommandLine.VarP(newFloat32SliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewFloat32SliceValue(value, p), name, "", usage)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string) {
-	CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewFloat32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.

--- a/float64.go
+++ b/float64.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- float64 Value
 type float64Value float64
 
-func newFloat64Value(val float64, p *float64) *float64Value {
+func NewFloat64Value(val float64, p *float64) *float64Value {
 	*p = val
 	return (*float64Value)(p)
 }
@@ -38,23 +38,23 @@ func (f *FlagSet) GetFloat64(name string) (float64, error) {
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
 func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string) {
-	f.VarP(newFloat64Value(value, p), name, "", usage)
+	f.VarP(NewFloat64Value(value, p), name, "", usage)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
-	f.VarP(newFloat64Value(value, p), name, shorthand, usage)
+	f.VarP(NewFloat64Value(value, p), name, shorthand, usage)
 }
 
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
 func Float64Var(p *float64, name string, value float64, usage string) {
-	CommandLine.VarP(newFloat64Value(value, p), name, "", usage)
+	CommandLine.VarP(NewFloat64Value(value, p), name, "", usage)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
 func Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
-	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewFloat64Value(value, p), name, shorthand, usage)
 }
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -12,7 +12,7 @@ type float64SliceValue struct {
 	changed bool
 }
 
-func newFloat64SliceValue(val []float64, p *[]float64) *float64SliceValue {
+func NewFloat64SliceValue(val []float64, p *[]float64) *float64SliceValue {
 	isv := new(float64SliceValue)
 	isv.value = p
 	*isv.value = val
@@ -120,23 +120,23 @@ func (f *FlagSet) GetFloat64Slice(name string) ([]float64, error) {
 // Float64SliceVar defines a float64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float64 variable in which to store the value of the flag.
 func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
-	f.VarP(newFloat64SliceValue(value, p), name, "", usage)
+	f.VarP(NewFloat64SliceValue(value, p), name, "", usage)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string) {
-	f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewFloat64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float64SliceVar defines a float64[] flag with specified name, default value, and usage string.
 // The argument p points to a float64[] variable in which to store the value of the flag.
 func Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
-	CommandLine.VarP(newFloat64SliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewFloat64SliceValue(value, p), name, "", usage)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string) {
-	CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewFloat64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.

--- a/int.go
+++ b/int.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- int Value
 type intValue int
 
-func newIntValue(val int, p *int) *intValue {
+func NewIntValue(val int, p *int) *intValue {
 	*p = val
 	return (*intValue)(p)
 }
@@ -38,23 +38,23 @@ func (f *FlagSet) GetInt(name string) (int, error) {
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 func (f *FlagSet) IntVar(p *int, name string, value int, usage string) {
-	f.VarP(newIntValue(value, p), name, "", usage)
+	f.VarP(NewIntValue(value, p), name, "", usage)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string) {
-	f.VarP(newIntValue(value, p), name, shorthand, usage)
+	f.VarP(NewIntValue(value, p), name, shorthand, usage)
 }
 
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 func IntVar(p *int, name string, value int, usage string) {
-	CommandLine.VarP(newIntValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIntValue(value, p), name, "", usage)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
 func IntVarP(p *int, name, shorthand string, value int, usage string) {
-	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIntValue(value, p), name, shorthand, usage)
 }
 
 // Int defines an int flag with specified name, default value, and usage string.

--- a/int16.go
+++ b/int16.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- int16 Value
 type int16Value int16
 
-func newInt16Value(val int16, p *int16) *int16Value {
+func NewInt16Value(val int16, p *int16) *int16Value {
 	*p = val
 	return (*int16Value)(p)
 }
@@ -42,23 +42,23 @@ func (f *FlagSet) GetInt16(name string) (int16, error) {
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
 func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string) {
-	f.VarP(newInt16Value(value, p), name, "", usage)
+	f.VarP(NewInt16Value(value, p), name, "", usage)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage string) {
-	f.VarP(newInt16Value(value, p), name, shorthand, usage)
+	f.VarP(NewInt16Value(value, p), name, shorthand, usage)
 }
 
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
 func Int16Var(p *int16, name string, value int16, usage string) {
-	CommandLine.VarP(newInt16Value(value, p), name, "", usage)
+	CommandLine.VarP(NewInt16Value(value, p), name, "", usage)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
 func Int16VarP(p *int16, name, shorthand string, value int16, usage string) {
-	CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt16Value(value, p), name, shorthand, usage)
 }
 
 // Int16 defines an int16 flag with specified name, default value, and usage string.

--- a/int32.go
+++ b/int32.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- int32 Value
 type int32Value int32
 
-func newInt32Value(val int32, p *int32) *int32Value {
+func NewInt32Value(val int32, p *int32) *int32Value {
 	*p = val
 	return (*int32Value)(p)
 }
@@ -42,23 +42,23 @@ func (f *FlagSet) GetInt32(name string) (int32, error) {
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
 func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string) {
-	f.VarP(newInt32Value(value, p), name, "", usage)
+	f.VarP(NewInt32Value(value, p), name, "", usage)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
-	f.VarP(newInt32Value(value, p), name, shorthand, usage)
+	f.VarP(NewInt32Value(value, p), name, shorthand, usage)
 }
 
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
 func Int32Var(p *int32, name string, value int32, usage string) {
-	CommandLine.VarP(newInt32Value(value, p), name, "", usage)
+	CommandLine.VarP(NewInt32Value(value, p), name, "", usage)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
 func Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
-	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt32Value(value, p), name, shorthand, usage)
 }
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -12,7 +12,7 @@ type int32SliceValue struct {
 	changed bool
 }
 
-func newInt32SliceValue(val []int32, p *[]int32) *int32SliceValue {
+func NewInt32SliceValue(val []int32, p *[]int32) *int32SliceValue {
 	isv := new(int32SliceValue)
 	isv.value = p
 	*isv.value = val
@@ -128,23 +128,23 @@ func (f *FlagSet) GetInt32Slice(name string) ([]int32, error) {
 // Int32SliceVar defines a int32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int32 variable in which to store the value of the flag.
 func (f *FlagSet) Int32SliceVar(p *[]int32, name string, value []int32, usage string) {
-	f.VarP(newInt32SliceValue(value, p), name, "", usage)
+	f.VarP(NewInt32SliceValue(value, p), name, "", usage)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string) {
-	f.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewInt32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int32SliceVar defines a int32[] flag with specified name, default value, and usage string.
 // The argument p points to a int32[] variable in which to store the value of the flag.
 func Int32SliceVar(p *[]int32, name string, value []int32, usage string) {
-	CommandLine.VarP(newInt32SliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewInt32SliceValue(value, p), name, "", usage)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string) {
-	CommandLine.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.

--- a/int64.go
+++ b/int64.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- int64 Value
 type int64Value int64
 
-func newInt64Value(val int64, p *int64) *int64Value {
+func NewInt64Value(val int64, p *int64) *int64Value {
 	*p = val
 	return (*int64Value)(p)
 }
@@ -38,23 +38,23 @@ func (f *FlagSet) GetInt64(name string) (int64, error) {
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
 func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string) {
-	f.VarP(newInt64Value(value, p), name, "", usage)
+	f.VarP(NewInt64Value(value, p), name, "", usage)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
-	f.VarP(newInt64Value(value, p), name, shorthand, usage)
+	f.VarP(NewInt64Value(value, p), name, shorthand, usage)
 }
 
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
 func Int64Var(p *int64, name string, value int64, usage string) {
-	CommandLine.VarP(newInt64Value(value, p), name, "", usage)
+	CommandLine.VarP(NewInt64Value(value, p), name, "", usage)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
 func Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
-	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt64Value(value, p), name, shorthand, usage)
 }
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -12,7 +12,7 @@ type int64SliceValue struct {
 	changed bool
 }
 
-func newInt64SliceValue(val []int64, p *[]int64) *int64SliceValue {
+func NewInt64SliceValue(val []int64, p *[]int64) *int64SliceValue {
 	isv := new(int64SliceValue)
 	isv.value = p
 	*isv.value = val
@@ -120,23 +120,23 @@ func (f *FlagSet) GetInt64Slice(name string) ([]int64, error) {
 // Int64SliceVar defines a int64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int64 variable in which to store the value of the flag.
 func (f *FlagSet) Int64SliceVar(p *[]int64, name string, value []int64, usage string) {
-	f.VarP(newInt64SliceValue(value, p), name, "", usage)
+	f.VarP(NewInt64SliceValue(value, p), name, "", usage)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string) {
-	f.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewInt64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int64SliceVar defines a int64[] flag with specified name, default value, and usage string.
 // The argument p points to a int64[] variable in which to store the value of the flag.
 func Int64SliceVar(p *[]int64, name string, value []int64, usage string) {
-	CommandLine.VarP(newInt64SliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewInt64SliceValue(value, p), name, "", usage)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string) {
-	CommandLine.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.

--- a/int8.go
+++ b/int8.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- int8 Value
 type int8Value int8
 
-func newInt8Value(val int8, p *int8) *int8Value {
+func NewInt8Value(val int8, p *int8) *int8Value {
 	*p = val
 	return (*int8Value)(p)
 }
@@ -42,23 +42,23 @@ func (f *FlagSet) GetInt8(name string) (int8, error) {
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
 func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string) {
-	f.VarP(newInt8Value(value, p), name, "", usage)
+	f.VarP(NewInt8Value(value, p), name, "", usage)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
-	f.VarP(newInt8Value(value, p), name, shorthand, usage)
+	f.VarP(NewInt8Value(value, p), name, shorthand, usage)
 }
 
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
 func Int8Var(p *int8, name string, value int8, usage string) {
-	CommandLine.VarP(newInt8Value(value, p), name, "", usage)
+	CommandLine.VarP(NewInt8Value(value, p), name, "", usage)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
 func Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
-	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt8Value(value, p), name, shorthand, usage)
 }
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.

--- a/int_slice.go
+++ b/int_slice.go
@@ -12,7 +12,7 @@ type intSliceValue struct {
 	changed bool
 }
 
-func newIntSliceValue(val []int, p *[]int) *intSliceValue {
+func NewIntSliceValue(val []int, p *[]int) *intSliceValue {
 	isv := new(intSliceValue)
 	isv.value = p
 	*isv.value = val
@@ -112,23 +112,23 @@ func (f *FlagSet) GetIntSlice(name string) ([]int, error) {
 // IntSliceVar defines a intSlice flag with specified name, default value, and usage string.
 // The argument p points to a []int variable in which to store the value of the flag.
 func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string) {
-	f.VarP(newIntSliceValue(value, p), name, "", usage)
+	f.VarP(NewIntSliceValue(value, p), name, "", usage)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string) {
-	f.VarP(newIntSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewIntSliceValue(value, p), name, shorthand, usage)
 }
 
 // IntSliceVar defines a int[] flag with specified name, default value, and usage string.
 // The argument p points to a int[] variable in which to store the value of the flag.
 func IntSliceVar(p *[]int, name string, value []int, usage string) {
-	CommandLine.VarP(newIntSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIntSliceValue(value, p), name, "", usage)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string) {
-	CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIntSliceValue(value, p), name, shorthand, usage)
 }
 
 // IntSlice defines a []int flag with specified name, default value, and usage string.

--- a/ip.go
+++ b/ip.go
@@ -9,7 +9,7 @@ import (
 // -- net.IP value
 type ipValue net.IP
 
-func newIPValue(val net.IP, p *net.IP) *ipValue {
+func NewIPValue(val net.IP, p *net.IP) *ipValue {
 	*p = val
 	return (*ipValue)(p)
 }
@@ -48,23 +48,23 @@ func (f *FlagSet) GetIP(name string) (net.IP, error) {
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
 func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string) {
-	f.VarP(newIPValue(value, p), name, "", usage)
+	f.VarP(NewIPValue(value, p), name, "", usage)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
-	f.VarP(newIPValue(value, p), name, shorthand, usage)
+	f.VarP(NewIPValue(value, p), name, shorthand, usage)
 }
 
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
 func IPVar(p *net.IP, name string, value net.IP, usage string) {
-	CommandLine.VarP(newIPValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIPValue(value, p), name, "", usage)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
 func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
-	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIPValue(value, p), name, shorthand, usage)
 }
 
 // IP defines an net.IP flag with specified name, default value, and usage string.

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -13,7 +13,7 @@ type ipSliceValue struct {
 	changed bool
 }
 
-func newIPSliceValue(val []net.IP, p *[]net.IP) *ipSliceValue {
+func NewIPSliceValue(val []net.IP, p *[]net.IP) *ipSliceValue {
 	ipsv := new(ipSliceValue)
 	ipsv.value = p
 	*ipsv.value = val
@@ -140,23 +140,23 @@ func (f *FlagSet) GetIPSlice(name string) ([]net.IP, error) {
 // IPSliceVar defines a ipSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
 func (f *FlagSet) IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string) {
-	f.VarP(newIPSliceValue(value, p), name, "", usage)
+	f.VarP(NewIPSliceValue(value, p), name, "", usage)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string) {
-	f.VarP(newIPSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewIPSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPSliceVar defines a []net.IP flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
 func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string) {
-	CommandLine.VarP(newIPSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIPSliceValue(value, p), name, "", usage)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string) {
-	CommandLine.VarP(newIPSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIPSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.

--- a/ipmask.go
+++ b/ipmask.go
@@ -9,7 +9,7 @@ import (
 // -- net.IPMask value
 type ipMaskValue net.IPMask
 
-func newIPMaskValue(val net.IPMask, p *net.IPMask) *ipMaskValue {
+func NewIPMaskValue(val net.IPMask, p *net.IPMask) *ipMaskValue {
 	*p = val
 	return (*ipMaskValue)(p)
 }
@@ -76,23 +76,23 @@ func (f *FlagSet) GetIPv4Mask(name string) (net.IPMask, error) {
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
 func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
-	f.VarP(newIPMaskValue(value, p), name, "", usage)
+	f.VarP(NewIPMaskValue(value, p), name, "", usage)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
-	f.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+	f.VarP(NewIPMaskValue(value, p), name, shorthand, usage)
 }
 
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
 func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
-	CommandLine.VarP(newIPMaskValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIPMaskValue(value, p), name, "", usage)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
 func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
-	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIPMaskValue(value, p), name, shorthand, usage)
 }
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.

--- a/ipnet.go
+++ b/ipnet.go
@@ -27,7 +27,7 @@ func (*ipNetValue) Type() string {
 	return "ipNet"
 }
 
-func newIPNetValue(val net.IPNet, p *net.IPNet) *ipNetValue {
+func NewIPNetValue(val net.IPNet, p *net.IPNet) *ipNetValue {
 	*p = val
 	return (*ipNetValue)(p)
 }
@@ -52,23 +52,23 @@ func (f *FlagSet) GetIPNet(name string) (net.IPNet, error) {
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
 func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
-	f.VarP(newIPNetValue(value, p), name, "", usage)
+	f.VarP(NewIPNetValue(value, p), name, "", usage)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
-	f.VarP(newIPNetValue(value, p), name, shorthand, usage)
+	f.VarP(NewIPNetValue(value, p), name, shorthand, usage)
 }
 
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
 func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIPNetValue(value, p), name, "", usage)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
 func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIPNetValue(value, p), name, shorthand, usage)
 }
 
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.

--- a/string.go
+++ b/string.go
@@ -3,7 +3,7 @@ package pflag
 // -- string Value
 type stringValue string
 
-func newStringValue(val string, p *string) *stringValue {
+func NewStringValue(val string, p *string) *stringValue {
 	*p = val
 	return (*stringValue)(p)
 }
@@ -34,23 +34,23 @@ func (f *FlagSet) GetString(name string) (string, error) {
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
 func (f *FlagSet) StringVar(p *string, name string, value string, usage string) {
-	f.VarP(newStringValue(value, p), name, "", usage)
+	f.VarP(NewStringValue(value, p), name, "", usage)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string) {
-	f.VarP(newStringValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringValue(value, p), name, shorthand, usage)
 }
 
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
 func StringVar(p *string, name string, value string, usage string) {
-	CommandLine.VarP(newStringValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringValue(value, p), name, "", usage)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
 func StringVarP(p *string, name, shorthand string, value string, usage string) {
-	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringValue(value, p), name, shorthand, usage)
 }
 
 // String defines a string flag with specified name, default value, and usage string.

--- a/string_array.go
+++ b/string_array.go
@@ -6,7 +6,7 @@ type stringArrayValue struct {
 	changed bool
 }
 
-func newStringArrayValue(val []string, p *[]string) *stringArrayValue {
+func NewStringArrayValue(val []string, p *[]string) *stringArrayValue {
 	ssv := new(stringArrayValue)
 	ssv.value = p
 	*ssv.value = val
@@ -80,24 +80,24 @@ func (f *FlagSet) GetStringArray(name string) ([]string, error) {
 // The argument p points to a []string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string) {
-	f.VarP(newStringArrayValue(value, p), name, "", usage)
+	f.VarP(NewStringArrayValue(value, p), name, "", usage)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	f.VarP(newStringArrayValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringArrayValue(value, p), name, shorthand, usage)
 }
 
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func StringArrayVar(p *[]string, name string, value []string, usage string) {
-	CommandLine.VarP(newStringArrayValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringArrayValue(value, p), name, "", usage)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
 func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	CommandLine.VarP(newStringArrayValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringArrayValue(value, p), name, shorthand, usage)
 }
 
 // StringArray defines a string flag with specified name, default value, and usage string.

--- a/string_slice.go
+++ b/string_slice.go
@@ -12,7 +12,7 @@ type stringSliceValue struct {
 	changed bool
 }
 
-func newStringSliceValue(val []string, p *[]string) *stringSliceValue {
+func NewStringSliceValue(val []string, p *[]string) *stringSliceValue {
 	ssv := new(stringSliceValue)
 	ssv.value = p
 	*ssv.value = val
@@ -102,12 +102,12 @@ func (f *FlagSet) GetStringSlice(name string) ([]string, error) {
 // will result in
 //   []string{"v1", "v2", "v3"}
 func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string) {
-	f.VarP(newStringSliceValue(value, p), name, "", usage)
+	f.VarP(NewStringSliceValue(value, p), name, "", usage)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	f.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringSliceValue(value, p), name, shorthand, usage)
 }
 
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
@@ -118,12 +118,12 @@ func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []s
 // will result in
 //   []string{"v1", "v2", "v3"}
 func StringSliceVar(p *[]string, name string, value []string, usage string) {
-	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringSliceValue(value, p), name, "", usage)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringSliceValue(value, p), name, shorthand, usage)
 }
 
 // StringSlice defines a string flag with specified name, default value, and usage string.

--- a/string_to_int.go
+++ b/string_to_int.go
@@ -13,7 +13,7 @@ type stringToIntValue struct {
 	changed bool
 }
 
-func newStringToIntValue(val map[string]int, p *map[string]int) *stringToIntValue {
+func NewStringToIntValue(val map[string]int, p *map[string]int) *stringToIntValue {
 	ssv := new(stringToIntValue)
 	ssv.value = p
 	*ssv.value = val
@@ -100,24 +100,24 @@ func (f *FlagSet) GetStringToInt(name string) (map[string]int, error) {
 // The argument p points to a map[string]int variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
 func (f *FlagSet) StringToIntVar(p *map[string]int, name string, value map[string]int, usage string) {
-	f.VarP(newStringToIntValue(value, p), name, "", usage)
+	f.VarP(NewStringToIntValue(value, p), name, "", usage)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string) {
-	f.VarP(newStringToIntValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringToIntValue(value, p), name, shorthand, usage)
 }
 
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
 func StringToIntVar(p *map[string]int, name string, value map[string]int, usage string) {
-	CommandLine.VarP(newStringToIntValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringToIntValue(value, p), name, "", usage)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
 func StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string) {
-	CommandLine.VarP(newStringToIntValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringToIntValue(value, p), name, shorthand, usage)
 }
 
 // StringToInt defines a string flag with specified name, default value, and usage string.

--- a/string_to_int64.go
+++ b/string_to_int64.go
@@ -13,7 +13,7 @@ type stringToInt64Value struct {
 	changed bool
 }
 
-func newStringToInt64Value(val map[string]int64, p *map[string]int64) *stringToInt64Value {
+func NewStringToInt64Value(val map[string]int64, p *map[string]int64) *stringToInt64Value {
 	ssv := new(stringToInt64Value)
 	ssv.value = p
 	*ssv.value = val
@@ -100,24 +100,24 @@ func (f *FlagSet) GetStringToInt64(name string) (map[string]int64, error) {
 // The argument p point64s to a map[string]int64 variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
 func (f *FlagSet) StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string) {
-	f.VarP(newStringToInt64Value(value, p), name, "", usage)
+	f.VarP(NewStringToInt64Value(value, p), name, "", usage)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string) {
-	f.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
+	f.VarP(NewStringToInt64Value(value, p), name, shorthand, usage)
 }
 
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
 func StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string) {
-	CommandLine.VarP(newStringToInt64Value(value, p), name, "", usage)
+	CommandLine.VarP(NewStringToInt64Value(value, p), name, "", usage)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
 func StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string) {
-	CommandLine.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringToInt64Value(value, p), name, shorthand, usage)
 }
 
 // StringToInt64 defines a string flag with specified name, default value, and usage string.

--- a/string_to_string.go
+++ b/string_to_string.go
@@ -13,7 +13,7 @@ type stringToStringValue struct {
 	changed bool
 }
 
-func newStringToStringValue(val map[string]string, p *map[string]string) *stringToStringValue {
+func NewStringToStringValue(val map[string]string, p *map[string]string) *stringToStringValue {
 	ssv := new(stringToStringValue)
 	ssv.value = p
 	*ssv.value = val
@@ -111,24 +111,24 @@ func (f *FlagSet) GetStringToString(name string) (map[string]string, error) {
 // The argument p points to a map[string]string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
 func (f *FlagSet) StringToStringVar(p *map[string]string, name string, value map[string]string, usage string) {
-	f.VarP(newStringToStringValue(value, p), name, "", usage)
+	f.VarP(NewStringToStringValue(value, p), name, "", usage)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string) {
-	f.VarP(newStringToStringValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringToStringValue(value, p), name, shorthand, usage)
 }
 
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
 func StringToStringVar(p *map[string]string, name string, value map[string]string, usage string) {
-	CommandLine.VarP(newStringToStringValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringToStringValue(value, p), name, "", usage)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
 func StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string) {
-	CommandLine.VarP(newStringToStringValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringToStringValue(value, p), name, shorthand, usage)
 }
 
 // StringToString defines a string flag with specified name, default value, and usage string.

--- a/uint.go
+++ b/uint.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- uint Value
 type uintValue uint
 
-func newUintValue(val uint, p *uint) *uintValue {
+func NewUintValue(val uint, p *uint) *uintValue {
 	*p = val
 	return (*uintValue)(p)
 }
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint(name string) (uint, error) {
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
 func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string) {
-	f.VarP(newUintValue(value, p), name, "", usage)
+	f.VarP(NewUintValue(value, p), name, "", usage)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string) {
-	f.VarP(newUintValue(value, p), name, shorthand, usage)
+	f.VarP(NewUintValue(value, p), name, shorthand, usage)
 }
 
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
 func UintVar(p *uint, name string, value uint, usage string) {
-	CommandLine.VarP(newUintValue(value, p), name, "", usage)
+	CommandLine.VarP(NewUintValue(value, p), name, "", usage)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
 func UintVarP(p *uint, name, shorthand string, value uint, usage string) {
-	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUintValue(value, p), name, shorthand, usage)
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.

--- a/uint16.go
+++ b/uint16.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- uint16 value
 type uint16Value uint16
 
-func newUint16Value(val uint16, p *uint16) *uint16Value {
+func NewUint16Value(val uint16, p *uint16) *uint16Value {
 	*p = val
 	return (*uint16Value)(p)
 }
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint16(name string) (uint16, error) {
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
 func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string) {
-	f.VarP(newUint16Value(value, p), name, "", usage)
+	f.VarP(NewUint16Value(value, p), name, "", usage)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
-	f.VarP(newUint16Value(value, p), name, shorthand, usage)
+	f.VarP(NewUint16Value(value, p), name, shorthand, usage)
 }
 
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
 func Uint16Var(p *uint16, name string, value uint16, usage string) {
-	CommandLine.VarP(newUint16Value(value, p), name, "", usage)
+	CommandLine.VarP(NewUint16Value(value, p), name, "", usage)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
-	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUint16Value(value, p), name, shorthand, usage)
 }
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.

--- a/uint32.go
+++ b/uint32.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- uint32 value
 type uint32Value uint32
 
-func newUint32Value(val uint32, p *uint32) *uint32Value {
+func NewUint32Value(val uint32, p *uint32) *uint32Value {
 	*p = val
 	return (*uint32Value)(p)
 }
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint32(name string) (uint32, error) {
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32 variable in which to store the value of the flag.
 func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string) {
-	f.VarP(newUint32Value(value, p), name, "", usage)
+	f.VarP(NewUint32Value(value, p), name, "", usage)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
-	f.VarP(newUint32Value(value, p), name, shorthand, usage)
+	f.VarP(NewUint32Value(value, p), name, shorthand, usage)
 }
 
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32  variable in which to store the value of the flag.
 func Uint32Var(p *uint32, name string, value uint32, usage string) {
-	CommandLine.VarP(newUint32Value(value, p), name, "", usage)
+	CommandLine.VarP(NewUint32Value(value, p), name, "", usage)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
-	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUint32Value(value, p), name, shorthand, usage)
 }
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.

--- a/uint64.go
+++ b/uint64.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- uint64 Value
 type uint64Value uint64
 
-func newUint64Value(val uint64, p *uint64) *uint64Value {
+func NewUint64Value(val uint64, p *uint64) *uint64Value {
 	*p = val
 	return (*uint64Value)(p)
 }
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint64(name string) (uint64, error) {
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
 func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string) {
-	f.VarP(newUint64Value(value, p), name, "", usage)
+	f.VarP(NewUint64Value(value, p), name, "", usage)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
-	f.VarP(newUint64Value(value, p), name, shorthand, usage)
+	f.VarP(NewUint64Value(value, p), name, shorthand, usage)
 }
 
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
 func Uint64Var(p *uint64, name string, value uint64, usage string) {
-	CommandLine.VarP(newUint64Value(value, p), name, "", usage)
+	CommandLine.VarP(NewUint64Value(value, p), name, "", usage)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
-	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUint64Value(value, p), name, shorthand, usage)
 }
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.

--- a/uint8.go
+++ b/uint8.go
@@ -5,7 +5,7 @@ import "strconv"
 // -- uint8 Value
 type uint8Value uint8
 
-func newUint8Value(val uint8, p *uint8) *uint8Value {
+func NewUint8Value(val uint8, p *uint8) *uint8Value {
 	*p = val
 	return (*uint8Value)(p)
 }
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint8(name string) (uint8, error) {
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
 func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string) {
-	f.VarP(newUint8Value(value, p), name, "", usage)
+	f.VarP(NewUint8Value(value, p), name, "", usage)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
-	f.VarP(newUint8Value(value, p), name, shorthand, usage)
+	f.VarP(NewUint8Value(value, p), name, shorthand, usage)
 }
 
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
 func Uint8Var(p *uint8, name string, value uint8, usage string) {
-	CommandLine.VarP(newUint8Value(value, p), name, "", usage)
+	CommandLine.VarP(NewUint8Value(value, p), name, "", usage)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
-	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUint8Value(value, p), name, shorthand, usage)
 }
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -12,7 +12,7 @@ type uintSliceValue struct {
 	changed bool
 }
 
-func newUintSliceValue(val []uint, p *[]uint) *uintSliceValue {
+func NewUintSliceValue(val []uint, p *[]uint) *uintSliceValue {
 	uisv := new(uintSliceValue)
 	uisv.value = p
 	*uisv.value = val
@@ -122,23 +122,23 @@ func (f *FlagSet) GetUintSlice(name string) ([]uint, error) {
 // UintSliceVar defines a uintSlice flag with specified name, default value, and usage string.
 // The argument p points to a []uint variable in which to store the value of the flag.
 func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string) {
-	f.VarP(newUintSliceValue(value, p), name, "", usage)
+	f.VarP(NewUintSliceValue(value, p), name, "", usage)
 }
 
 // UintSliceVarP is like UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string) {
-	f.VarP(newUintSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewUintSliceValue(value, p), name, shorthand, usage)
 }
 
 // UintSliceVar defines a uint[] flag with specified name, default value, and usage string.
 // The argument p points to a uint[] variable in which to store the value of the flag.
 func UintSliceVar(p *[]uint, name string, value []uint, usage string) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewUintSliceValue(value, p), name, "", usage)
 }
 
 // UintSliceVarP is like the UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUintSliceValue(value, p), name, shorthand, usage)
 }
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.


### PR DESCRIPTION
this makes possible to do the following:

```go
flag := pflag.Flag{
	Name:      "sample-option",
	Shorthand: "s",
	DefValue:  "default value",
	Value:     pflag.NewStringValue("default value", new(string)),
	Usage:     "option you can add to cobra command with Flags().AddFlag()",
}

cobra.Command{}.Flags().AddFlag(&flag)
```

It allows one to keep the flag definition separately and use the same flag in several CLI commands or subcommands.

cobra has AddFlag() method, but, as far as I see, user can't just make Flag structure and use it. The thing that causes problems is Value field: it requites Value interface implementation, but you can't access default implementations available inside pflag. 
When Value field is nil, you face 'nil pointer dereference' error.