### PR TITLE
Introduced fuzzing by adding a fuzzer 

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,14 @@
+package pflag
+
+import (
+	"strings"
+)
+
+func Fuzz(data []byte) int {
+	f := NewFlagSet("test", ContinueOnError)
+	err := f.Parse(strings.Split(string(data), " "))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer for the flagset parser.

If there is interest in fuzzing pflag, I will be happy to put more work into it. 

This fuzzer can be run locally and we can see if oss-fuzz will accept integrating pflag into their project. I will be happy to get that going. 

The PR does not change any functionality of the core library.