### PR TITLE
Improve CountVar documentation

### DIFF
--- a/count.go
+++ b/count.go
@@ -57,7 +57,9 @@ func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string) {
 	flag.NoOptDefVal = "+1"
 }
 
-// CountVar like CountVar only the flag is placed on the CommandLine instead of a given flag set
+// CountVar defines a count flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+// A count flag will add 1 to its value every time it is found on the command line
 func CountVar(p *int, name string, usage string) {
 	CommandLine.CountVar(p, name, usage)
 }


### PR DESCRIPTION
I found the current documentation for [CountVar](https://godoc.org/github.com/spf13/pflag#CountVar) confusing. It took me a while to realize it's referring to the [*other* CountVar](https://godoc.org/github.com/spf13/pflag#FlagSet.CountVar) function.
So I've copied docstring from the other function, in the spirit of commit 159e1d735932e06dea06984c46ecd275decb7506.