### PR TITLE
Add support for specifying only a shortflag

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -56,6 +56,12 @@ func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage st
 	flag.NoOptDefVal = "true"
 }
 
+// BoolVarS is like BoolVar, but accepts a shorthand letter to be used after a single dash, alone.
+func (f *FlagSet) BoolVarS(p *bool, name string, shorthand string, value bool, usage string) {
+	flag := f.VarSF(newBoolValue(value, p), name, shorthand, usage)
+	flag.NoOptDefVal = "true"
+}
+
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
 func BoolVar(p *bool, name string, value bool, usage string) {
@@ -65,6 +71,12 @@ func BoolVar(p *bool, name string, value bool, usage string) {
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
 	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage)
+	flag.NoOptDefVal = "true"
+}
+
+// BoolVarS is like BoolVar, but accepts a shorthand letter to be used after a single dash, alone.
+func BoolVarS(p *bool, name string, shorthand string, value bool, usage string) {
+	flag := CommandLine.VarSF(newBoolValue(value, p), name, shorthand, usage)
 	flag.NoOptDefVal = "true"
 }
 
@@ -81,6 +93,13 @@ func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string) *bool 
 	return p
 }
 
+// BoolS is like Bool, but accepts a shorthand letter to be used after a single dash, alone.
+func (f *FlagSet) BoolS(name string, shorthand string, value bool, usage string) *bool {
+	p := new(bool)
+	f.BoolVarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
 func Bool(name string, value bool, usage string) *bool {
@@ -90,5 +109,11 @@ func Bool(name string, value bool, usage string) *bool {
 // BoolP is like Bool, but accepts a shorthand letter that can be used after a single dash.
 func BoolP(name, shorthand string, value bool, usage string) *bool {
 	b := CommandLine.BoolP(name, shorthand, value, usage)
+	return b
+}
+
+// BoolS is like Bool, but accepts a shorthand letter to be used after a single dash, alone.
+func BoolS(name string, shorthand string, value bool, usage string) *bool {
+	b := CommandLine.BoolS(name, shorthand, value, usage)
 	return b
 }

--- a/bool_slice.go
+++ b/bool_slice.go
@@ -147,15 +147,25 @@ func (f *FlagSet) BoolSliceVarP(p *[]bool, name, shorthand string, value []bool,
 	f.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
 }
 
+// BoolSliceVarS is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) BoolSliceVarS(p *[]bool, name string, shorthand string, value []bool, usage string) {
+	f.VarS(newBoolSliceValue(value, p), name, shorthand, usage)
+}
+
 // BoolSliceVar defines a []bool flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
 func BoolSliceVar(p *[]bool, name string, value []bool, usage string) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, "", usage)
+	CommandLine.BoolSliceVarP(p, name, "", value, usage)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
+	CommandLine.BoolSliceVarP(p, name, shorthand, value, usage)
+}
+
+// BoolSliceVarS is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func BoolSliceVarS(p *[]bool, name string, shorthand string, value []bool, usage string) {
+	CommandLine.BoolSliceVarS(p, name, shorthand, value, usage)
 }
 
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.
@@ -173,6 +183,13 @@ func (f *FlagSet) BoolSliceP(name, shorthand string, value []bool, usage string)
 	return &p
 }
 
+// BoolSliceS is like BoolSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) BoolSliceS(name string, shorthand string, value []bool, usage string) *[]bool {
+	p := []bool{}
+	f.BoolSliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.
 // The return value is the address of a []bool variable that stores the value of the flag.
 func BoolSlice(name string, value []bool, usage string) *[]bool {
@@ -182,4 +199,9 @@ func BoolSlice(name string, value []bool, usage string) *[]bool {
 // BoolSliceP is like BoolSlice, but accepts a shorthand letter that can be used after a single dash.
 func BoolSliceP(name, shorthand string, value []bool, usage string) *[]bool {
 	return CommandLine.BoolSliceP(name, shorthand, value, usage)
+}
+
+// BoolSliceS is like BoolSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func BoolSliceS(name string, shorthand string, value []bool, usage string) *[]bool {
+	return CommandLine.BoolSliceS(name, shorthand, value, usage)
 }

--- a/bool_test.go
+++ b/bool_test.go
@@ -162,3 +162,18 @@ func TestInvalidValue(t *testing.T) {
 		t.Fatal("expected an error but did not get any, tristate has value", tristate)
 	}
 }
+
+func TestBoolP(t *testing.T) {
+	b := BoolP("bool", "b", false, "bool value in CommandLine")
+	c := BoolP("c", "c", false, "other bool value")
+	args := []string{"--bool"}
+	if err := CommandLine.Parse(args); err != nil {
+		t.Error("expected no error, got ", err)
+	}
+	if *b != true {
+		t.Errorf("expected b=true got b=%v", *b)
+	}
+	if *c != false {
+		t.Errorf("expect c=false got c=%v", *c)
+	}
+}

--- a/bool_test.go
+++ b/bool_test.go
@@ -162,18 +162,3 @@ func TestInvalidValue(t *testing.T) {
 		t.Fatal("expected an error but did not get any, tristate has value", tristate)
 	}
 }
-
-func TestBoolP(t *testing.T) {
-	b := BoolP("bool", "b", false, "bool value in CommandLine")
-	c := BoolP("c", "c", false, "other bool value")
-	args := []string{"--bool"}
-	if err := CommandLine.Parse(args); err != nil {
-		t.Error("expected no error, got ", err)
-	}
-	if *b != true {
-		t.Errorf("expected b=true got b=%v", *b)
-	}
-	if *c != false {
-		t.Errorf("expect c=false got c=%v", *c)
-	}
-}

--- a/bytes.go
+++ b/bytes.go
@@ -171,6 +171,11 @@ func (f *FlagSet) BytesBase64VarP(p *[]byte, name, shorthand string, value []byt
 	f.VarP(newBytesBase64Value(value, p), name, shorthand, usage)
 }
 
+// BytesBase64VarS is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) BytesBase64VarS(p *[]byte, name, shorthand string, value []byte, usage string) {
+	f.VarS(newBytesBase64Value(value, p), name, shorthand, usage)
+}
+
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
 func BytesBase64Var(p *[]byte, name string, value []byte, usage string) {
@@ -180,6 +185,11 @@ func BytesBase64Var(p *[]byte, name string, value []byte, usage string) {
 // BytesBase64VarP is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash.
 func BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string) {
 	CommandLine.VarP(newBytesBase64Value(value, p), name, shorthand, usage)
+}
+
+// BytesBase64VarS is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func BytesBase64VarS(p *[]byte, name, shorthand string, value []byte, usage string) {
+	CommandLine.VarS(newBytesBase64Value(value, p), name, shorthand, usage)
 }
 
 // BytesBase64 defines an []byte flag with specified name, default value, and usage string.
@@ -197,6 +207,13 @@ func (f *FlagSet) BytesBase64P(name, shorthand string, value []byte, usage strin
 	return p
 }
 
