### PR TITLE
remove dead code for checking error nil

### DIFF
--- a/string_array.go
+++ b/string_array.go
@@ -31,11 +31,7 @@ func (s *stringArrayValue) Append(val string) error {
 func (s *stringArrayValue) Replace(val []string) error {
 	out := make([]string, len(val))
 	for i, d := range val {
-		var err error
 		out[i] = d
-		if err != nil {
-			return err
-		}
 	}
 	*s.value = out
 	return nil


### PR DESCRIPTION
Here is the previous dead code:

1. Assigning: "err" = "nil".
2. At condition "err != nil", the value of "err" must be "nil".
3. The condition "err != nil" cannot be true.