### PR TITLE
add Setter and Setv()

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -23,6 +23,18 @@ func (b *boolValue) Set(s string) error {
 	return err
 }
 
+func (b *boolValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case bool:
+		*b = boolValue(tv)
+	case string:
+		return b.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (b *boolValue) Type() string {
 	return "bool"
 }

--- a/bool_slice.go
+++ b/bool_slice.go
@@ -53,6 +53,17 @@ func (s *boolSliceValue) Set(val string) error {
 	return nil
 }
 
+// Setv tries its best to set the value from an arbitrary type
+func (s *boolSliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []bool:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 // Type returns a string that uniquely represents this flag's type.
 func (s *boolSliceValue) Type() string {
 	return "boolSlice"

--- a/bytes.go
+++ b/bytes.go
@@ -28,6 +28,18 @@ func (bytesHex *bytesHexValue) Set(value string) error {
 	return nil
 }
 
+func (bytesHex *bytesHexValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []byte:
+		*bytesHex = tv
+	case string:
+		return bytesHex.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 // Type implements pflag.Value.Type.
 func (*bytesHexValue) Type() string {
 	return "bytesHex"
@@ -126,6 +138,19 @@ func (bytesBase64 *bytesBase64Value) Set(value string) error {
 
 	*bytesBase64 = bin
 
+	return nil
+}
+
+// Setv tries its best to set the value from an arbitrary type
+func (bytesBase64 *bytesBase64Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []byte:
+		*bytesBase64 = tv
+	case string:
+		return bytesBase64.Set(tv)
+	default:
+		return ErrSetv
+	}
 	return nil
 }
 

--- a/duration.go
+++ b/duration.go
@@ -18,6 +18,18 @@ func (d *durationValue) Set(s string) error {
 	return err
 }
 
+func (d *durationValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case time.Duration:
+		*d = durationValue(tv)
+	case string:
+		return d.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (d *durationValue) Type() string {
 	return "duration"
 }

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -39,6 +39,16 @@ func (s *durationSliceValue) Set(val string) error {
 	return nil
 }
 
+func (s *durationSliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []time.Duration:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (s *durationSliceValue) Type() string {
 	return "durationSlice"
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -92,6 +92,34 @@ func TestEverything(t *testing.T) {
 			t.Log(k, *v)
 		}
 	}
+	// Now set all flags to real values
+	if Setv("test_bool", true) != nil {
+		t.Error("Could not Setv bool to true")
+	}
+	if Setv("test_int", 1) != nil {
+		t.Error("Could not Setv int to 1")
+	}
+	if Setv("test_int64", 1) != nil {
+		t.Error("Could not Setv int64 to 1")
+	}
+	if Setv("test_uint", 1) != nil {
+		t.Error("Could not Setv uint to 1")
+	}
+	if Setv("test_uint64", 1) != nil {
+		t.Error("Could not Setv uint64 to 1")
+	}
+	if Setv("test_string", "1") != nil {
+		t.Error("Could not Setv string to \"1\"")
+	}
+	if Setv("test_float64", 1) != nil {
+		t.Error("Could not Setv float64 to 1")
+	}
+	if Setv("test_duration", time.Duration(1)) != nil {
+		t.Error("Could not Setv time.Duration to 1")
+	}
+	if Setv("test_optional_int", 1) != nil {
+		t.Error("Could not Setv optional int to 1")
+	}
 	// Now test they're visited in sort order.
 	var flagNames []string
 	Visit(func(f *Flag) { flagNames = append(flagNames, f.Name) })

--- a/float32.go
+++ b/float32.go
@@ -16,6 +16,26 @@ func (f *float32Value) Set(s string) error {
 	return err
 }
 
+func (f *float32Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case float32:
+		*f = float32Value(tv)
+	case int16:
+		*f = float32Value(tv)
+	case int8:
+		*f = float32Value(tv)
+	case uint16:
+		*f = float32Value(tv)
+	case uint8:
+		*f = float32Value(tv)
+	case string:
+		return f.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (f *float32Value) Type() string {
 	return "float32"
 }

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -41,6 +41,16 @@ func (s *float32SliceValue) Set(val string) error {
 	return nil
 }
 
+func (s *float32SliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []float32:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (s *float32SliceValue) Type() string {
 	return "float32Slice"
 }

--- a/float64.go
+++ b/float64.go
@@ -16,6 +16,36 @@ func (f *float64Value) Set(s string) error {
 	return err
 }
 
+func (f *float64Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case float64:
+		*f = float64Value(tv)
+	case float32:
+		*f = float64Value(tv)
+	case int:
+		*f = float64Value(tv)
+	case int32:
+		*f = float64Value(tv)
+	case int16:
+		*f = float64Value(tv)
+	case int8:
+		*f = float64Value(tv)
+	case uint:
+		*f = float64Value(tv)
+	case uint32:
+		*f = float64Value(tv)
+	case uint16:
+		*f = float64Value(tv)
+	case uint8:
+		*f = float64Value(tv)
+	case string:
+		return f.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (f *float64Value) Type() string {
 	return "float64"
 }

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -39,6 +39,16 @@ func (s *float64SliceValue) Set(val string) error {
 	return nil
 }
 
+func (s *float64SliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []float64:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (s *float64SliceValue) Type() string {
 	return "float64Slice"
 }

--- a/int.go
+++ b/int.go
@@ -16,6 +16,28 @@ func (i *intValue) Set(s string) error {
 	return err
 }
 
+func (i *intValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case int:
+		*i = intValue(tv)
+	case int32:
+		*i = intValue(tv)
+	case int16:
+		*i = intValue(tv)
+	case int8:
+		*i = intValue(tv)
+	case uint16:
+		*i = intValue(tv)
+	case uint8:
+		*i = intValue(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *intValue) Type() string {
 	return "int"
 }

--- a/int16.go
+++ b/int16.go
@@ -16,6 +16,22 @@ func (i *int16Value) Set(s string) error {
 	return err
 }
 
+func (i *int16Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case int16:
+		*i = int16Value(tv)
+	case int8:
+		*i = int16Value(tv)
+	case uint8:
+		*i = int16Value(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *int16Value) Type() string {
 	return "int16"
 }

--- a/int32.go
+++ b/int32.go
@@ -16,6 +16,28 @@ func (i *int32Value) Set(s string) error {
 	return err
 }
 
+func (i *int32Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case int:
+		*i = int32Value(tv)
+	case int32:
+		*i = int32Value(tv)
+	case int16:
+		*i = int32Value(tv)
+	case int8:
+		*i = int32Value(tv)
+	case uint16:
+		*i = int32Value(tv)
+	case uint8:
+		*i = int32Value(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *int32Value) Type() string {
 	return "int32"
 }

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -41,6 +41,16 @@ func (s *int32SliceValue) Set(val string) error {
 	return nil
 }
 
+func (s *int32SliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []int32:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (s *int32SliceValue) Type() string {
 	return "int32Slice"
 }

--- a/int64.go
+++ b/int64.go
@@ -16,6 +16,34 @@ func (i *int64Value) Set(s string) error {
 	return err
 }
 
+func (i *int64Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case int:
+		*i = int64Value(tv)
+	case int64:
+		*i = int64Value(tv)
+	case int32:
+		*i = int64Value(tv)
+	case int16:
+		*i = int64Value(tv)
+	case int8:
+		*i = int64Value(tv)
+	case uint:
+		*i = int64Value(tv)
+	case uint32:
+		*i = int64Value(tv)
+	case uint16:
+		*i = int64Value(tv)
+	case uint8:
+		*i = int64Value(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *int64Value) Type() string {
 	return "int64"
 }

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -39,6 +39,16 @@ func (s *int64SliceValue) Set(val string) error {
 	return nil
 }
 
+func (s *int64SliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []int64:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (s *int64SliceValue) Type() string {
 	return "int64Slice"
 }

--- a/int8.go
+++ b/int8.go
@@ -16,6 +16,18 @@ func (i *int8Value) Set(s string) error {
 	return err
 }
 
+func (i *int8Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case int8:
+		*i = int8Value(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *int8Value) Type() string {
 	return "int8"
 }

--- a/int_slice.go
+++ b/int_slice.go
@@ -39,6 +39,16 @@ func (s *intSliceValue) Set(val string) error {
 	return nil
 }
 
+func (s *intSliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []int:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (s *intSliceValue) Type() string {
 	return "intSlice"
 }

--- a/ip.go
+++ b/ip.go
@@ -24,6 +24,18 @@ func (i *ipValue) Set(s string) error {
 	return nil
 }
 
+func (i *ipValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case net.IP:
+		*i = ipValue(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *ipValue) Type() string {
 	return "ip"
 }

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -54,6 +54,18 @@ func (s *ipSliceValue) Set(val string) error {
 	return nil
 }
 
+func (s *ipSliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []net.IP:
+		*s.value = tv
+	case string:
+		return s.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 // Type returns a string that uniquely represents this flag's type.
 func (s *ipSliceValue) Type() string {
 	return "ipSlice"

--- a/ipmask.go
+++ b/ipmask.go
@@ -24,6 +24,18 @@ func (i *ipMaskValue) Set(s string) error {
 	return nil
 }
 
+func (i *ipMaskValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case net.IPMask:
+		*i = ipMaskValue(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *ipMaskValue) Type() string {
 	return "ipMask"
 }

--- a/ipnet.go
+++ b/ipnet.go
@@ -23,6 +23,18 @@ func (ipnet *ipNetValue) Set(value string) error {
 	return nil
 }
 
+func (ipnet *ipNetValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case net.IPNet:
+		*ipnet = ipNetValue(tv)
+	case string:
+		return ipnet.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (*ipNetValue) Type() string {
 	return "ipNet"
 }

--- a/string.go
+++ b/string.go
@@ -1,5 +1,7 @@
 package pflag
 
+import "fmt"
+
 // -- string Value
 type stringValue string
 
@@ -12,6 +14,14 @@ func (s *stringValue) Set(val string) error {
 	*s = stringValue(val)
 	return nil
 }
+
+func (s *stringValue) Setv(v interface{}) error { // handled specially, since target is a string
+	if tv, ok := v.(string); ok {
+		return s.Set(tv)
+	}
+	return s.Set(fmt.Sprint(v))
+}
+
 func (s *stringValue) Type() string {
 	return "string"
 }

--- a/string_array.go
+++ b/string_array.go
@@ -23,6 +23,16 @@ func (s *stringArrayValue) Set(val string) error {
 	return nil
 }
 
+func (s *stringArrayValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []string:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (s *stringArrayValue) Append(val string) error {
 	*s.value = append(*s.value, val)
 	return nil

--- a/string_slice.go
+++ b/string_slice.go
@@ -53,6 +53,16 @@ func (s *stringSliceValue) Set(val string) error {
 	return nil
 }
 
+func (s *stringSliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []string:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (s *stringSliceValue) Type() string {
 	return "stringSlice"
 }

--- a/uint.go
+++ b/uint.go
@@ -16,6 +16,44 @@ func (i *uintValue) Set(s string) error {
 	return err
 }
 
+func (i *uintValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case uint:
+		*i = uintValue(tv)
+	case uint32:
+		*i = uintValue(tv)
+	case uint16:
+		*i = uintValue(tv)
+	case uint8:
+		*i = uintValue(tv)
+	case int:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uintValue(tv)
+	case int32:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uintValue(tv)
+	case int16:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uintValue(tv)
+	case int8:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uintValue(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *uintValue) Type() string {
 	return "uint"
 }

--- a/uint16.go
+++ b/uint16.go
@@ -16,6 +16,30 @@ func (i *uint16Value) Set(s string) error {
 	return err
 }
 
+func (i *uint16Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case uint16:
+		*i = uint16Value(tv)
+	case uint8:
+		*i = uint16Value(tv)
+	case int16:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint16Value(tv)
+	case int8:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint16Value(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *uint16Value) Type() string {
 	return "uint16"
 }

--- a/uint32.go
+++ b/uint32.go
@@ -16,6 +16,44 @@ func (i *uint32Value) Set(s string) error {
 	return err
 }
 
+func (i *uint32Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case uint:
+		*i = uint32Value(tv)
+	case uint32:
+		*i = uint32Value(tv)
+	case uint16:
+		*i = uint32Value(tv)
+	case uint8:
+		*i = uint32Value(tv)
+	case int:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint32Value(tv)
+	case int32:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint32Value(tv)
+	case int16:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint32Value(tv)
+	case int8:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint32Value(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *uint32Value) Type() string {
 	return "uint32"
 }

--- a/uint64.go
+++ b/uint64.go
@@ -16,6 +16,51 @@ func (i *uint64Value) Set(s string) error {
 	return err
 }
 
+func (i *uint64Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case uint:
+		*i = uint64Value(tv)
+	case uint64:
+		*i = uint64Value(tv)
+	case uint32:
+		*i = uint64Value(tv)
+	case uint16:
+		*i = uint64Value(tv)
+	case uint8:
+		*i = uint64Value(tv)
+	case int:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint64Value(tv)
+	case int64:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint64Value(tv)
+	case int32:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint64Value(tv)
+	case int16:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint64Value(tv)
+	case int8:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint64Value(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *uint64Value) Type() string {
 	return "uint64"
 }

--- a/uint8.go
+++ b/uint8.go
@@ -16,6 +16,23 @@ func (i *uint8Value) Set(s string) error {
 	return err
 }
 
+func (i *uint8Value) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case uint8:
+		*i = uint8Value(tv)
+	case int8:
+		if tv < 0 {
+			return ErrSetv
+		}
+		*i = uint8Value(tv)
+	case string:
+		return i.Set(tv)
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (i *uint8Value) Type() string {
 	return "uint8"
 }

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -38,6 +38,16 @@ func (s *uintSliceValue) Set(val string) error {
 	return nil
 }
 
+func (s *uintSliceValue) Setv(v interface{}) error {
+	switch tv := v.(type) {
+	case []uint:
+		*s.value = tv
+	default:
+		return ErrSetv
+	}
+	return nil
+}
+
 func (s *uintSliceValue) Type() string {
 	return "uintSlice"
 }


### PR DESCRIPTION
See commit message for details.
This functionality is primarily useful for users of pflag as an API, as it allows to Visit arbitrary flags and give them a typed value without needing the various `*Value` types exposed (while also integrating with user-defined Value implementations).
In the future, it may be feasible to expand the given type uses of Setv().

Notes:
1. uint32 is not convertible to an in32, because max(uint32) > max(int32)
2. (u)int32 is not convertible to a float32, because of floating errors.
3. int to uint conversions check against ints < 0.
4. any value whose Set() calls append() does not pass through string types to Set()