### PR TITLE
Use two dashes to describe unknown flags in errors

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -457,7 +457,11 @@ func (f *FlagSet) Set(name, value string) error {
 	normalName := f.normalizeFlagName(name)
 	flag, ok := f.formal[normalName]
 	if !ok {
-		return fmt.Errorf("no such flag -%v", name)
+		dash := "--"
+		if len(name) == 1 {
+			dash = "-"
+		}
+		return fmt.Errorf("no such flag %v%v", dash, name)
 	}
 
 	err := flag.Value.Set(value)
@@ -494,7 +498,11 @@ func (f *FlagSet) SetAnnotation(name, key string, values []string) error {
 	normalName := f.normalizeFlagName(name)
 	flag, ok := f.formal[normalName]
 	if !ok {
-		return fmt.Errorf("no such flag -%v", name)
+		dash := "--"
+		if len(name) == 1 {
+			dash = "-"
+		}
+		return fmt.Errorf("no such flag %v%v", dash, name)
 	}
 	if flag.Annotations == nil {
 		flag.Annotations = map[string][]string{}


### PR DESCRIPTION
In two unknown flag errors, a single dash is used to describe the flag. This commit fixes that to use two dashes if the flag's len(name) > 1, as would be standard for a long flag name. 