### PR TITLE
Add OmitDefValInUsage property in Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,32 @@ Would result in something like
 | --flagname       | ip=4321         |
 | [nothing]        | ip=1234         |
 
+## Preventing non-zero default values printing
+
+Sometimes the default value of a flag is set internally to the
+value that is not allowed to be entered by an end-user, like '-1'
+for a network port value in range [0-65535]. To avoid confusion
+of an end-user, the printout of default value can be suppressed
+per flag:
+
+``` go
+var ip = flag.IntP("flagname", "f", 1234, "help message")
+flag.Lookup("flagname").OmitDefValInUsage = true
+```
+
+By default `OmitDefValInUsage` is set to `false` and the snippet
+above would print:
+
+```
+    --flagname int    help message (default 1234)
+```
+
+and with `OmitDefValInUsage` set to `true` it would print:
+
+```
+    --flagname int    help message
+```
+
 ## Command line flag syntax
 
 ```

--- a/flag.go
+++ b/flag.go
@@ -180,6 +180,7 @@ type Flag struct {
 	Hidden              bool                // used by cobra.Command to allow flags to be hidden from help/usage text
 	ShorthandDeprecated string              // If the shorthand of this flag is deprecated, this string is the new or now thing to use
 	Annotations         map[string][]string // used by cobra.Command bash autocomple code
+	OmitDefValInUsage   bool                // Omit (if true) or print (if false or by default) the default value in usage message
 }
 
 // Value is the interface to the dynamic value stored in a flag.
@@ -728,7 +729,7 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 		}
 
 		line += usage
-		if !flag.defaultIsZeroValue() {
+		if !flag.defaultIsZeroValue() && !flag.OmitDefValInUsage {
 			if flag.Value.Type() == "string" {
 				line += fmt.Sprintf(" (default %q)", flag.DefValue)
 			} else {


### PR DESCRIPTION
It controls whether to omit printing default value if set to 'true'.

This can avoid some ugly printouts if default value is internally set out of scope of allowed values and end user should not be confused by it.