+// BytesBase64S is like BytesBase64, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) BytesBase64S(name, shorthand string, value []byte, usage string) *[]byte {
+	p := new([]byte)
+	f.BytesBase64VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // BytesBase64 defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
 func BytesBase64(name string, value []byte, usage string) *[]byte {
@@ -206,4 +223,9 @@ func BytesBase64(name string, value []byte, usage string) *[]byte {
 // BytesBase64P is like BytesBase64, but accepts a shorthand letter that can be used after a single dash.
 func BytesBase64P(name, shorthand string, value []byte, usage string) *[]byte {
 	return CommandLine.BytesBase64P(name, shorthand, value, usage)
+}
+
+// BytesBase64S is like BytesBase64, but accepts a shorthand letter that can be used after a single dash, alone.
+func BytesBase64S(name, shorthand string, value []byte, usage string) *[]byte {
+	return CommandLine.BytesBase64S(name, shorthand, value, usage)
 }

--- a/count.go
+++ b/count.go
@@ -57,6 +57,12 @@ func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string) {
 	flag.NoOptDefVal = "+1"
 }
 
+// CountVarS is like CountVar only take a shorthand for the flag name, alone.
+func (f *FlagSet) CountVarS(p *int, name, shorthand string, usage string) {
+	flag := f.VarSF(newCountValue(0, p), name, shorthand, usage)
+	flag.NoOptDefVal = "+1"
+}
+
 // CountVar like CountVar only the flag is placed on the CommandLine instead of a given flag set
 func CountVar(p *int, name string, usage string) {
 	CommandLine.CountVar(p, name, usage)
@@ -65,6 +71,11 @@ func CountVar(p *int, name string, usage string) {
 // CountVarP is like CountVar only take a shorthand for the flag name.
 func CountVarP(p *int, name, shorthand string, usage string) {
 	CommandLine.CountVarP(p, name, shorthand, usage)
+}
+
+// CountVarS is like CountVar only take a shorthand for the flag name, alone.
+func CountVarS(p *int, name, shorthand string, usage string) {
+	CommandLine.CountVarS(p, name, shorthand, usage)
 }
 
 // Count defines a count flag with specified name, default value, and usage string.
@@ -83,6 +94,13 @@ func (f *FlagSet) CountP(name, shorthand string, usage string) *int {
 	return p
 }
 
+// CountS is like Count only takes a shorthand for the flag name, alone.
+func (f *FlagSet) CountS(name, shorthand string, usage string) *int {
+	p := new(int)
+	f.CountVarS(p, name, shorthand, usage)
+	return p
+}
+
 // Count defines a count flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 // A count flag will add 1 to its value evey time it is found on the command line
@@ -93,4 +111,9 @@ func Count(name string, usage string) *int {
 // CountP is like Count only takes a shorthand for the flag name.
 func CountP(name, shorthand string, usage string) *int {
 	return CommandLine.CountP(name, shorthand, usage)
+}
+
+// CountS is like Count only takes a shorthand for the flag name, alone.
+func CountS(name, shorthand string, usage string) *int {
+	return CommandLine.CountS(name, shorthand, usage)
 }

--- a/duration.go
+++ b/duration.go
@@ -48,6 +48,11 @@ func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value t
 	f.VarP(newDurationValue(value, p), name, shorthand, usage)
 }
 
+// DurationVarS is like DurationVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) DurationVarS(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
+	f.VarS(newDurationValue(value, p), name, shorthand, usage)
+}
+
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
 func DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
@@ -57,6 +62,11 @@ func DurationVar(p *time.Duration, name string, value time.Duration, usage strin
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
 func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
 	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage)
+}
+
+// DurationVarS is like DurationVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func DurationVarS(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
+	CommandLine.VarS(newDurationValue(value, p), name, shorthand, usage)
 }
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
@@ -74,6 +84,13 @@ func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage s
 	return p
 }
 
+// DurationS is like Duration, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) DurationS(name, shorthand string, value time.Duration, usage string) *time.Duration {
+	p := new(time.Duration)
+	f.DurationVarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a time.Duration variable that stores the value of the flag.
 func Duration(name string, value time.Duration, usage string) *time.Duration {
@@ -83,4 +100,9 @@ func Duration(name string, value time.Duration, usage string) *time.Duration {
 // DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
 func DurationP(name, shorthand string, value time.Duration, usage string) *time.Duration {
 	return CommandLine.DurationP(name, shorthand, value, usage)
+}
+
+// DurationS is like Duration, but accepts a shorthand letter that can be used after a single dash, alone.
+func DurationS(name, shorthand string, value time.Duration, usage string) *time.Duration {
+	return CommandLine.DurationS(name, shorthand, value, usage)
 }

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -128,6 +128,11 @@ func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, 
 	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
 }
 
+// DurationSliceVarS is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) DurationSliceVarS(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
+	f.VarS(newDurationSliceValue(value, p), name, shorthand, usage)
+}
+
 // DurationSliceVar defines a duration[] flag with specified name, default value, and usage string.
 // The argument p points to a duration[] variable in which to store the value of the flag.
 func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
@@ -137,6 +142,11 @@ func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, us
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
 	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+}
+
+// DurationSliceVarS is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func DurationSliceVarS(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
+	CommandLine.VarS(newDurationSliceValue(value, p), name, shorthand, usage)
 }
 
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
@@ -154,6 +164,13 @@ func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, 
 	return &p
 }
 
+// DurationSliceS is like DurationSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) DurationSliceS(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
+	p := []time.Duration{}
+	f.DurationSliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a []time.Duration variable that stores the value of the flag.
 func DurationSlice(name string, value []time.Duration, usage string) *[]time.Duration {
@@ -163,4 +180,9 @@ func DurationSlice(name string, value []time.Duration, usage string) *[]time.Dur
 // DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
 func DurationSliceP(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
 	return CommandLine.DurationSliceP(name, shorthand, value, usage)
+}
+
+// DurationSliceS is like DurationSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func DurationSliceS(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
+	return CommandLine.DurationSliceS(name, shorthand, value, usage)
 }

--- a/float32.go
+++ b/float32.go
@@ -50,6 +50,11 @@ func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32,
 	f.VarP(newFloat32Value(value, p), name, shorthand, usage)
 }
 
+// Float32VarS is like Float32Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Float32VarS(p *float32, name, shorthand string, value float32, usage string) {
+	f.VarS(newFloat32Value(value, p), name, shorthand, usage)
+}
+
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
 func Float32Var(p *float32, name string, value float32, usage string) {
@@ -59,6 +64,11 @@ func Float32Var(p *float32, name string, value float32, usage string) {
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
 func Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
 	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage)
+}
+
+// Float32VarS is like Float32Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Float32VarS(p *float32, name, shorthand string, value float32, usage string) {
+	CommandLine.VarS(newFloat32Value(value, p), name, shorthand, usage)
 }
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.
@@ -76,6 +86,13 @@ func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string) 
 	return p
 }
 
+// Float32S is like Float32, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Float32S(name, shorthand string, value float32, usage string) *float32 {
+	p := new(float32)
+	f.Float32VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Float32 defines a float32 flag with specified name, default value, and usage string.
 // The return value is the address of a float32 variable that stores the value of the flag.
 func Float32(name string, value float32, usage string) *float32 {
@@ -85,4 +102,9 @@ func Float32(name string, value float32, usage string) *float32 {
 // Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
 func Float32P(name, shorthand string, value float32, usage string) *float32 {
 	return CommandLine.Float32P(name, shorthand, value, usage)
+}
+
+// Float32S is like Float32, but accepts a shorthand letter that can be used after a single dash, alone.
+func Float32S(name, shorthand string, value float32, usage string) *float32 {
+	return CommandLine.Float32S(name, shorthand, value, usage)
 }

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -136,6 +136,11 @@ func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value [
 	f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
 }
 
+// Float32SliceVarS is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Float32SliceVarS(p *[]float32, name, shorthand string, value []float32, usage string) {
+	f.VarS(newFloat32SliceValue(value, p), name, shorthand, usage)
+}
+
 // Float32SliceVar defines a float32[] flag with specified name, default value, and usage string.
 // The argument p points to a float32[] variable in which to store the value of the flag.
 func Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
@@ -145,6 +150,11 @@ func Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string) {
 	CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
+}
+
+// Float32SliceVarS is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func Float32SliceVarS(p *[]float32, name, shorthand string, value []float32, usage string) {
+	CommandLine.VarS(newFloat32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.
@@ -162,6 +172,13 @@ func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage s
 	return &p
 }
 
