### PR TITLE
fix TestSetOutput

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -915,8 +915,8 @@ func VarP(value Value, name, shorthand, usage string) {
 // returns the error.
 func (f *FlagSet) failf(format string, a ...interface{}) error {
 	err := fmt.Errorf(format, a...)
+	fmt.Fprintln(f.Output(), err)
 	if f.errorHandling != ContinueOnError {
-		fmt.Fprintln(f.Output(), err)
 		f.usage()
 	}
 	return err

--- a/flag_test.go
+++ b/flag_test.go
@@ -860,7 +860,7 @@ func TestSetOutput(t *testing.T) {
 	flags.Init("test", ContinueOnError)
 	flags.Parse([]string{"--unknown"})
 	if out := buf.String(); !strings.Contains(out, "--unknown") {
-		t.Logf("expected output mentioning unknown; got %q", out)
+		t.Errorf("expected output mentioning unknown; got %q", out)
 	}
 }
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -859,9 +859,14 @@ func TestSetOutput(t *testing.T) {
 	flags.SetOutput(&buf)
 	flags.Init("test", ContinueOnError)
 	flags.Parse([]string{"--unknown"})
-	if out := buf.String(); !strings.Contains(out, "--unknown") {
-		t.Errorf("expected output mentioning unknown; got %q", out)
+	out := buf.String()
+	if out == "" {
+		t.Error("expected output, got none")
 	}
+	if strings.Contains(out, "--unknown") {
+		return
+	}
+	t.Errorf("expected output mentioning unknown; got %q", out)
 }
 
 func TestOutput(t *testing.T) {


### PR DESCRIPTION
The `TestSetOutput` test is silently failing. This PR fixes that.

```
=== RUN   TestSetOutput
--- PASS: TestSetOutput (0.00s)
        flag_test.go:853: expected output mentioning unknown; got ""
```