### PR TITLE
Fix usage messages for count variables

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -701,7 +701,11 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 
 		varname, usage := UnquoteUsage(flag)
 		if varname != "" {
-			line += " " + varname
+			if flag.Value.Type() == "count" {
+				line += "=" + varname
+			} else {
+				line += " " + varname
+			}
 		}
 		if flag.NoOptDefVal != "" {
 			switch flag.Value.Type() {

--- a/flag_test.go
+++ b/flag_test.go
@@ -1186,7 +1186,7 @@ const defaultOutput = `      --A                         for bootstrapping, allo
       --custom custom             custom Value implementation
       --customP custom            a VarP with default (default 10)
       --maxT timeout              set timeout for dial
-  -v, --verbose count             verbosity
+  -v, --verbose=count             verbosity
 `
 
 // Custom value that satisfies the Value interface.


### PR DESCRIPTION
The usage message would print with the argument separated from the flag by a space, but only an equals sign works.

Closes #267.