+// Float32SliceS is like Float32Slice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Float32SliceS(name, shorthand string, value []float32, usage string) *[]float32 {
+	p := []float32{}
+	f.Float32SliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.
 // The return value is the address of a []float32 variable that stores the value of the flag.
 func Float32Slice(name string, value []float32, usage string) *[]float32 {
@@ -171,4 +188,9 @@ func Float32Slice(name string, value []float32, usage string) *[]float32 {
 // Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
 func Float32SliceP(name, shorthand string, value []float32, usage string) *[]float32 {
 	return CommandLine.Float32SliceP(name, shorthand, value, usage)
+}
+
+// Float32SliceS is like Float32Slice, but accepts a shorthand letter that can be used after a single dash, alone.
+func Float32SliceS(name, shorthand string, value []float32, usage string) *[]float32 {
+	return CommandLine.Float32SliceS(name, shorthand, value, usage)
 }

--- a/float64.go
+++ b/float64.go
@@ -46,6 +46,11 @@ func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64,
 	f.VarP(newFloat64Value(value, p), name, shorthand, usage)
 }
 
+// Float64VarS is like Float64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Float64VarS(p *float64, name, shorthand string, value float64, usage string) {
+	f.VarS(newFloat64Value(value, p), name, shorthand, usage)
+}
+
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
 func Float64Var(p *float64, name string, value float64, usage string) {
@@ -55,6 +60,11 @@ func Float64Var(p *float64, name string, value float64, usage string) {
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
 func Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
 	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage)
+}
+
+// Float64VarS is like Float64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Float64VarS(p *float64, name, shorthand string, value float64, usage string) {
+	CommandLine.VarS(newFloat64Value(value, p), name, shorthand, usage)
 }
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.
@@ -72,6 +82,13 @@ func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string) 
 	return p
 }
 
+// Float64S is like Float64, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Float64S(name, shorthand string, value float64, usage string) *float64 {
+	p := new(float64)
+	f.Float64VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Float64 defines a float64 flag with specified name, default value, and usage string.
 // The return value is the address of a float64 variable that stores the value of the flag.
 func Float64(name string, value float64, usage string) *float64 {
@@ -81,4 +98,9 @@ func Float64(name string, value float64, usage string) *float64 {
 // Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
 func Float64P(name, shorthand string, value float64, usage string) *float64 {
 	return CommandLine.Float64P(name, shorthand, value, usage)
+}
+
+// Float64S is like Float64, but accepts a shorthand letter that can be used after a single dash, alone.
+func Float64S(name, shorthand string, value float64, usage string) *float64 {
+	return CommandLine.Float64S(name, shorthand, value, usage)
 }

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -128,6 +128,11 @@ func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value [
 	f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
 }
 
+// Float64SliceVarS is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Float64SliceVarS(p *[]float64, name, shorthand string, value []float64, usage string) {
+	f.VarS(newFloat64SliceValue(value, p), name, shorthand, usage)
+}
+
 // Float64SliceVar defines a float64[] flag with specified name, default value, and usage string.
 // The argument p points to a float64[] variable in which to store the value of the flag.
 func Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
@@ -137,6 +142,11 @@ func Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string) {
 	CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
+}
+
+// Float64SliceVarS is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func Float64SliceVarS(p *[]float64, name, shorthand string, value []float64, usage string) {
+	CommandLine.VarS(newFloat64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.
@@ -154,6 +164,13 @@ func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage s
 	return &p
 }
 
+// Float64SliceS is like Float64Slice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Float64SliceS(name, shorthand string, value []float64, usage string) *[]float64 {
+	p := []float64{}
+	f.Float64SliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.
 // The return value is the address of a []float64 variable that stores the value of the flag.
 func Float64Slice(name string, value []float64, usage string) *[]float64 {
@@ -163,4 +180,9 @@ func Float64Slice(name string, value []float64, usage string) *[]float64 {
 // Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
 func Float64SliceP(name, shorthand string, value []float64, usage string) *[]float64 {
 	return CommandLine.Float64SliceP(name, shorthand, value, usage)
+}
+
+// Float64SliceS is like Float64Slice, but accepts a shorthand letter that can be used after a single dash, alone.
+func Float64SliceS(name, shorthand string, value []float64, usage string) *[]float64 {
+	return CommandLine.Float64SliceS(name, shorthand, value, usage)
 }

--- a/int.go
+++ b/int.go
@@ -46,6 +46,11 @@ func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage strin
 	f.VarP(newIntValue(value, p), name, shorthand, usage)
 }
 
+// IntVarS is like IntVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IntVarS(p *int, name, shorthand string, value int, usage string) {
+	f.VarS(newIntValue(value, p), name, shorthand, usage)
+}
+
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 func IntVar(p *int, name string, value int, usage string) {
@@ -55,6 +60,11 @@ func IntVar(p *int, name string, value int, usage string) {
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
 func IntVarP(p *int, name, shorthand string, value int, usage string) {
 	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage)
+}
+
+// IntVarS is like IntVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func IntVarS(p *int, name, shorthand string, value int, usage string) {
+	CommandLine.VarS(newIntValue(value, p), name, shorthand, usage)
 }
 
 // Int defines an int flag with specified name, default value, and usage string.
@@ -72,6 +82,13 @@ func (f *FlagSet) IntP(name, shorthand string, value int, usage string) *int {
 	return p
 }
 
+// IntS is like Int, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IntS(name, shorthand string, value int, usage string) *int {
+	p := new(int)
+	f.IntVarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Int defines an int flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 func Int(name string, value int, usage string) *int {
@@ -81,4 +98,9 @@ func Int(name string, value int, usage string) *int {
 // IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
 func IntP(name, shorthand string, value int, usage string) *int {
 	return CommandLine.IntP(name, shorthand, value, usage)
+}
+
+// IntS is like Int, but accepts a shorthand letter that can be used after a single dash, alone.
+func IntS(name, shorthand string, value int, usage string) *int {
+	return CommandLine.IntS(name, shorthand, value, usage)
 }

--- a/int16.go
+++ b/int16.go
@@ -50,6 +50,11 @@ func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage
 	f.VarP(newInt16Value(value, p), name, shorthand, usage)
 }
 
+// Int16VarS is like Int16Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int16VarS(p *int16, name, shorthand string, value int16, usage string) {
+	f.VarS(newInt16Value(value, p), name, shorthand, usage)
+}
+
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
 func Int16Var(p *int16, name string, value int16, usage string) {
@@ -59,6 +64,11 @@ func Int16Var(p *int16, name string, value int16, usage string) {
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
 func Int16VarP(p *int16, name, shorthand string, value int16, usage string) {
 	CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage)
+}
+
+// Int16VarS is like Int16Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int16VarS(p *int16, name, shorthand string, value int16, usage string) {
+	CommandLine.VarS(newInt16Value(value, p), name, shorthand, usage)
 }
 
 // Int16 defines an int16 flag with specified name, default value, and usage string.
@@ -76,6 +86,13 @@ func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string) *int
 	return p
 }
 
+// Int16S is like Int16, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int16S(name, shorthand string, value int16, usage string) *int16 {
+	p := new(int16)
+	f.Int16VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Int16 defines an int16 flag with specified name, default value, and usage string.
 // The return value is the address of an int16 variable that stores the value of the flag.
 func Int16(name string, value int16, usage string) *int16 {
@@ -85,4 +102,9 @@ func Int16(name string, value int16, usage string) *int16 {
 // Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
 func Int16P(name, shorthand string, value int16, usage string) *int16 {
 	return CommandLine.Int16P(name, shorthand, value, usage)
+}
+
+// Int16S is like Int16, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int16S(name, shorthand string, value int16, usage string) *int16 {
+	return CommandLine.Int16S(name, shorthand, value, usage)
 }

--- a/int32.go
+++ b/int32.go
@@ -50,6 +50,11 @@ func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage
 	f.VarP(newInt32Value(value, p), name, shorthand, usage)
 }
 
