### PR TITLE
Fix typos in count.go, flag.go

### DIFF
--- a/count.go
+++ b/count.go
@@ -85,7 +85,7 @@ func (f *FlagSet) CountP(name, shorthand string, usage string) *int {
 
 // Count defines a count flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
-// A count flag will add 1 to its value evey time it is found on the command line
+// A count flag will add 1 to its value every time it is found on the command line
 func Count(name string, usage string) *int {
 	return CommandLine.CountP(name, "", usage)
 }

--- a/flag.go
+++ b/flag.go
@@ -179,7 +179,7 @@ type Flag struct {
 	Deprecated          string              // If this flag is deprecated, this string is the new or now thing to use
 	Hidden              bool                // used by cobra.Command to allow flags to be hidden from help/usage text
 	ShorthandDeprecated string              // If the shorthand of this flag is deprecated, this string is the new or now thing to use
-	Annotations         map[string][]string // used by cobra.Command bash autocomple code
+	Annotations         map[string][]string // used by cobra.Command bash autocompletion code
 }
 
 // Value is the interface to the dynamic value stored in a flag.


### PR DESCRIPTION
Changes:
flag.go - changed "autocomple" to "autocompletion".
count.go - changed "evey" to "every".