### PR TITLE
Remove -test.* special case

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -1014,10 +1014,6 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parseFunc) (outShorts string, outArgs []string, err error) {
 	outArgs = args
 
-	if strings.HasPrefix(shorthands, "test.") {
-		return
-	}
-
 	outShorts = shorthands[1:]
 	c := shorthands[0]
 


### PR DESCRIPTION
Reverts cb88ea77998c3f024757528e3305022ab50b43be

I am not able to find any context about this change. As best as I can tell this change was made to mimic the 'go test' command.

It is breaking my use of spf13/pflag in [gotestsum](https://github.com/gotestyourself/gotestsum) by silently dropping any flag which starts with `-test.` instead giving an error.

Does anyone know why this change was made? Why does it silently drop all of these flags?