+// Int32VarS is like Int32Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int32VarS(p *int32, name, shorthand string, value int32, usage string) {
+	f.VarS(newInt32Value(value, p), name, shorthand, usage)
+}
+
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
 func Int32Var(p *int32, name string, value int32, usage string) {
@@ -59,6 +64,11 @@ func Int32Var(p *int32, name string, value int32, usage string) {
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
 func Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
 	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage)
+}
+
+// Int32VarS is like Int32Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int32VarS(p *int32, name, shorthand string, value int32, usage string) {
+	CommandLine.VarS(newInt32Value(value, p), name, shorthand, usage)
 }
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.
@@ -76,6 +86,13 @@ func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string) *int
 	return p
 }
 
+// Int32S is like Int32, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int32S(name, shorthand string, value int32, usage string) *int32 {
+	p := new(int32)
+	f.Int32VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Int32 defines an int32 flag with specified name, default value, and usage string.
 // The return value is the address of an int32 variable that stores the value of the flag.
 func Int32(name string, value int32, usage string) *int32 {
@@ -85,4 +102,9 @@ func Int32(name string, value int32, usage string) *int32 {
 // Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
 func Int32P(name, shorthand string, value int32, usage string) *int32 {
 	return CommandLine.Int32P(name, shorthand, value, usage)
+}
+
+// Int32S is like Int32, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int32S(name, shorthand string, value int32, usage string) *int32 {
+	return CommandLine.Int32S(name, shorthand, value, usage)
 }

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -136,6 +136,11 @@ func (f *FlagSet) Int32SliceVarP(p *[]int32, name, shorthand string, value []int
 	f.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
 }
 
+// Int32SliceVarS is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int32SliceVarS(p *[]int32, name, shorthand string, value []int32, usage string) {
+	f.VarS(newInt32SliceValue(value, p), name, shorthand, usage)
+}
+
 // Int32SliceVar defines a int32[] flag with specified name, default value, and usage string.
 // The argument p points to a int32[] variable in which to store the value of the flag.
 func Int32SliceVar(p *[]int32, name string, value []int32, usage string) {
@@ -145,6 +150,11 @@ func Int32SliceVar(p *[]int32, name string, value []int32, usage string) {
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string) {
 	CommandLine.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
+}
+
+// Int32SliceVarS is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int32SliceVarS(p *[]int32, name, shorthand string, value []int32, usage string) {
+	CommandLine.VarS(newInt32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.
@@ -162,6 +172,13 @@ func (f *FlagSet) Int32SliceP(name, shorthand string, value []int32, usage strin
 	return &p
 }
 
+// Int32SliceS is like Int32Slice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int32SliceS(name, shorthand string, value []int32, usage string) *[]int32 {
+	p := []int32{}
+	f.Int32SliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.
 // The return value is the address of a []int32 variable that stores the value of the flag.
 func Int32Slice(name string, value []int32, usage string) *[]int32 {
@@ -171,4 +188,9 @@ func Int32Slice(name string, value []int32, usage string) *[]int32 {
 // Int32SliceP is like Int32Slice, but accepts a shorthand letter that can be used after a single dash.
 func Int32SliceP(name, shorthand string, value []int32, usage string) *[]int32 {
 	return CommandLine.Int32SliceP(name, shorthand, value, usage)
+}
+
+// Int32SliceS is like Int32Slice, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int32SliceS(name, shorthand string, value []int32, usage string) *[]int32 {
+	return CommandLine.Int32SliceS(name, shorthand, value, usage)
 }

--- a/int64.go
+++ b/int64.go
@@ -46,6 +46,11 @@ func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage
 	f.VarP(newInt64Value(value, p), name, shorthand, usage)
 }
 
+// Int64VarS is like Int64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int64VarS(p *int64, name, shorthand string, value int64, usage string) {
+	f.VarS(newInt64Value(value, p), name, shorthand, usage)
+}
+
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
 func Int64Var(p *int64, name string, value int64, usage string) {
@@ -55,6 +60,11 @@ func Int64Var(p *int64, name string, value int64, usage string) {
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
 func Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
 	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage)
+}
+
+// Int64VarS is like Int64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int64VarS(p *int64, name, shorthand string, value int64, usage string) {
+	CommandLine.VarS(newInt64Value(value, p), name, shorthand, usage)
 }
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.
@@ -72,6 +82,13 @@ func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string) *int
 	return p
 }
 
+// Int64S is like Int64, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int64S(name, shorthand string, value int64, usage string) *int64 {
+	p := new(int64)
+	f.Int64VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Int64 defines an int64 flag with specified name, default value, and usage string.
 // The return value is the address of an int64 variable that stores the value of the flag.
 func Int64(name string, value int64, usage string) *int64 {
@@ -81,4 +98,9 @@ func Int64(name string, value int64, usage string) *int64 {
 // Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
 func Int64P(name, shorthand string, value int64, usage string) *int64 {
 	return CommandLine.Int64P(name, shorthand, value, usage)
+}
+
+// Int64S is like Int64, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int64S(name, shorthand string, value int64, usage string) *int64 {
+	return CommandLine.Int64S(name, shorthand, value, usage)
 }

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -128,6 +128,11 @@ func (f *FlagSet) Int64SliceVarP(p *[]int64, name, shorthand string, value []int
 	f.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
 }
 
+// Int64SliceVarS is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int64SliceVarS(p *[]int64, name, shorthand string, value []int64, usage string) {
+	f.VarS(newInt64SliceValue(value, p), name, shorthand, usage)
+}
+
 // Int64SliceVar defines a int64[] flag with specified name, default value, and usage string.
 // The argument p points to a int64[] variable in which to store the value of the flag.
 func Int64SliceVar(p *[]int64, name string, value []int64, usage string) {
@@ -137,6 +142,11 @@ func Int64SliceVar(p *[]int64, name string, value []int64, usage string) {
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string) {
 	CommandLine.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
+}
+
+// Int64SliceVarS is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int64SliceVarS(p *[]int64, name, shorthand string, value []int64, usage string) {
+	CommandLine.VarS(newInt64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.
@@ -154,6 +164,13 @@ func (f *FlagSet) Int64SliceP(name, shorthand string, value []int64, usage strin
 	return &p
 }
 
+// Int64SliceS is like Int64Slice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int64SliceS(name, shorthand string, value []int64, usage string) *[]int64 {
+	p := []int64{}
+	f.Int64SliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.
 // The return value is the address of a []int64 variable that stores the value of the flag.
 func Int64Slice(name string, value []int64, usage string) *[]int64 {
@@ -163,4 +180,9 @@ func Int64Slice(name string, value []int64, usage string) *[]int64 {
 // Int64SliceP is like Int64Slice, but accepts a shorthand letter that can be used after a single dash.
 func Int64SliceP(name, shorthand string, value []int64, usage string) *[]int64 {
 	return CommandLine.Int64SliceP(name, shorthand, value, usage)
+}
+
+// Int64SliceS is like Int64Slice, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int64SliceS(name, shorthand string, value []int64, usage string) *[]int64 {
+	return CommandLine.Int64SliceS(name, shorthand, value, usage)
 }

--- a/int8.go
+++ b/int8.go
@@ -50,6 +50,11 @@ func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage st
 	f.VarP(newInt8Value(value, p), name, shorthand, usage)
 }
 
+// Int8VarS is like Int8Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int8VarS(p *int8, name, shorthand string, value int8, usage string) {
+	f.VarS(newInt8Value(value, p), name, shorthand, usage)
+}
+
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
 func Int8Var(p *int8, name string, value int8, usage string) {
@@ -59,6 +64,11 @@ func Int8Var(p *int8, name string, value int8, usage string) {
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
 func Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
 	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage)
+}
+
+// Int8VarS is like Int8Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int8VarS(p *int8, name, shorthand string, value int8, usage string) {
+	CommandLine.VarS(newInt8Value(value, p), name, shorthand, usage)
 }
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.
@@ -76,6 +86,13 @@ func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string) *int8 
 	return p
 }
 
