### PR TITLE
Add MustGet() function for fixed flags

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -44,6 +44,15 @@ func (f *FlagSet) GetBool(name string) (bool, error) {
 	return val.(bool), nil
 }
 
+// MustGetBool is like GetBool, but panics on error.
+func (f *FlagSet) MustGetBool(name string) bool {
+	val, err := f.GetBool(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
 func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {

--- a/bool_slice.go
+++ b/bool_slice.go
@@ -136,6 +136,15 @@ func (f *FlagSet) GetBoolSlice(name string) ([]bool, error) {
 	return val.([]bool), nil
 }
 
+// MustGetBoolSlice is like GetBoolSlice, but panics on error.
+func (f *FlagSet) MustGetBoolSlice(name string) []bool {
+	val, err := f.GetBoolSlice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // BoolSliceVar defines a boolSlice flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
 func (f *FlagSet) BoolSliceVar(p *[]bool, name string, value []bool, usage string) {

--- a/bytes.go
+++ b/bytes.go
@@ -60,6 +60,15 @@ func (f *FlagSet) GetBytesHex(name string) ([]byte, error) {
 	return val.([]byte), nil
 }
 
+// MustGetBytesHex is like GetBytesHex, but panics on error.
+func (f *FlagSet) MustGetBytesHex(name string) []byte {
+	val, err := f.GetBytesHex(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
 func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string) {
@@ -152,12 +161,20 @@ func bytesBase64ValueConv(sval string) (interface{}, error) {
 // GetBytesBase64 return the []byte value of a flag with the given name
 func (f *FlagSet) GetBytesBase64(name string) ([]byte, error) {
 	val, err := f.getFlagType(name, "bytesBase64", bytesBase64ValueConv)
-
 	if err != nil {
 		return []byte{}, err
 	}
 
 	return val.([]byte), nil
+}
+
+// MustGetBytesBase64 is like GetBytesBase64, but panics on error.
+func (f *FlagSet) MustGetBytesBase64(name string) []byte {
+	val, err := f.GetBytesBase64(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
 }
 
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.

--- a/bytes.go
+++ b/bytes.go
@@ -161,6 +161,7 @@ func bytesBase64ValueConv(sval string) (interface{}, error) {
 // GetBytesBase64 return the []byte value of a flag with the given name
 func (f *FlagSet) GetBytesBase64(name string) ([]byte, error) {
 	val, err := f.getFlagType(name, "bytesBase64", bytesBase64ValueConv)
+
 	if err != nil {
 		return []byte{}, err
 	}

--- a/count.go
+++ b/count.go
@@ -44,6 +44,15 @@ func (f *FlagSet) GetCount(name string) (int, error) {
 	return val.(int), nil
 }
 
+// MustGetCount is like GetCount, but panics on error.
+func (f *FlagSet) MustGetCount(name string) int {
+	val, err := f.GetCount(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // CountVar defines a count flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 // A count flag will add 1 to its value every time it is found on the command line

--- a/duration.go
+++ b/duration.go
@@ -37,6 +37,15 @@ func (f *FlagSet) GetDuration(name string) (time.Duration, error) {
 	return val.(time.Duration), nil
 }
 
+// MustGetDuration is like GetDuration, but panics on error.
+func (f *FlagSet) MustGetDuration(name string) time.Duration {
+	val, err := f.GetDuration(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
 func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -117,6 +117,15 @@ func (f *FlagSet) GetDurationSlice(name string) ([]time.Duration, error) {
 	return val.([]time.Duration), nil
 }
 
+// MustGetDurationSlice is like GetDurationSlice, but panics on error.
+func (f *FlagSet) MustGetDurationSlice(name string) []time.Duration {
+	val, err := f.GetDurationSlice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // DurationSliceVar defines a durationSlice flag with specified name, default value, and usage string.
 // The argument p points to a []time.Duration variable in which to store the value of the flag.
 func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {

--- a/float32.go
+++ b/float32.go
@@ -39,6 +39,15 @@ func (f *FlagSet) GetFloat32(name string) (float32, error) {
 	return val.(float32), nil
 }
 
+// MustGetFloat32 is like GetFloat32, but panics on error.
+func (f *FlagSet) MustGetFloat32(name string) float32 {
+	val, err := f.GetFloat32(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
 func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string) {

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -125,6 +125,15 @@ func (f *FlagSet) GetFloat32Slice(name string) ([]float32, error) {
 	return val.([]float32), nil
 }
 
+// MustGetFloat32Slice is like GetFloat32Slice, but panics on error.
+func (f *FlagSet) MustGetFloat32Slice(name string) []float32 {
+	val, err := f.GetFloat32Slice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Float32SliceVar defines a float32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float32 variable in which to store the value of the flag.
 func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string) {

--- a/float64.go
+++ b/float64.go
@@ -35,6 +35,15 @@ func (f *FlagSet) GetFloat64(name string) (float64, error) {
 	return val.(float64), nil
 }
 
+// MustGetFloat64 is like GetFloat64, but panics on error.
+func (f *FlagSet) MustGetFloat64(name string) float64 {
+	val, err := f.GetFloat64(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
 func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string) {

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -117,6 +117,15 @@ func (f *FlagSet) GetFloat64Slice(name string) ([]float64, error) {
 	return val.([]float64), nil
 }
 
+// MustGetFloat64Slice is like GetFloat64Slice, but panics on error.
+func (f *FlagSet) MustGetFloat64Slice(name string) []float64 {
+	val, err := f.GetFloat64Slice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Float64SliceVar defines a float64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float64 variable in which to store the value of the flag.
 func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string) {

--- a/int.go
+++ b/int.go
@@ -35,6 +35,15 @@ func (f *FlagSet) GetInt(name string) (int, error) {
 	return val.(int), nil
 }
 
+// MustGetInt is like GetInt, but panics on error.
+func (f *FlagSet) MustGetInt(name string) int {
+	val, err := f.GetInt(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 func (f *FlagSet) IntVar(p *int, name string, value int, usage string) {

--- a/int16.go
+++ b/int16.go
@@ -39,6 +39,15 @@ func (f *FlagSet) GetInt16(name string) (int16, error) {
 	return val.(int16), nil
 }
 
+// MustGetInt16 is like GetInt16, but panics on error.
+func (f *FlagSet) MustGetInt16(name string) int16 {
+	val, err := f.GetInt16(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
 func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string) {

--- a/int32.go
+++ b/int32.go
@@ -39,6 +39,15 @@ func (f *FlagSet) GetInt32(name string) (int32, error) {
 	return val.(int32), nil
 }
 
+// MustGetInt32 is like GetInt32, but panics on error.
+func (f *FlagSet) MustGetInt32(name string) int32 {
+	val, err := f.GetInt32(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
 func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string) {

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -125,6 +125,15 @@ func (f *FlagSet) GetInt32Slice(name string) ([]int32, error) {
 	return val.([]int32), nil
 }
 
+// MustGetInt32Slice is like GetInt32Slice, but panics on error.
+func (f *FlagSet) MustGetInt32Slice(name string) []int32 {
+	val, err := f.GetInt32Slice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Int32SliceVar defines a int32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int32 variable in which to store the value of the flag.
 func (f *FlagSet) Int32SliceVar(p *[]int32, name string, value []int32, usage string) {

--- a/int64.go
+++ b/int64.go
@@ -35,6 +35,15 @@ func (f *FlagSet) GetInt64(name string) (int64, error) {
 	return val.(int64), nil
 }
 
+// MustGetInt64 is like GetInt64, but panics on error.
+func (f *FlagSet) MustGetInt64(name string) int64 {
+	val, err := f.GetInt64(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
 func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string) {

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -117,6 +117,15 @@ func (f *FlagSet) GetInt64Slice(name string) ([]int64, error) {
 	return val.([]int64), nil
 }
 
+// MustGetInt64Slice is like GetInt64Slice, but panics on error.
+func (f *FlagSet) MustGetInt64Slice(name string) []int64 {
+	val, err := f.GetInt64Slice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Int64SliceVar defines a int64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int64 variable in which to store the value of the flag.
 func (f *FlagSet) Int64SliceVar(p *[]int64, name string, value []int64, usage string) {

--- a/int8.go
+++ b/int8.go
@@ -39,6 +39,15 @@ func (f *FlagSet) GetInt8(name string) (int8, error) {
 	return val.(int8), nil
 }
 
+// MustGetInt8 is like GetInt8, but panics on error.
+func (f *FlagSet) MustGetInt8(name string) int8 {
+	val, err := f.GetInt8(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
 func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string) {

--- a/int_slice.go
+++ b/int_slice.go
@@ -109,6 +109,15 @@ func (f *FlagSet) GetIntSlice(name string) ([]int, error) {
 	return val.([]int), nil
 }
 
+// MustGetIntSlice is like GetIntSlice, but panics on error.
+func (f *FlagSet) MustGetIntSlice(name string) []int {
+	val, err := f.GetIntSlice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // IntSliceVar defines a intSlice flag with specified name, default value, and usage string.
 // The argument p points to a []int variable in which to store the value of the flag.
 func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string) {

--- a/ip.go
+++ b/ip.go
@@ -45,6 +45,15 @@ func (f *FlagSet) GetIP(name string) (net.IP, error) {
 	return val.(net.IP), nil
 }
 
+// MustGetIP is like GetIP, but panics on error.
+func (f *FlagSet) MustGetIP(name string) net.IP {
+	val, err := f.GetIP(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
 func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string) {

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -137,6 +137,15 @@ func (f *FlagSet) GetIPSlice(name string) ([]net.IP, error) {
 	return val.([]net.IP), nil
 }
 
+// MustGetIPSlice is like GetIPSlice, but panics on error.
+func (f *FlagSet) MustGetIPSlice(name string) []net.IP {
+	val, err := f.GetIPSlice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // IPSliceVar defines a ipSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
 func (f *FlagSet) IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string) {

--- a/ipmask.go
+++ b/ipmask.go
@@ -73,6 +73,15 @@ func (f *FlagSet) GetIPv4Mask(name string) (net.IPMask, error) {
 	return val.(net.IPMask), nil
 }
 
+// MustGetIPv4Mask is like GetIPv4Mask, but panics on error.
+func (f *FlagSet) MustGetIPv4Mask(name string) net.IPMask {
+	val, err := f.GetIPv4Mask(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
 func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {

--- a/ipnet.go
+++ b/ipnet.go
@@ -49,6 +49,15 @@ func (f *FlagSet) GetIPNet(name string) (net.IPNet, error) {
 	return val.(net.IPNet), nil
 }
 
+// MustGetIPNet is like GetIPNet, but panics on error.
+func (f *FlagSet) MustGetIPNet(name string) net.IPNet {
+	val, err := f.GetIPNet(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
 func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {

--- a/string.go
+++ b/string.go
@@ -31,6 +31,15 @@ func (f *FlagSet) GetString(name string) (string, error) {
 	return val.(string), nil
 }
 
+// MustGetString is like GetString, but panics on error.
+func (f *FlagSet) MustGetString(name string) string {
+	val, err := f.GetString(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
 func (f *FlagSet) StringVar(p *string, name string, value string, usage string) {

--- a/string_array.go
+++ b/string_array.go
@@ -76,6 +76,15 @@ func (f *FlagSet) GetStringArray(name string) ([]string, error) {
 	return val.([]string), nil
 }
 
+// MustGetStringArray is like GetStringArray, but panics on error.
+func (f *FlagSet) MustGetStringArray(name string) []string {
+	val, err := f.GetStringArray(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.

--- a/string_slice.go
+++ b/string_slice.go
@@ -94,6 +94,15 @@ func (f *FlagSet) GetStringSlice(name string) ([]string, error) {
 	return val.([]string), nil
 }
 
+// MustGetStringSlice is like GetStringSlice, but panics on error.
+func (f *FlagSet) MustGetStringSlice(name string) []string {
+	val, err := f.GetStringSlice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.

--- a/string_to_int.go
+++ b/string_to_int.go
@@ -96,6 +96,15 @@ func (f *FlagSet) GetStringToInt(name string) (map[string]int, error) {
 	return val.(map[string]int), nil
 }
 
+// MustGetStringToInt is like GetStringToInt, but panics on error.
+func (f *FlagSet) MustGetStringToInt(name string) map[string]int {
+	val, err := f.GetStringToInt(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma

--- a/string_to_int64.go
+++ b/string_to_int64.go
@@ -96,6 +96,15 @@ func (f *FlagSet) GetStringToInt64(name string) (map[string]int64, error) {
 	return val.(map[string]int64), nil
 }
 
+// MustGetStringToInt64 is like GetStringToInt64, but panics on error.
+func (f *FlagSet) MustGetStringToInt64(name string) map[string]int64 {
+	val, err := f.GetStringToInt64(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma

--- a/string_to_string.go
+++ b/string_to_string.go
@@ -107,6 +107,15 @@ func (f *FlagSet) GetStringToString(name string) (map[string]string, error) {
 	return val.(map[string]string), nil
 }
 
+// MustGetStringToString is like GetStringToString, but panics on error.
+func (f *FlagSet) MustGetStringToString(name string) map[string]string {
+	val, err := f.GetStringToString(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma

--- a/uint.go
+++ b/uint.go
@@ -39,6 +39,15 @@ func (f *FlagSet) GetUint(name string) (uint, error) {
 	return val.(uint), nil
 }
 
+// MustGetUint is like GetUint, but panics on error.
+func (f *FlagSet) MustGetUint(name string) uint {
+	val, err := f.GetUint(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
 func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string) {

--- a/uint16.go
+++ b/uint16.go
@@ -39,6 +39,15 @@ func (f *FlagSet) GetUint16(name string) (uint16, error) {
 	return val.(uint16), nil
 }
 
+// MustGetUint16 is like GetUint16, but panics on error.
+func (f *FlagSet) MustGetUint16(name string) uint16 {
+	val, err := f.GetUint16(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
 func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string) {

--- a/uint32.go
+++ b/uint32.go
@@ -39,6 +39,15 @@ func (f *FlagSet) GetUint32(name string) (uint32, error) {
 	return val.(uint32), nil
 }
 
+// MustGetUint32 is like GetUint32, but panics on error.
+func (f *FlagSet) MustGetUint32(name string) uint32 {
+	val, err := f.GetUint32(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32 variable in which to store the value of the flag.
 func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string) {

--- a/uint64.go
+++ b/uint64.go
@@ -39,6 +39,15 @@ func (f *FlagSet) GetUint64(name string) (uint64, error) {
 	return val.(uint64), nil
 }
 
+// MustGetUint64 is like GetUint64, but panics on error.
+func (f *FlagSet) MustGetUint64(name string) uint64 {
+	val, err := f.GetUint64(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
 func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string) {

--- a/uint8.go
+++ b/uint8.go
@@ -39,6 +39,15 @@ func (f *FlagSet) GetUint8(name string) (uint8, error) {
 	return val.(uint8), nil
 }
 
+// MustGetUint8 is like GetUint8, but panics on error.
+func (f *FlagSet) MustGetUint8(name string) uint8 {
+	val, err := f.GetUint8(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
 func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string) {

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -119,6 +119,15 @@ func (f *FlagSet) GetUintSlice(name string) ([]uint, error) {
 	return val.([]uint), nil
 }
 
+// MustGetUintSlice is like GetUintSlice, but panics on error.
+func (f *FlagSet) MustGetUintSlice(name string) []uint {
+	val, err := f.GetUintSlice(name)
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
 // UintSliceVar defines a uintSlice flag with specified name, default value, and usage string.
 // The argument p points to a []uint variable in which to store the value of the flag.
 func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string) {


### PR DESCRIPTION
Instead of omitting errors everytime for fixed flags, adding a `Must` function (like how `regexp` has) would be better