### PR TITLE
don't print to stdout unconditionally on ExitOnError

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -1151,7 +1151,7 @@ func (f *FlagSet) Parse(arguments []string) error {
 		case ContinueOnError:
 			return err
 		case ExitOnError:
-			fmt.Println(err)
+			fmt.Fprintln(f.Output(), err)
 			os.Exit(2)
 		case PanicOnError:
 			panic(err)


### PR DESCRIPTION
If flagset.output was set to stderr, the error would still be
printed to stdout instead of stderr.