+// Int8S is like Int8, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Int8S(name, shorthand string, value int8, usage string) *int8 {
+	p := new(int8)
+	f.Int8VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Int8 defines an int8 flag with specified name, default value, and usage string.
 // The return value is the address of an int8 variable that stores the value of the flag.
 func Int8(name string, value int8, usage string) *int8 {
@@ -85,4 +102,9 @@ func Int8(name string, value int8, usage string) *int8 {
 // Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
 func Int8P(name, shorthand string, value int8, usage string) *int8 {
 	return CommandLine.Int8P(name, shorthand, value, usage)
+}
+
+// Int8S is like Int8, but accepts a shorthand letter that can be used after a single dash, alone.
+func Int8S(name, shorthand string, value int8, usage string) *int8 {
+	return CommandLine.Int8S(name, shorthand, value, usage)
 }

--- a/int_slice.go
+++ b/int_slice.go
@@ -120,6 +120,11 @@ func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, us
 	f.VarP(newIntSliceValue(value, p), name, shorthand, usage)
 }
 
+// IntSliceVarS is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IntSliceVarS(p *[]int, name, shorthand string, value []int, usage string) {
+	f.VarS(newIntSliceValue(value, p), name, shorthand, usage)
+}
+
 // IntSliceVar defines a int[] flag with specified name, default value, and usage string.
 // The argument p points to a int[] variable in which to store the value of the flag.
 func IntSliceVar(p *[]int, name string, value []int, usage string) {
@@ -129,6 +134,11 @@ func IntSliceVar(p *[]int, name string, value []int, usage string) {
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string) {
 	CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage)
+}
+
+// IntSliceVarS is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func IntSliceVarS(p *[]int, name, shorthand string, value []int, usage string) {
+	CommandLine.VarS(newIntSliceValue(value, p), name, shorthand, usage)
 }
 
 // IntSlice defines a []int flag with specified name, default value, and usage string.
@@ -146,6 +156,13 @@ func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string) *
 	return &p
 }
 
+// IntSliceS is like IntSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IntSliceS(name, shorthand string, value []int, usage string) *[]int {
+	p := []int{}
+	f.IntSliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // IntSlice defines a []int flag with specified name, default value, and usage string.
 // The return value is the address of a []int variable that stores the value of the flag.
 func IntSlice(name string, value []int, usage string) *[]int {
@@ -155,4 +172,9 @@ func IntSlice(name string, value []int, usage string) *[]int {
 // IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
 func IntSliceP(name, shorthand string, value []int, usage string) *[]int {
 	return CommandLine.IntSliceP(name, shorthand, value, usage)
+}
+
+// IntSliceS is like IntSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func IntSliceS(name, shorthand string, value []int, usage string) *[]int {
+	return CommandLine.IntSliceS(name, shorthand, value, usage)
 }

--- a/ip.go
+++ b/ip.go
@@ -56,6 +56,11 @@ func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage 
 	f.VarP(newIPValue(value, p), name, shorthand, usage)
 }
 
+// IPVarS is like IPVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IPVarS(p *net.IP, name, shorthand string, value net.IP, usage string) {
+	f.VarS(newIPValue(value, p), name, shorthand, usage)
+}
+
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
 func IPVar(p *net.IP, name string, value net.IP, usage string) {
@@ -65,6 +70,11 @@ func IPVar(p *net.IP, name string, value net.IP, usage string) {
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
 func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
 	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage)
+}
+
+// IPVarS is like IPVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func IPVarS(p *net.IP, name, shorthand string, value net.IP, usage string) {
+	CommandLine.VarS(newIPValue(value, p), name, shorthand, usage)
 }
 
 // IP defines an net.IP flag with specified name, default value, and usage string.
@@ -82,6 +92,13 @@ func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string) *net.I
 	return p
 }
 
+// IPS is like IP, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IPS(name, shorthand string, value net.IP, usage string) *net.IP {
+	p := new(net.IP)
+	f.IPVarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // IP defines an net.IP flag with specified name, default value, and usage string.
 // The return value is the address of an net.IP variable that stores the value of the flag.
 func IP(name string, value net.IP, usage string) *net.IP {
@@ -91,4 +108,9 @@ func IP(name string, value net.IP, usage string) *net.IP {
 // IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
 func IPP(name, shorthand string, value net.IP, usage string) *net.IP {
 	return CommandLine.IPP(name, shorthand, value, usage)
+}
+
+// IPS is like IP, but accepts a shorthand letter that can be used after a single dash, alone.
+func IPS(name, shorthand string, value net.IP, usage string) *net.IP {
+	return CommandLine.IPS(name, shorthand, value, usage)
 }

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -148,6 +148,11 @@ func (f *FlagSet) IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.I
 	f.VarP(newIPSliceValue(value, p), name, shorthand, usage)
 }
 
+// IPSliceVarS is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IPSliceVarS(p *[]net.IP, name, shorthand string, value []net.IP, usage string) {
+	f.VarS(newIPSliceValue(value, p), name, shorthand, usage)
+}
+
 // IPSliceVar defines a []net.IP flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
 func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string) {
@@ -157,6 +162,11 @@ func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string) {
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string) {
 	CommandLine.VarP(newIPSliceValue(value, p), name, shorthand, usage)
+}
+
+// IPSliceVarS is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func IPSliceVarS(p *[]net.IP, name, shorthand string, value []net.IP, usage string) {
+	CommandLine.VarS(newIPSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.
@@ -174,6 +184,13 @@ func (f *FlagSet) IPSliceP(name, shorthand string, value []net.IP, usage string)
 	return &p
 }
 
+// IPSliceS is like IPSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IPSliceS(name, shorthand string, value []net.IP, usage string) *[]net.IP {
+	p := []net.IP{}
+	f.IPSliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of the flag.
 func IPSlice(name string, value []net.IP, usage string) *[]net.IP {
@@ -183,4 +200,9 @@ func IPSlice(name string, value []net.IP, usage string) *[]net.IP {
 // IPSliceP is like IPSlice, but accepts a shorthand letter that can be used after a single dash.
 func IPSliceP(name, shorthand string, value []net.IP, usage string) *[]net.IP {
 	return CommandLine.IPSliceP(name, shorthand, value, usage)
+}
+
+// IPSliceS is like IPSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func IPSliceS(name, shorthand string, value []net.IP, usage string) *[]net.IP {
+	return CommandLine.IPSliceS(name, shorthand, value, usage)
 }

--- a/ipmask.go
+++ b/ipmask.go
@@ -84,6 +84,11 @@ func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IP
 	f.VarP(newIPMaskValue(value, p), name, shorthand, usage)
 }
 
+// IPMaskVarS is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IPMaskVarS(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
+	f.VarS(newIPMaskValue(value, p), name, shorthand, usage)
+}
+
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
 func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
@@ -93,6 +98,11 @@ func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
 func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
 	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+}
+
+// IPMaskVarS is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func IPMaskVarS(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
+	CommandLine.VarS(newIPMaskValue(value, p), name, shorthand, usage)
 }
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
@@ -110,6 +120,13 @@ func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string
 	return p
 }
 
+// IPMaskS is like IPMask, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IPMaskS(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
+	p := new(net.IPMask)
+	f.IPMaskVarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPMask variable that stores the value of the flag.
 func IPMask(name string, value net.IPMask, usage string) *net.IPMask {
@@ -119,4 +136,9 @@ func IPMask(name string, value net.IPMask, usage string) *net.IPMask {
 // IPMaskP is like IP, but accepts a shorthand letter that can be used after a single dash.
 func IPMaskP(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
 	return CommandLine.IPMaskP(name, shorthand, value, usage)
+}
+
+// IPMaskS is like IP, but accepts a shorthand letter that can be used after a single dash, alone.
+func IPMaskS(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
+	return CommandLine.IPMaskS(name, shorthand, value, usage)
 }

--- a/ipnet.go
+++ b/ipnet.go
@@ -60,6 +60,11 @@ func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNe
 	f.VarP(newIPNetValue(value, p), name, shorthand, usage)
 }
 
+// IPNetVarS is like IPNetVar, but accepts a shorthand letter that can be used after a single , alone, alone.
+func (f *FlagSet) IPNetVarS(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
+	f.VarS(newIPNetValue(value, p), name, shorthand, usage)
+}
+
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
 func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
@@ -69,6 +74,11 @@ func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
 func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
 	CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage)
