### PR TITLE
DOCO: the docs claim a `default value` parameter

### DIFF
--- a/count.go
+++ b/count.go
@@ -44,7 +44,7 @@ func (f *FlagSet) GetCount(name string) (int, error) {
 	return val.(int), nil
 }
 
-// CountVar defines a count flag with specified name, default value, and usage string.
+// CountVar defines a count flag with specified name, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 // A count flag will add 1 to its value every time it is found on the command line
 func (f *FlagSet) CountVar(p *int, name string, usage string) {
@@ -67,7 +67,7 @@ func CountVarP(p *int, name, shorthand string, usage string) {
 	CommandLine.CountVarP(p, name, shorthand, usage)
 }
 
-// Count defines a count flag with specified name, default value, and usage string.
+// Count defines a count flag with specified name, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 // A count flag will add 1 to its value every time it is found on the command line
 func (f *FlagSet) Count(name string, usage string) *int {
@@ -83,7 +83,7 @@ func (f *FlagSet) CountP(name, shorthand string, usage string) *int {
 	return p
 }
 
-// Count defines a count flag with specified name, default value, and usage string.
+// Count defines a count flag with specified name, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 // A count flag will add 1 to its value evey time it is found on the command line
 func Count(name string, usage string) *int {


### PR DESCRIPTION
The docs mention a `default value` parameter, but there is none.