### PR TITLE
Custom flag's usage string shouldn't change its "defaults" section after parsing

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -544,7 +544,7 @@ func (f *Flag) defaultIsZeroValue() bool {
 	case *intSliceValue, *stringSliceValue, *stringArrayValue:
 		return f.DefValue == "[]"
 	default:
-		switch f.Value.String() {
+		switch f.DefValue {
 		case "false":
 			return true
 		case "<nil>":

--- a/flag_test.go
+++ b/flag_test.go
@@ -1262,3 +1262,39 @@ func TestVisitFlagOrder(t *testing.T) {
 		i++
 	})
 }
+
+// TestCustomFlagValue verifies that custom flag usage string doesn't change its "default" section after parsing
+func TestCustomFlagDefValue(t *testing.T) {
+	fs := NewFlagSet("TestCustomFlagDefValue", ContinueOnError)
+	var buf bytes.Buffer
+	fs.SetOutput(&buf)
+
+	var cv customValue
+	fs.VarP(&cv, "customP", "", "a VarP with no default")
+
+	fs.PrintDefaults()
+	beforeParse := buf.String()
+	buf.Reset()
+
+	args := []string{
+		"--customP=10",
+	}
+
+	if err := fs.Parse(args); err != nil {
+		t.Error("expected no error, got ", err)
+	}
+
+	val := fs.Lookup("customP").Value.String()
+	if val != "10" {
+		t.Errorf("expected customP to be set to the new value, got %s\n", val)
+	}
+
+	fs.PrintDefaults()
+	afterParse := buf.String()
+
+	if beforeParse != afterParse {
+		fmt.Println("\n" + beforeParse)
+		fmt.Println("\n" + afterParse)
+		t.Errorf("got %q want %q\n", afterParse, beforeParse)
+	}
+}


### PR DESCRIPTION
Right now the "defaults" section of the usage line of a custom flag is generated based on the value of "f.Value.String()" which can change after parsing. So the "usage" info returned by the following two types pf invocation can be different:

(--customFlag has no default)
./program --help
./program --customFlag=10 --help