+}
+
+// IPNetVarS is like IPNetVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func IPNetVarS(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
+	CommandLine.VarS(newIPNetValue(value, p), name, shorthand, usage)
 }
 
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.
@@ -86,6 +96,13 @@ func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string) 
 	return p
 }
 
+// IPNetS is like IPNet, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) IPNetS(name, shorthand string, value net.IPNet, usage string) *net.IPNet {
+	p := new(net.IPNet)
+	f.IPNetVarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPNet variable that stores the value of the flag.
 func IPNet(name string, value net.IPNet, usage string) *net.IPNet {
@@ -95,4 +112,9 @@ func IPNet(name string, value net.IPNet, usage string) *net.IPNet {
 // IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
 func IPNetP(name, shorthand string, value net.IPNet, usage string) *net.IPNet {
 	return CommandLine.IPNetP(name, shorthand, value, usage)
+}
+
+// IPNetS is like IPNet, but accepts a shorthand letter that can be used after a single dash, alone.
+func IPNetS(name, shorthand string, value net.IPNet, usage string) *net.IPNet {
+	return CommandLine.IPNetS(name, shorthand, value, usage)
 }

--- a/string.go
+++ b/string.go
@@ -42,6 +42,11 @@ func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, us
 	f.VarP(newStringValue(value, p), name, shorthand, usage)
 }
 
+// StringVarS is like StringVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringVarS(p *string, name, shorthand string, value string, usage string) {
+	f.VarS(newStringValue(value, p), name, shorthand, usage)
+}
+
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
 func StringVar(p *string, name string, value string, usage string) {
@@ -51,6 +56,11 @@ func StringVar(p *string, name string, value string, usage string) {
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
 func StringVarP(p *string, name, shorthand string, value string, usage string) {
 	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage)
+}
+
+// StringVarS is like StringVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringVarS(p *string, name, shorthand string, value string, usage string) {
+	CommandLine.VarS(newStringValue(value, p), name, shorthand, usage)
 }
 
 // String defines a string flag with specified name, default value, and usage string.
@@ -68,6 +78,13 @@ func (f *FlagSet) StringP(name, shorthand string, value string, usage string) *s
 	return p
 }
 
+// StringS is like String, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringS(name, shorthand string, value string, usage string) *string {
+	p := new(string)
+	f.StringVarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // String defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a string variable that stores the value of the flag.
 func String(name string, value string, usage string) *string {
@@ -77,4 +94,9 @@ func String(name string, value string, usage string) *string {
 // StringP is like String, but accepts a shorthand letter that can be used after a single dash.
 func StringP(name, shorthand string, value string, usage string) *string {
 	return CommandLine.StringP(name, shorthand, value, usage)
+}
+
+// StringS is like String, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringS(name, shorthand string, value string, usage string) *string {
+	return CommandLine.StringS(name, shorthand, value, usage)
 }

--- a/string_array.go
+++ b/string_array.go
@@ -88,6 +88,11 @@ func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []s
 	f.VarP(newStringArrayValue(value, p), name, shorthand, usage)
 }
 
+// StringArrayVarS is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringArrayVarS(p *[]string, name, shorthand string, value []string, usage string) {
+	f.VarS(newStringArrayValue(value, p), name, shorthand, usage)
+}
+
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
@@ -98,6 +103,11 @@ func StringArrayVar(p *[]string, name string, value []string, usage string) {
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
 func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string) {
 	CommandLine.VarP(newStringArrayValue(value, p), name, shorthand, usage)
+}
+
+// StringArrayVarS is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringArrayVarS(p *[]string, name, shorthand string, value []string, usage string) {
+	CommandLine.VarS(newStringArrayValue(value, p), name, shorthand, usage)
 }
 
 // StringArray defines a string flag with specified name, default value, and usage string.
@@ -116,6 +126,13 @@ func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage str
 	return &p
 }
 
+// StringArrayS is like StringArray, but accepts a shorthand letter that can be used after a single , alone, alone.
+func (f *FlagSet) StringArrayS(name, shorthand string, value []string, usage string) *[]string {
+	p := []string{}
+	f.StringArrayVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
@@ -126,4 +143,9 @@ func StringArray(name string, value []string, usage string) *[]string {
 // StringArrayP is like StringArray, but accepts a shorthand letter that can be used after a single dash.
 func StringArrayP(name, shorthand string, value []string, usage string) *[]string {
 	return CommandLine.StringArrayP(name, shorthand, value, usage)
+}
+
+// StringArrayS is like StringArray, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringArrayS(name, shorthand string, value []string, usage string) *[]string {
+	return CommandLine.StringArrayS(name, shorthand, value, usage)
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -110,6 +110,11 @@ func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []s
 	f.VarP(newStringSliceValue(value, p), name, shorthand, usage)
 }
 
+// StringSliceVarS is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringSliceVarS(p *[]string, name, shorthand string, value []string, usage string) {
+	f.VarS(newStringSliceValue(value, p), name, shorthand, usage)
+}
+
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
@@ -124,6 +129,11 @@ func StringSliceVar(p *[]string, name string, value []string, usage string) {
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
 	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+}
+
+// StringSliceVarS is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringSliceVarS(p *[]string, name, shorthand string, value []string, usage string) {
+	CommandLine.VarS(newStringSliceValue(value, p), name, shorthand, usage)
 }
 
 // StringSlice defines a string flag with specified name, default value, and usage string.
@@ -146,6 +156,13 @@ func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage str
 	return &p
 }
 
+// StringSliceS is like StringSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringSliceS(name, shorthand string, value []string, usage string) *[]string {
+	p := []string{}
+	f.StringSliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // StringSlice defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
@@ -160,4 +177,9 @@ func StringSlice(name string, value []string, usage string) *[]string {
 // StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
 func StringSliceP(name, shorthand string, value []string, usage string) *[]string {
 	return CommandLine.StringSliceP(name, shorthand, value, usage)
+}
+
+// StringSliceS is like StringSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringSliceS(name, shorthand string, value []string, usage string) *[]string {
+	return CommandLine.StringSliceS(name, shorthand, value, usage)
 }

--- a/string_to_int.go
+++ b/string_to_int.go
@@ -108,6 +108,11 @@ func (f *FlagSet) StringToIntVarP(p *map[string]int, name, shorthand string, val
 	f.VarP(newStringToIntValue(value, p), name, shorthand, usage)
 }
 
+// StringToIntVarS is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringToIntVarS(p *map[string]int, name, shorthand string, value map[string]int, usage string) {
+	f.VarS(newStringToIntValue(value, p), name, shorthand, usage)
+}
+
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
@@ -118,6 +123,11 @@ func StringToIntVar(p *map[string]int, name string, value map[string]int, usage 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
 func StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string) {
 	CommandLine.VarP(newStringToIntValue(value, p), name, shorthand, usage)
+}
+
+// StringToIntVarS is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringToIntVarS(p *map[string]int, name, shorthand string, value map[string]int, usage string) {
+	CommandLine.VarS(newStringToIntValue(value, p), name, shorthand, usage)
 }
 
 // StringToInt defines a string flag with specified name, default value, and usage string.
@@ -136,6 +146,13 @@ func (f *FlagSet) StringToIntP(name, shorthand string, value map[string]int, usa
 	return &p
 }
 
