### PR TITLE
feat:use flags by struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ in a command-line interface. The methods of FlagSet are
 analogous to the top-level functions for the command-line
 flag set.
 
+Not only can you set flags one by one, but also set them by struct. For example:
+
+```go
+type testOptions struct {
+    String      string   `flag:"string" short:"a" default:"abc" desc:"this is string"`
+}
+
+flagSet.AddFlags(testOptions{})
+```
+
+It is also very convenient to use:
+
+```go
+var opts = testOptions{}
+flagSet.SetValues(&opts)
+```
+
 ## Setting no option default values for flags
 
 After you create a flag it is possible to set the pflag.NoOptDefVal for
@@ -270,6 +287,7 @@ In order to support flags defined using Go's `flag` package, they must be added 
 to support flags defined by third-party dependencies (e.g. `golang/glog`).
 
 **Example**: You want to add the Go flags to the `CommandLine` flagset
+
 ```go
 import (
 	goflag "flag"

--- a/bool.go
+++ b/bool.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // optional interface to indicate boolean flags that can be
 // supplied without "=value" text
@@ -91,4 +94,24 @@ func Bool(name string, value bool, usage string) *bool {
 func BoolP(name, shorthand string, value bool, usage string) *bool {
 	b := CommandLine.BoolP(name, shorthand, value, usage)
 	return b
+}
+
+// Set bool flag to flagSet
+func setBoolFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := boolConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.BoolP(name, shorthand, defVal.(bool), usage)
+	return nil
+}
+
+// Set bool value from flagSet
+func setBoolValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetBool(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/bool_slice.go
+++ b/bool_slice.go
@@ -2,6 +2,7 @@ package pflag
 
 import (
 	"io"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -182,4 +183,24 @@ func BoolSlice(name string, value []bool, usage string) *[]bool {
 // BoolSliceP is like BoolSlice, but accepts a shorthand letter that can be used after a single dash.
 func BoolSliceP(name, shorthand string, value []bool, usage string) *[]bool {
 	return CommandLine.BoolSliceP(name, shorthand, value, usage)
+}
+
+// Set bool slice flag to flagSet
+func setBoolSliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := boolSliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.BoolSliceP(name, shorthand, defVal.([]bool), usage)
+	return nil
+}
+
+// Set bool slice value from flagSet
+func setBoolSliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetBoolSlice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/duration.go
+++ b/duration.go
@@ -1,6 +1,7 @@
 package pflag
 
 import (
+	"reflect"
 	"time"
 )
 
@@ -83,4 +84,24 @@ func Duration(name string, value time.Duration, usage string) *time.Duration {
 // DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
 func DurationP(name, shorthand string, value time.Duration, usage string) *time.Duration {
 	return CommandLine.DurationP(name, shorthand, value, usage)
+}
+
+// Set time.Duration flag to flagSet
+func setDurationFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := durationConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.DurationP(name, shorthand, defVal.(time.Duration), usage)
+	return nil
+}
+
+// Set duration value from flagSet
+func setDurationValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetDuration(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -2,6 +2,7 @@ package pflag
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -163,4 +164,24 @@ func DurationSlice(name string, value []time.Duration, usage string) *[]time.Dur
 // DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
 func DurationSliceP(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
 	return CommandLine.DurationSliceP(name, shorthand, value, usage)
+}
+
+// Set time.Duration slice flag to flagSet
+func setDurationSliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := durationSliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.DurationSliceP(name, shorthand, defVal.([]time.Duration), usage)
+	return nil
+}
+
+// Set duration slice value from flagSet
+func setDurationSliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetDurationSlice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/flag_reflect.go
+++ b/flag_reflect.go
@@ -1,0 +1,182 @@
+package pflag
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"reflect"
+	"regexp"
+	"time"
+)
+
+func (f *FlagSet) AddFlags(obj interface{}) error {
+	objT := reflect.TypeOf(obj)
+	if isStructPtr(objT) {
+		return fmt.Errorf("%v must be a struct not a struct pointer!", obj)
+	}
+	return parseFlagsFromTag("", f, objT)
+}
+
+func (f *FlagSet) SetValues(obj interface{}) error {
+	objT := reflect.TypeOf(obj)
+	objV := reflect.ValueOf(obj)
+	if !isStructPtr(objT) {
+		return fmt.Errorf("%v must be a struct pointer", obj)
+	}
+	objT = objT.Elem()
+	objV = objV.Elem()
+
+	return setValuesFromFlagSet("", f, objT, objV)
+}
+
+type setFlagFunc func(*FlagSet, string, string, string, string) error
+type setValueFunc func(*FlagSet, string, reflect.Value) error
+
+var typeOf = reflect.TypeOf
+
+var typeSetFlagMap = map[reflect.Type]setFlagFunc{
+	typeOf(bool(true)):        setBoolFlag,
+	typeOf([]bool{}):          setBoolSliceFlag,
+	typeOf(string("")):        setStringFlag,
+	typeOf([]string{}):        setStringSliceFlag,
+	typeOf(int(1)):            setIntFlag,
+	typeOf([]int{}):           setIntSliceFlag,
+	typeOf(int8(1)):           setInt8Flag,
+	typeOf(int16(1)):          setInt16Flag,
+	typeOf(int32(1)):          setInt32Flag,
+	typeOf([]int32{}):         setInt32SliceFlag,
+	typeOf(int64(1)):          setInt64Flag,
+	typeOf([]int64{}):         setInt64SliceFlag,
+	typeOf(uint(1)):           setUintFlag,
+	typeOf([]uint{}):          setUintSliceFlag,
+	typeOf(uint8(1)):          setUint8Flag,
+	typeOf(uint16(1)):         setUint16Flag,
+	typeOf(uint32(1)):         setUint32Flag,
+	typeOf(uint64(1)):         setUint64Flag,
+	typeOf(float32(1)):        setFloat32Flag,
+	typeOf([]float32{}):       setFloat32SliceFlag,
+	typeOf(float64(1)):        setFloat64Flag,
+	typeOf([]float64{}):       setFloat64SliceFlag,
+	typeOf(time.Second):       setDurationFlag,
+	typeOf([]time.Duration{}): setDurationSliceFlag,
+	typeOf(net.IP{}):          setIPFlag,
+	typeOf([]net.IP{}):        setIPSliceFlag,
+	typeOf(net.IPMask{}):      setIPMaskFlag,
+	typeOf(net.IPNet{}):       setIPNetFlag,
+}
+
+var typeSetValueMap = map[reflect.Type]setValueFunc{
+	typeOf(bool(true)):        setBoolValue,
+	typeOf([]bool{}):          setBoolSliceValue,
+	typeOf(string("")):        setStringValue,
+	typeOf([]string{}):        setStringSliceValue,
+	typeOf(int(1)):            setIntValue,
+	typeOf([]int{}):           setIntSliceValue,
+	typeOf(int8(1)):           setInt8Value,
+	typeOf(int16(1)):          setInt16Value,
+	typeOf(int32(1)):          setInt32Value,
+	typeOf([]int32{}):         setInt32SliceValue,
+	typeOf(int64(1)):          setInt64Value,
+	typeOf([]int64{}):         setInt64SliceValue,
+	typeOf(uint(1)):           setUintValue,
+	typeOf([]uint{}):          setUintSliceValue,
+	typeOf(uint8(1)):          setUint8Value,
+	typeOf(uint16(1)):         setUint16Value,
+	typeOf(uint32(1)):         setUint32Value,
+	typeOf(uint64(1)):         setUint64Value,
+	typeOf(float32(1)):        setFloat32Value,
+	typeOf([]float32{}):       setFloat32SliceValue,
+	typeOf(float64(1)):        setFloat64Value,
+	typeOf([]float64{}):       setFloat64SliceValue,
+	typeOf(time.Second):       setDurationValue,
+	typeOf([]time.Duration{}): setDurationSliceValue,
+	typeOf(net.IP{}):          setIPValue,
+	typeOf([]net.IP{}):        setIPSliceValue,
+	typeOf(net.IPMask{}):      setIPMaskValue,
+	typeOf(net.IPNet{}):       setIPNetValue,
+}
+
+func setValuesFromFlagSet(prefix string, flagSet *FlagSet, objT reflect.Type, objV reflect.Value) error {
+	for i := 0; i < objT.NumField(); i++ {
+		fieldV := objV.Field(i)
+		if !fieldV.CanSet() {
+			continue
+		}
+		fieldT := objT.Field(i)
+
+		flag := fieldT.Tag.Get("flag")
+		if prefix != "" {
+			flag = prefix + "." + flag
+		}
+
+		setFunc, ok := typeSetValueMap[fieldT.Type]
+		if ok {
+			if err := setFunc(flagSet, flag, fieldV); err != nil {
+				return err
+			}
+		} else {
+			// do recursion process when filed is struct
+			if !fieldT.Anonymous && fieldT.Type.Kind() == reflect.Struct {
+				if err := setValuesFromFlagSet(flag, flagSet, fieldT.Type, fieldV); err != nil {
+					return err
+				}
+			}
+			// not support type, do nothing
+		}
+
+	}
+	return nil
+}
+
+func parseFlagsFromTag(prefix string, flagSet *FlagSet, objT reflect.Type) error {
+	for i := 0; i < objT.NumField(); i++ {
+		fieldT := objT.Field(i)
+		tag := fieldT.Tag
+		flag := tag.Get("flag")
+		shorthand := tag.Get("short")
+		if prefix != "" {
+			flag = prefix + "." + flag
+			shorthand = ""
+		}
+		def := tag.Get("default")
+		// def from env
+		def = defFromEnv(def)
+		desc := tag.Get("desc")
+
+		setFunc, ok := typeSetFlagMap[fieldT.Type]
+		if ok {
+			if err := setFunc(flagSet, flag, shorthand, def, desc); err != nil {
+				return err
+			}
+		} else {
+			// do recursion process when filed is struct
+			if !fieldT.Anonymous && fieldT.Type.Kind() == reflect.Struct {
+				return parseFlagsFromTag(flag, flagSet, fieldT.Type)
+			}
+			// not support type, do nothing
+		}
+	}
+	return nil
+}
+
+func defFromEnv(def string) string {
+	matchedParenthesis, err := regexp.MatchString(`^\$\(\w+\)$`, def)
+	if err != nil {
+		return def
+	}
+
+	matchedBrace, err := regexp.MatchString(`^\$\{\w+\}$`, def)
+	if err != nil {
+		return def
+	}
+
+	if matchedParenthesis || matchedBrace {
+		return os.Getenv(def[2 : len(def)-1])
+	}
+
+	return def
+}
+
+func isStructPtr(t reflect.Type) bool {
+	return t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Struct
+}

--- a/flag_reflect_test.go
+++ b/flag_reflect_test.go
@@ -1,0 +1,299 @@
+package pflag
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+type testOptions struct {
+	String      string   `flag:"string" short:"a" default:"abc" desc:"this is string"`
+	StringSlice []string `flag:"stringSlice" default:"[a,b]" desc:"this is string slice"`
+
+	Bool      bool   `flag:"bool" short:"b" default:"true" desc:"this is bool"`
+	BoolSlice []bool `flag:"boolSlice" default:"[true,false]" desc:"this is bool slice"`
+
+	Int          int       `flag:"int" short:"c" default:"1" desc:"this is int"`
+	IntSlice     []int     `flag:"intSlice" default:"[1,2]" desc:"this is int slice"`
+	Int8         int8      `flag:"int8" default:"1" desc:"this is int8"`
+	Int16        int16     `flag:"int16" default:"1" desc:"this is int16"`
+	Int32        int32     `flag:"int32" default:"1" desc:"this is int32"`
+	Int32Slice   []int32   `flag:"int32Slice" default:"[1,2]" desc:"this is int32 slice"`
+	Int64        int64     `flag:"int64" default:"1" desc:"this is int64"`
+	Int64Slice   []int64   `flag:"int64Slice"  default:"[1,2]" desc:"this is int64 slice"`
+	Uint         uint      `flag:"uint" default:"1" desc:"this is uint"`
+	UintSlice    []uint    `flag:"uintSlice" default:"[1,2]" desc:"this is uint slice"`
+	Uint8        uint8     `flag:"uint8" default:"1" desc:"this is uint8"`
+	Uint16       uint16    `flag:"uint16" default:"1" desc:"this is uint16"`
+	Uint32       uint32    `flag:"uint32" default:"1" desc:"this is uint32"`
+	Uint64       uint64    `flag:"uint64" default:"1" desc:"this is uint64"`
+	Float32      float32   `flag:"float32" default:"1.1" desc:"this is float32"`
+	Float32Slice []float32 `flag:"float32Slice" default:"1.1,2.1" desc:"this is float32 slice"`
+	Float64      float64   `flag:"float64" default:"1.1" desc:"this is float64"`
+	Float64Slice []float64 `flag:"float64Slice" default:"1.1,2.1" desc:"this is float64 slice"`
+
+	Duration      time.Duration   `flag:"duration" short:"d" default:"1s" desc:"this is duration"`
+	DurationSlice []time.Duration `flag:"durationSlice" default:"1s,2m" desc:"this is duration slice"`
+
+	IP      net.IP     `flag:"ip" short:"i" default:"127.0.0.1" desc:"this is ip"`
+	IPSlice []net.IP   `flag:"ipSlice" default:"127.0.0.1,127.0.0.2" desc:"this is ip slice"`
+	IPMask  net.IPMask `flag:"ipMask" default:"255.255.255.255" desc:"this is ipMask"`
+	IPNet   net.IPNet  `flag:"ipNet" default:"192.0.2.1/24" desc:"this is ipNet"`
+
+	Env string `flag:"env" short:"e" default:"${PWD}" desc:"this is env"`
+
+	Others otherInfo `flag:"others"`
+}
+
+type otherInfo struct {
+	// can't set shorhand
+	String string `flag:"string" default:"abcd" desc:"this is others.string"`
+}
+
+func TestSetValues(t *testing.T) {
+	f := NewFlagSet("", ContinueOnError)
+	if err := f.AddFlags(testOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	args := []string{
+		"--bool", "true",
+		"--string", "abcd",
+		"--int", "2",
+		"--duration", "2s",
+		"--ip", "127.0.0.2",
+		"--others.string", "abcde",
+	}
+	if err := f.Parse(args); err != nil {
+		t.Error(err)
+	}
+
+	var opts = testOptions{}
+	if err := f.SetValues(&opts); err != nil {
+		t.Error(err)
+	}
+
+	if opts.Bool != true {
+		t.Errorf("bool(%v) is not equals (%v)", opts.Bool, true)
+	}
+	if opts.String != "abcd" {
+		t.Errorf("string(%v) is not equals (%v)", opts.String, "abcd")
+	}
+	if opts.Int != 2 {
+		t.Errorf("int(%v) is not equals (%v)", opts.Int, 1)
+	}
+	if opts.Duration != 2*time.Second {
+		t.Errorf("duration(%v) is not equals (%v)", opts.Duration, 2*time.Second)
+	}
+
+	if !bytes.Equal(opts.IP, net.ParseIP("127.0.0.2")) {
+		t.Errorf("ip(%v) is not equals (%v)", opts.IP, net.ParseIP("127.0.0.2"))
+	}
+	if opts.Others.String != "abcde" {
+		t.Errorf("others.string(%v) is not equals (%v)", opts.Others.String, "abcde")
+	}
+
+}
+
+func TestAddFlags(t *testing.T) {
+	f := NewFlagSet("", ContinueOnError)
+	err := f.AddFlags(testOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		Name      string
+		Shorthand string
+		Def       string
+		Usage     string
+	}{
+		{
+			Name:      "string",
+			Shorthand: "a",
+			Def:       "abc",
+			Usage:     "this is string",
+		},
+		{
+			Name:  "stringSlice",
+			Def:   "[a,b]",
+			Usage: "this is string slice",
+		},
+		{
+			Name:      "bool",
+			Shorthand: "b",
+			Def:       "true",
+			Usage:     "this is bool",
+		},
+		{
+			Name:  "boolSlice",
+			Def:   "[true,false]",
+			Usage: "this is bool slice",
+		},
+		{
+			Name:      "int",
+			Shorthand: "c",
+			Def:       "1",
+			Usage:     "this is int",
+		},
+		{
+			Name:  "intSlice",
+			Def:   "[1,2]",
+			Usage: "this is int slice",
+		},
+		{
+			Name:  "int8",
+			Def:   "1",
+			Usage: "this is int8",
+		},
+		{
+			Name:  "int16",
+			Def:   "1",
+			Usage: "this is int16",
+		},
+		{
+			Name:  "int32",
+			Def:   "1",
+			Usage: "this is int32",
+		},
+		{
+			Name:  "int32Slice",
+			Def:   "[1,2]",
+			Usage: "this is int32 slice",
+		},
+		{
+			Name:  "int64",
+			Def:   "1",
+			Usage: "this is int64",
+		},
+		{
+			Name:  "int64Slice",
+			Def:   "[1,2]",
+			Usage: "this is int64 slice",
+		},
+		{
+			Name:  "uint",
+			Def:   "1",
+			Usage: "this is uint",
+		},
+		{
+			Name:  "uintSlice",
+			Def:   "[1,2]",
+			Usage: "this is uint slice",
+		},
+		{
+			Name:  "uint8",
+			Def:   "1",
+			Usage: "this is uint8",
+		},
+		{
+			Name:  "uint16",
+			Def:   "1",
+			Usage: "this is uint16",
+		},
+		{
+			Name:  "uint32",
+			Def:   "1",
+			Usage: "this is uint32",
+		},
+		{
+			Name:  "uint64",
+			Def:   "1",
+			Usage: "this is uint64",
+		},
+		{
+			Name:  "float32",
+			Def:   "1.1",
+			Usage: "this is float32",
+		},
+		{
+			Name:  "float32Slice",
+			Def:   "[1.100000,2.100000]",
+			Usage: "this is float32 slice",
+		},
+		{
+			Name:  "float64",
+			Def:   "1.1",
+			Usage: "this is float64",
+		},
+		{
+			Name:  "float64Slice",
+			Def:   "[1.100000,2.100000]",
+			Usage: "this is float64 slice",
+		},
+		{
+			Name:      "duration",
+			Shorthand: "d",
+			Def:       "1s",
+			Usage:     "this is duration",
+		},
+		{
+			Name:  "durationSlice",
+			Def:   "[1s,2m0s]",
+			Usage: "this is duration slice",
+		},
+		{
+			Name:      "ip",
+			Shorthand: "i",
+			Def:       "127.0.0.1",
+			Usage:     "this is ip",
+		},
+		{
+			Name:  "ipSlice",
+			Def:   "[127.0.0.1,127.0.0.2]",
+			Usage: "this is ip slice",
+		},
+		{
+			Name:  "ipMask",
+			Def:   "ffffffff",
+			Usage: "this is ipMask",
+		},
+		{
+			Name:  "ipNet",
+			Def:   "192.0.2.0/24",
+			Usage: "this is ipNet",
+		},
+		{
+			Name:      "env",
+			Shorthand: "e",
+			Def:       os.Getenv("PWD"),
+			Usage:     "this is env",
+		},
+		{
+			Name:  "others.string",
+			Def:   "abcd",
+			Usage: "this is others.string",
+		},
+	}
+
+	for _, c := range cases {
+		normalName := f.normalizeFlagName(c.Name)
+		itemFlag := f.formal[normalName]
+		err := checkFlag(itemFlag, c.Name, c.Shorthand, c.Def, c.Usage)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func checkFlag(flag *Flag, name, short, def, desc string) error {
+	if flag == nil {
+		return fmt.Errorf("flag is nil")
+	}
+	if flag.Name != name {
+		return fmt.Errorf("flag(%s) not equal flag.Name(%s) \n", name, flag.Name)
+	}
+	if flag.Shorthand != short {
+		return fmt.Errorf("short(%s) not equal in flag.Shorthand(%s) \n", short, flag.Shorthand)
+	}
+	if flag.DefValue != def {
+		return fmt.Errorf("def(%s) not equal in flag.DefValue(%s) \n", def, flag.DefValue)
+	}
+	if flag.Usage != desc {
+		return fmt.Errorf("desc(%s) not equal in flag.Usage(%s) \n", desc, flag.Usage)
+	}
+	return nil
+}

--- a/float32.go
+++ b/float32.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- float32 Value
 type float32Value float32
@@ -85,4 +88,24 @@ func Float32(name string, value float32, usage string) *float32 {
 // Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
 func Float32P(name, shorthand string, value float32, usage string) *float32 {
 	return CommandLine.Float32P(name, shorthand, value, usage)
+}
+
+// Set float32 flag to flagSet
+func setFloat32Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := float32Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Float32P(name, shorthand, defVal.(float32), usage)
+	return nil
+}
+
+// Set float32 value from flagSet
+func setFloat32Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetFloat32(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -2,6 +2,7 @@ package pflag
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -171,4 +172,24 @@ func Float32Slice(name string, value []float32, usage string) *[]float32 {
 // Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
 func Float32SliceP(name, shorthand string, value []float32, usage string) *[]float32 {
 	return CommandLine.Float32SliceP(name, shorthand, value, usage)
+}
+
+// Set float32 slice flag to flagSet
+func setFloat32SliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := float32SliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Float32SliceP(name, shorthand, defVal.([]float32), usage)
+	return nil
+}
+
+// Set float32 slice value from flagSet
+func setFloat32SliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetFloat32Slice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/float64.go
+++ b/float64.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- float64 Value
 type float64Value float64
@@ -81,4 +84,24 @@ func Float64(name string, value float64, usage string) *float64 {
 // Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
 func Float64P(name, shorthand string, value float64, usage string) *float64 {
 	return CommandLine.Float64P(name, shorthand, value, usage)
+}
+
+// Set float64 flag to flagSet
+func setFloat64Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := float64Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Float64P(name, shorthand, defVal.(float64), usage)
+	return nil
+}
+
+// Set float64 value from flagSet
+func setFloat64Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetFloat64(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -2,6 +2,7 @@ package pflag
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -163,4 +164,24 @@ func Float64Slice(name string, value []float64, usage string) *[]float64 {
 // Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
 func Float64SliceP(name, shorthand string, value []float64, usage string) *[]float64 {
 	return CommandLine.Float64SliceP(name, shorthand, value, usage)
+}
+
+// Set float64 slice flag to flagSet
+func setFloat64SliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := float64SliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Float64SliceP(name, shorthand, defVal.([]float64), usage)
+	return nil
+}
+
+// Set float64 slice value from flagSet
+func setFloat64SliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetFloat64Slice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/int.go
+++ b/int.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- int Value
 type intValue int
@@ -81,4 +84,24 @@ func Int(name string, value int, usage string) *int {
 // IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
 func IntP(name, shorthand string, value int, usage string) *int {
 	return CommandLine.IntP(name, shorthand, value, usage)
+}
+
+// Set int flag to flagSet
+func setIntFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := intConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.IntP(name, shorthand, defVal.(int), usage)
+	return nil
+}
+
+// Set int value from flagSet
+func setIntValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetInt(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/int16.go
+++ b/int16.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- int16 Value
 type int16Value int16
@@ -85,4 +88,24 @@ func Int16(name string, value int16, usage string) *int16 {
 // Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
 func Int16P(name, shorthand string, value int16, usage string) *int16 {
 	return CommandLine.Int16P(name, shorthand, value, usage)
+}
+
+// Set int16 flag to flagSet
+func setInt16Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := int16Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Int16P(name, shorthand, defVal.(int16), usage)
+	return nil
+}
+
+// Set int16 value from flagSet
+func setInt16Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetInt16(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/int32.go
+++ b/int32.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- int32 Value
 type int32Value int32
@@ -85,4 +88,24 @@ func Int32(name string, value int32, usage string) *int32 {
 // Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
 func Int32P(name, shorthand string, value int32, usage string) *int32 {
 	return CommandLine.Int32P(name, shorthand, value, usage)
+}
+
+// Set int32 flag to flagSet
+func setInt32Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := int32Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Int32P(name, shorthand, defVal.(int32), usage)
+	return nil
+}
+
+// Set int32 value from flagSet
+func setInt32Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetInt32(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -2,6 +2,7 @@ package pflag
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -171,4 +172,24 @@ func Int32Slice(name string, value []int32, usage string) *[]int32 {
 // Int32SliceP is like Int32Slice, but accepts a shorthand letter that can be used after a single dash.
 func Int32SliceP(name, shorthand string, value []int32, usage string) *[]int32 {
 	return CommandLine.Int32SliceP(name, shorthand, value, usage)
+}
+
+// Set int32 slice flag to flagSet
+func setInt32SliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := int32SliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Int32SliceP(name, shorthand, defVal.([]int32), usage)
+	return nil
+}
+
+// Set int32 slice value from flagSet
+func setInt32SliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetInt32Slice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/int64.go
+++ b/int64.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- int64 Value
 type int64Value int64
@@ -81,4 +84,24 @@ func Int64(name string, value int64, usage string) *int64 {
 // Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
 func Int64P(name, shorthand string, value int64, usage string) *int64 {
 	return CommandLine.Int64P(name, shorthand, value, usage)
+}
+
+// Set int64 flag to flagSet
+func setInt64Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := int64Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Int64P(name, shorthand, defVal.(int64), usage)
+	return nil
+}
+
+// Set int64 value from flagSet
+func setInt64Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetInt64(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -2,6 +2,7 @@ package pflag
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -163,4 +164,24 @@ func Int64Slice(name string, value []int64, usage string) *[]int64 {
 // Int64SliceP is like Int64Slice, but accepts a shorthand letter that can be used after a single dash.
 func Int64SliceP(name, shorthand string, value []int64, usage string) *[]int64 {
 	return CommandLine.Int64SliceP(name, shorthand, value, usage)
+}
+
+// Set int64 slice flag to flagSet
+func setInt64SliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := int64SliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Int64SliceP(name, shorthand, defVal.([]int64), usage)
+	return nil
+}
+
+// Set int64 slice value from flagSet
+func setInt64SliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetInt64Slice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/int8.go
+++ b/int8.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- int8 Value
 type int8Value int8
@@ -85,4 +88,24 @@ func Int8(name string, value int8, usage string) *int8 {
 // Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
 func Int8P(name, shorthand string, value int8, usage string) *int8 {
 	return CommandLine.Int8P(name, shorthand, value, usage)
+}
+
+// Set int8 flag to flagSet
+func setInt8Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := int8Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Int8P(name, shorthand, defVal.(int8), usage)
+	return nil
+}
+
+// Set int8 value from flagSet
+func setInt8Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetInt8(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/int_slice.go
+++ b/int_slice.go
@@ -2,6 +2,7 @@ package pflag
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -155,4 +156,24 @@ func IntSlice(name string, value []int, usage string) *[]int {
 // IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
 func IntSliceP(name, shorthand string, value []int, usage string) *[]int {
 	return CommandLine.IntSliceP(name, shorthand, value, usage)
+}
+
+// Set int slice flag to flagSet
+func setIntSliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := intSliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.IntSliceP(name, shorthand, defVal.([]int), usage)
+	return nil
+}
+
+// Set int slice value from flagSet
+func setIntSliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetIntSlice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/ip.go
+++ b/ip.go
@@ -3,6 +3,7 @@ package pflag
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 )
 
@@ -91,4 +92,24 @@ func IP(name string, value net.IP, usage string) *net.IP {
 // IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
 func IPP(name, shorthand string, value net.IP, usage string) *net.IP {
 	return CommandLine.IPP(name, shorthand, value, usage)
+}
+
+// Set net.IP flag to flagSet
+func setIPFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := ipConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.IPP(name, shorthand, defVal.(net.IP), usage)
+	return nil
+}
+
+// Set net.IP value from flagSet
+func setIPValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetIP(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"reflect"
 	"strings"
 )
 
@@ -183,4 +184,24 @@ func IPSlice(name string, value []net.IP, usage string) *[]net.IP {
 // IPSliceP is like IPSlice, but accepts a shorthand letter that can be used after a single dash.
 func IPSliceP(name, shorthand string, value []net.IP, usage string) *[]net.IP {
 	return CommandLine.IPSliceP(name, shorthand, value, usage)
+}
+
+// Set net.IP slice flag to flagSet
+func setIPSliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := ipSliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.IPSliceP(name, shorthand, defVal.([]net.IP), usage)
+	return nil
+}
+
+// Set net.IP slice value from flagSet
+func setIPSliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetIPSlice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/ipmask.go
+++ b/ipmask.go
@@ -3,6 +3,7 @@ package pflag
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 )
 
@@ -119,4 +120,24 @@ func IPMask(name string, value net.IPMask, usage string) *net.IPMask {
 // IPMaskP is like IP, but accepts a shorthand letter that can be used after a single dash.
 func IPMaskP(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
 	return CommandLine.IPMaskP(name, shorthand, value, usage)
+}
+
+// Set net.IPMask flag to flagSet
+func setIPMaskFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := parseIPv4Mask(value)
+	if err != nil {
+		return err
+	}
+	flagSet.IPMaskP(name, shorthand, defVal.(net.IPMask), usage)
+	return nil
+}
+
+// Set net.IPMask value from flagSet
+func setIPMaskValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetIPv4Mask(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/ipnet.go
+++ b/ipnet.go
@@ -3,6 +3,7 @@ package pflag
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 )
 
@@ -95,4 +96,24 @@ func IPNet(name string, value net.IPNet, usage string) *net.IPNet {
 // IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
 func IPNetP(name, shorthand string, value net.IPNet, usage string) *net.IPNet {
 	return CommandLine.IPNetP(name, shorthand, value, usage)
+}
+
+// Set net.IPNet flag to flagSet
+func setIPNetFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := ipNetConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.IPNetP(name, shorthand, defVal.(net.IPNet), usage)
+	return nil
+}
+
+// Set net.IPNet value from flagSet
+func setIPNetValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetIPNet(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/string.go
+++ b/string.go
@@ -1,5 +1,7 @@
 package pflag
 
+import "reflect"
+
 // -- string Value
 type stringValue string
 
@@ -77,4 +79,24 @@ func String(name string, value string, usage string) *string {
 // StringP is like String, but accepts a shorthand letter that can be used after a single dash.
 func StringP(name, shorthand string, value string, usage string) *string {
 	return CommandLine.StringP(name, shorthand, value, usage)
+}
+
+// Set string flag to flagSet
+func setStringFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := stringConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.StringP(name, shorthand, defVal.(string), usage)
+	return nil
+}
+
+// Set string value from flagSet
+func setStringValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetString(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -3,6 +3,7 @@ package pflag
 import (
 	"bytes"
 	"encoding/csv"
+	"reflect"
 	"strings"
 )
 
@@ -160,4 +161,24 @@ func StringSlice(name string, value []string, usage string) *[]string {
 // StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
 func StringSliceP(name, shorthand string, value []string, usage string) *[]string {
 	return CommandLine.StringSliceP(name, shorthand, value, usage)
+}
+
+// Set string slice flag to flagSet
+func setStringSliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := stringSliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.StringSliceP(name, shorthand, defVal.([]string), usage)
+	return nil
+}
+
+// Set string slice value from flagSet
+func setStringSliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetStringSlice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/uint.go
+++ b/uint.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- uint Value
 type uintValue uint
@@ -85,4 +88,24 @@ func Uint(name string, value uint, usage string) *uint {
 // UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
 func UintP(name, shorthand string, value uint, usage string) *uint {
 	return CommandLine.UintP(name, shorthand, value, usage)
+}
+
+// Set uint flag to flagSet
+func setUintFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := uintConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.UintP(name, shorthand, defVal.(uint), usage)
+	return nil
+}
+
+// Set uint value from flagSet
+func setUintValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetUint(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/uint16.go
+++ b/uint16.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- uint16 value
 type uint16Value uint16
@@ -85,4 +88,24 @@ func Uint16(name string, value uint16, usage string) *uint16 {
 // Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
 func Uint16P(name, shorthand string, value uint16, usage string) *uint16 {
 	return CommandLine.Uint16P(name, shorthand, value, usage)
+}
+
+// Set uint16 flag to flagSet
+func setUint16Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := uint16Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Uint16P(name, shorthand, defVal.(uint16), usage)
+	return nil
+}
+
+// Set uint16 value from flagSet
+func setUint16Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetUint16(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/uint32.go
+++ b/uint32.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- uint32 value
 type uint32Value uint32
@@ -85,4 +88,24 @@ func Uint32(name string, value uint32, usage string) *uint32 {
 // Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
 func Uint32P(name, shorthand string, value uint32, usage string) *uint32 {
 	return CommandLine.Uint32P(name, shorthand, value, usage)
+}
+
+// Set uint32 flag to flagSet
+func setUint32Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := uint32Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Uint32P(name, shorthand, defVal.(uint32), usage)
+	return nil
+}
+
+// Set uint32 value from flagSet
+func setUint32Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetUint32(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/uint64.go
+++ b/uint64.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- uint64 Value
 type uint64Value uint64
@@ -85,4 +88,24 @@ func Uint64(name string, value uint64, usage string) *uint64 {
 // Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
 func Uint64P(name, shorthand string, value uint64, usage string) *uint64 {
 	return CommandLine.Uint64P(name, shorthand, value, usage)
+}
+
+// Set uint64 flag to flagSet
+func setUint64Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := uint64Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Uint64P(name, shorthand, defVal.(uint64), usage)
+	return nil
+}
+
+// Set uint64 value from flagSet
+func setUint64Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetUint64(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/uint8.go
+++ b/uint8.go
@@ -1,6 +1,9 @@
 package pflag
 
-import "strconv"
+import (
+	"reflect"
+	"strconv"
+)
 
 // -- uint8 Value
 type uint8Value uint8
@@ -85,4 +88,24 @@ func Uint8(name string, value uint8, usage string) *uint8 {
 // Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
 func Uint8P(name, shorthand string, value uint8, usage string) *uint8 {
 	return CommandLine.Uint8P(name, shorthand, value, usage)
+}
+
+// Set uint8 flag to flagSet
+func setUint8Flag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := uint8Conv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.Uint8P(name, shorthand, defVal.(uint8), usage)
+	return nil
+}
+
+// Set uint8 value from flagSet
+func setUint8Value(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetUint8(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -2,6 +2,7 @@ package pflag
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -165,4 +166,24 @@ func UintSlice(name string, value []uint, usage string) *[]uint {
 // UintSliceP is like UintSlice, but accepts a shorthand letter that can be used after a single dash.
 func UintSliceP(name, shorthand string, value []uint, usage string) *[]uint {
 	return CommandLine.UintSliceP(name, shorthand, value, usage)
+}
+
+// Set uint slice flag to flagSet
+func setUintSliceFlag(flagSet *FlagSet, name, shorthand, value, usage string) error {
+	defVal, err := uintSliceConv(value)
+	if err != nil {
+		return err
+	}
+	flagSet.UintSliceP(name, shorthand, defVal.([]uint), usage)
+	return nil
+}
+
+// Set uint slice value from flagSet
+func setUintSliceValue(flagSet *FlagSet, name string, fieldV reflect.Value) error {
+	val, err := flagSet.GetUintSlice(name)
+	if err != nil {
+		return err
+	}
+	fieldV.Set(reflect.ValueOf(val))
+	return nil
 }


### PR DESCRIPTION
Add two methods to FlagSet：
AddFlags(obj interface{}) error // add flags to FlagSet by struct
SetValues(obj interface{}) error // set struct values from FlagSet

How to use?
type testOptions struct {
String string flag:"string" short:"a" default:"abc" desc:"this is string"
}
flagSet.AddFlags(testOptions{})

var opts = testOptions{}
flagSet.SetValues(&opts)
The two methods support most types eg. int uint bool string float net.IP time.Duration, It also can support nested struct.