+// StringToIntS is like StringToInt, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringToIntS(name, shorthand string, value map[string]int, usage string) *map[string]int {
+	p := map[string]int{}
+	f.StringToIntVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // StringToInt defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
@@ -146,4 +163,9 @@ func StringToInt(name string, value map[string]int, usage string) *map[string]in
 // StringToIntP is like StringToInt, but accepts a shorthand letter that can be used after a single dash.
 func StringToIntP(name, shorthand string, value map[string]int, usage string) *map[string]int {
 	return CommandLine.StringToIntP(name, shorthand, value, usage)
+}
+
+// StringToIntS is like StringToInt, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringToIntS(name, shorthand string, value map[string]int, usage string) *map[string]int {
+	return CommandLine.StringToIntS(name, shorthand, value, usage)
 }

--- a/string_to_int64.go
+++ b/string_to_int64.go
@@ -108,6 +108,11 @@ func (f *FlagSet) StringToInt64VarP(p *map[string]int64, name, shorthand string,
 	f.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
 }
 
+// StringToInt64VarS is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringToInt64VarS(p *map[string]int64, name, shorthand string, value map[string]int64, usage string) {
+	f.VarS(newStringToInt64Value(value, p), name, shorthand, usage)
+}
+
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
@@ -118,6 +123,11 @@ func StringToInt64Var(p *map[string]int64, name string, value map[string]int64, 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
 func StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string) {
 	CommandLine.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
+}
+
+// StringToInt64VarS is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringToInt64VarS(p *map[string]int64, name, shorthand string, value map[string]int64, usage string) {
+	CommandLine.VarS(newStringToInt64Value(value, p), name, shorthand, usage)
 }
 
 // StringToInt64 defines a string flag with specified name, default value, and usage string.
@@ -136,6 +146,13 @@ func (f *FlagSet) StringToInt64P(name, shorthand string, value map[string]int64,
 	return &p
 }
 
+// StringToInt64S is like StringToInt64, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringToInt64S(name, shorthand string, value map[string]int64, usage string) *map[string]int64 {
+	p := map[string]int64{}
+	f.StringToInt64VarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // StringToInt64 defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int64 variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
@@ -146,4 +163,9 @@ func StringToInt64(name string, value map[string]int64, usage string) *map[strin
 // StringToInt64P is like StringToInt64, but accepts a shorthand letter that can be used after a single dash.
 func StringToInt64P(name, shorthand string, value map[string]int64, usage string) *map[string]int64 {
 	return CommandLine.StringToInt64P(name, shorthand, value, usage)
+}
+
+// StringToInt64S is like StringToInt64, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringToInt64S(name, shorthand string, value map[string]int64, usage string) *map[string]int64 {
+	return CommandLine.StringToInt64S(name, shorthand, value, usage)
 }

--- a/string_to_string.go
+++ b/string_to_string.go
@@ -119,6 +119,11 @@ func (f *FlagSet) StringToStringVarP(p *map[string]string, name, shorthand strin
 	f.VarP(newStringToStringValue(value, p), name, shorthand, usage)
 }
 
+// StringToStringVarS is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringToStringVarS(p *map[string]string, name, shorthand string, value map[string]string, usage string) {
+	f.VarS(newStringToStringValue(value, p), name, shorthand, usage)
+}
+
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
@@ -129,6 +134,11 @@ func StringToStringVar(p *map[string]string, name string, value map[string]strin
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
 func StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string) {
 	CommandLine.VarP(newStringToStringValue(value, p), name, shorthand, usage)
+}
+
+// StringToStringVarS is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringToStringVarS(p *map[string]string, name, shorthand string, value map[string]string, usage string) {
+	CommandLine.VarS(newStringToStringValue(value, p), name, shorthand, usage)
 }
 
 // StringToString defines a string flag with specified name, default value, and usage string.
@@ -147,6 +157,13 @@ func (f *FlagSet) StringToStringP(name, shorthand string, value map[string]strin
 	return &p
 }
 
+// StringToStringS is like StringToString, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) StringToStringS(name, shorthand string, value map[string]string, usage string) *map[string]string {
+	p := map[string]string{}
+	f.StringToStringVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // StringToString defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
@@ -157,4 +174,9 @@ func StringToString(name string, value map[string]string, usage string) *map[str
 // StringToStringP is like StringToString, but accepts a shorthand letter that can be used after a single dash.
 func StringToStringP(name, shorthand string, value map[string]string, usage string) *map[string]string {
 	return CommandLine.StringToStringP(name, shorthand, value, usage)
+}
+
+// StringToStringS is like StringToString, but accepts a shorthand letter that can be used after a single dash, alone.
+func StringToStringS(name, shorthand string, value map[string]string, usage string) *map[string]string {
+	return CommandLine.StringToStringS(name, shorthand, value, usage)
 }

--- a/uint.go
+++ b/uint.go
@@ -50,6 +50,11 @@ func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage st
 	f.VarP(newUintValue(value, p), name, shorthand, usage)
 }
 
+// UintVarS is like UintVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) UintVarS(p *uint, name, shorthand string, value uint, usage string) {
+	f.VarS(newUintValue(value, p), name, shorthand, usage)
+}
+
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
 func UintVar(p *uint, name string, value uint, usage string) {
@@ -59,6 +64,11 @@ func UintVar(p *uint, name string, value uint, usage string) {
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
 func UintVarP(p *uint, name, shorthand string, value uint, usage string) {
 	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage)
+}
+
+// UintVarS is like UintVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func UintVarS(p *uint, name, shorthand string, value uint, usage string) {
+	CommandLine.VarS(newUintValue(value, p), name, shorthand, usage)
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.
@@ -76,6 +86,13 @@ func (f *FlagSet) UintP(name, shorthand string, value uint, usage string) *uint 
 	return p
 }
 
+// UintS is like Uint, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) UintS(name, shorthand string, value uint, usage string) *uint {
+	p := new(uint)
+	f.UintVarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Uint defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
 func Uint(name string, value uint, usage string) *uint {
@@ -85,4 +102,9 @@ func Uint(name string, value uint, usage string) *uint {
 // UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
 func UintP(name, shorthand string, value uint, usage string) *uint {
 	return CommandLine.UintP(name, shorthand, value, usage)
+}
+
+// UintS is like Uint, but accepts a shorthand letter that can be used after a single dash, alone.
+func UintS(name, shorthand string, value uint, usage string) *uint {
+	return CommandLine.UintS(name, shorthand, value, usage)
 }

--- a/uint16.go
+++ b/uint16.go
@@ -50,6 +50,11 @@ func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, us
 	f.VarP(newUint16Value(value, p), name, shorthand, usage)
 }
 
+// Uint16VarS is like Uint16Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Uint16VarS(p *uint16, name, shorthand string, value uint16, usage string) {
+	f.VarS(newUint16Value(value, p), name, shorthand, usage)
+}
+
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
 func Uint16Var(p *uint16, name string, value uint16, usage string) {
@@ -59,6 +64,11 @@ func Uint16Var(p *uint16, name string, value uint16, usage string) {
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
 	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage)
+}
+
+// Uint16VarS is like Uint16Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Uint16VarS(p *uint16, name, shorthand string, value uint16, usage string) {
+	CommandLine.VarS(newUint16Value(value, p), name, shorthand, usage)
 }
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.
@@ -76,6 +86,13 @@ func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string) *u
 	return p
 }
 
+// Uint16S is like Uint16, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Uint16S(name, shorthand string, value uint16, usage string) *uint16 {
+	p := new(uint16)
+	f.Uint16VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Uint16 defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
 func Uint16(name string, value uint16, usage string) *uint16 {
@@ -85,4 +102,9 @@ func Uint16(name string, value uint16, usage string) *uint16 {
 // Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
 func Uint16P(name, shorthand string, value uint16, usage string) *uint16 {
 	return CommandLine.Uint16P(name, shorthand, value, usage)
+}
+
+// Uint16S is like Uint16, but accepts a shorthand letter that can be used after a single dash, alone.
+func Uint16S(name, shorthand string, value uint16, usage string) *uint16 {
+	return CommandLine.Uint16S(name, shorthand, value, usage)
 }

--- a/uint32.go
+++ b/uint32.go
@@ -50,6 +50,11 @@ func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, us
 	f.VarP(newUint32Value(value, p), name, shorthand, usage)
 }
 
+// Uint32VarS is like Uint32Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Uint32VarS(p *uint32, name, shorthand string, value uint32, usage string) {
+	f.VarS(newUint32Value(value, p), name, shorthand, usage)
+}
+
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32  variable in which to store the value of the flag.
 func Uint32Var(p *uint32, name string, value uint32, usage string) {
@@ -59,6 +64,11 @@ func Uint32Var(p *uint32, name string, value uint32, usage string) {
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
 	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage)
+}
+
+// Uint32VarS is like Uint32Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Uint32VarS(p *uint32, name, shorthand string, value uint32, usage string) {
+	CommandLine.VarS(newUint32Value(value, p), name, shorthand, usage)
 }
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
@@ -76,6 +86,13 @@ func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string) *u
 	return p
 }
 
+// Uint32S is like Uint32, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Uint32S(name, shorthand string, value uint32, usage string) *uint32 {
+	p := new(uint32)
+	f.Uint32VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
 // The return value is the address of a uint32  variable that stores the value of the flag.
 func Uint32(name string, value uint32, usage string) *uint32 {
@@ -85,4 +102,9 @@ func Uint32(name string, value uint32, usage string) *uint32 {
 // Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
 func Uint32P(name, shorthand string, value uint32, usage string) *uint32 {
 	return CommandLine.Uint32P(name, shorthand, value, usage)
+}
+
+// Uint32S is like Uint32, but accepts a shorthand letter that can be used after a single dash, alone.
+func Uint32S(name, shorthand string, value uint32, usage string) *uint32 {
+	return CommandLine.Uint32S(name, shorthand, value, usage)
 }

--- a/uint64.go
+++ b/uint64.go
@@ -50,6 +50,11 @@ func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, us
 	f.VarP(newUint64Value(value, p), name, shorthand, usage)
 }
 
+// Uint64VarS is like Uint64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Uint64VarS(p *uint64, name, shorthand string, value uint64, usage string) {
+	f.VarS(newUint64Value(value, p), name, shorthand, usage)
+}
+
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
 func Uint64Var(p *uint64, name string, value uint64, usage string) {
@@ -59,6 +64,11 @@ func Uint64Var(p *uint64, name string, value uint64, usage string) {
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
 	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage)
+}
+
+// Uint64VarS is like Uint64Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Uint64VarS(p *uint64, name, shorthand string, value uint64, usage string) {
+	CommandLine.VarS(newUint64Value(value, p), name, shorthand, usage)
 }
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
@@ -76,6 +86,13 @@ func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string) *u
 	return p
 }
 
+// Uint64S is like Uint64, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Uint64S(name, shorthand string, value uint64, usage string) *uint64 {
+	p := new(uint64)
+	f.Uint64VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
 // The return value is the address of a uint64 variable that stores the value of the flag.
 func Uint64(name string, value uint64, usage string) *uint64 {
@@ -85,4 +102,9 @@ func Uint64(name string, value uint64, usage string) *uint64 {
 // Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
 func Uint64P(name, shorthand string, value uint64, usage string) *uint64 {
 	return CommandLine.Uint64P(name, shorthand, value, usage)
+}
+
+// Uint64S is like Uint64, but accepts a shorthand letter that can be used after a single dash, alone.
+func Uint64S(name, shorthand string, value uint64, usage string) *uint64 {
+	return CommandLine.Uint64S(name, shorthand, value, usage)
 }

--- a/uint8.go
+++ b/uint8.go
@@ -50,6 +50,11 @@ func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage
 	f.VarP(newUint8Value(value, p), name, shorthand, usage)
 }
 
+// Uint8VarS is like Uint8Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Uint8VarS(p *uint8, name, shorthand string, value uint8, usage string) {
+	f.VarS(newUint8Value(value, p), name, shorthand, usage)
+}
+
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
 func Uint8Var(p *uint8, name string, value uint8, usage string) {
@@ -59,6 +64,11 @@ func Uint8Var(p *uint8, name string, value uint8, usage string) {
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
 	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage)
+}
+
+// Uint8VarS is like Uint8Var, but accepts a shorthand letter that can be used after a single dash, alone.
+func Uint8VarS(p *uint8, name, shorthand string, value uint8, usage string) {
+	CommandLine.VarS(newUint8Value(value, p), name, shorthand, usage)
 }
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
@@ -76,6 +86,13 @@ func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string) *uin
 	return p
 }
 
+// Uint8S is like Uint8, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) Uint8S(name, shorthand string, value uint8, usage string) *uint8 {
+	p := new(uint8)
+	f.Uint8VarS(p, name, shorthand, value, usage)
+	return p
+}
+
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
 // The return value is the address of a uint8 variable that stores the value of the flag.
 func Uint8(name string, value uint8, usage string) *uint8 {
@@ -85,4 +102,9 @@ func Uint8(name string, value uint8, usage string) *uint8 {
 // Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
 func Uint8P(name, shorthand string, value uint8, usage string) *uint8 {
 	return CommandLine.Uint8P(name, shorthand, value, usage)
+}
+
+// Uint8S is like Uint8, but accepts a shorthand letter that can be used after a single dash, alone.
+func Uint8S(name, shorthand string, value uint8, usage string) *uint8 {
+	return CommandLine.Uint8S(name, shorthand, value, usage)
 }

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -130,6 +130,11 @@ func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint,
 	f.VarP(newUintSliceValue(value, p), name, shorthand, usage)
 }
 
+// UintSliceVarS is like UintSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) UintSliceVarS(p *[]uint, name, shorthand string, value []uint, usage string) {
+	f.VarS(newUintSliceValue(value, p), name, shorthand, usage)
+}
+
 // UintSliceVar defines a uint[] flag with specified name, default value, and usage string.
 // The argument p points to a uint[] variable in which to store the value of the flag.
 func UintSliceVar(p *[]uint, name string, value []uint, usage string) {
@@ -139,6 +144,11 @@ func UintSliceVar(p *[]uint, name string, value []uint, usage string) {
 // UintSliceVarP is like the UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string) {
 	CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage)
+}
+
+// UintSliceVarS is like the UintSliceVar, but accepts a shorthand letter that can be used after a single dash, alone.
+func UintSliceVarS(p *[]uint, name, shorthand string, value []uint, usage string) {
+	CommandLine.VarS(newUintSliceValue(value, p), name, shorthand, usage)
 }
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.
@@ -156,6 +166,13 @@ func (f *FlagSet) UintSliceP(name, shorthand string, value []uint, usage string)
 	return &p
 }
 
+// UintSliceS is like UintSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func (f *FlagSet) UintSliceS(name, shorthand string, value []uint, usage string) *[]uint {
+	p := []uint{}
+	f.UintSliceVarS(&p, name, shorthand, value, usage)
+	return &p
+}
+
 // UintSlice defines a []uint flag with specified name, default value, and usage string.
 // The return value is the address of a []uint variable that stores the value of the flag.
 func UintSlice(name string, value []uint, usage string) *[]uint {
@@ -165,4 +182,9 @@ func UintSlice(name string, value []uint, usage string) *[]uint {
 // UintSliceP is like UintSlice, but accepts a shorthand letter that can be used after a single dash.
 func UintSliceP(name, shorthand string, value []uint, usage string) *[]uint {
 	return CommandLine.UintSliceP(name, shorthand, value, usage)
+}
+
+// UintSliceS is like UintSlice, but accepts a shorthand letter that can be used after a single dash, alone.
+func UintSliceS(name, shorthand string, value []uint, usage string) *[]uint {
+	return CommandLine.UintSliceS(name, shorthand, value, usage)
 }


### PR DESCRIPTION
This PR seeks to add support for specifying flags with only a shortflag.

```
$ go test -race -cover
PASS
coverage: 63.9% of statements
ok      github.com/spf13/pflag  1.040s
```

Fixes #139
Closes #165
Closes #171
Fixes spf13/cobra#679