### PR TITLE
First-pass adding complex flags.

### DIFF
--- a/complex128.go
+++ b/complex128.go
@@ -1,0 +1,86 @@
+// +build go1.15
+
+package pflag
+
+import "strconv"
+
+// -- complex128 Value
+type complex128Value complex128
+
+func newComplex128Value(val complex128, p *complex128) *complex128Value {
+	*p = val
+	return (*complex128Value)(p)
+}
+
+func (c *complex128Value) Set(s string) error {
+	v, err := strconv.ParseComplex(s, 128)
+	*c = complex128Value(v)
+	return err
+}
+
+func (c *complex128Value) Type() string {
+	return "complex128"
+}
+
+func (c *complex128Value) String() string { return strconv.FormatComplex(complex128(*c), 'g', -1, 128) }
+
+func complex128Conv(sval string) (interface{}, error) {
+	return strconv.ParseComplex(sval, 128)
+}
+
+// GetComplex128 return the complex128 value of a flag with the given name
+func (f *FlagSet) GetComplex128(name string) (complex128, error) {
+	val, err := f.getFlagType(name, "complex128", complex128Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(complex128), nil
+}
+
+// Complex128Var defines a complex128 flag with specified name, default value, and usage string.
+// The argument p points to a complex128 variable in which to store the value of the flag.
+func (f *FlagSet) Complex128Var(p *complex128, name string, value complex128, usage string) {
+	f.VarP(newComplex128Value(value, p), name, "", usage)
+}
+
+// Complex128VarP is like Complex128Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Complex128VarP(p *complex128, name, shorthand string, value complex128, usage string) {
+	f.VarP(newComplex128Value(value, p), name, shorthand, usage)
+}
+
+// Complex128Var defines a complex128 flag with specified name, default value, and usage string.
+// The argument p points to a complex128 variable in which to store the value of the flag.
+func Complex128Var(p *complex128, name string, value complex128, usage string) {
+	CommandLine.VarP(newComplex128Value(value, p), name, "", usage)
+}
+
+// Complex128VarP is like Complex128Var, but accepts a shorthand letter that can be used after a single dash.
+func Complex128VarP(p *complex128, name, shorthand string, value complex128, usage string) {
+	CommandLine.VarP(newComplex128Value(value, p), name, shorthand, usage)
+}
+
+// Complex128 defines a complex128 flag with specified name, default value, and usage string.
+// The return value is the address of a complex128 variable that stores the value of the flag.
+func (f *FlagSet) Complex128(name string, value complex128, usage string) *complex128 {
+	p := new(complex128)
+	f.Complex128VarP(p, name, "", value, usage)
+	return p
+}
+
+// Complex128P is like Complex128, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Complex128P(name, shorthand string, value complex128, usage string) *complex128 {
+	p := new(complex128)
+	f.Complex128VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Complex128 defines a complex128 flag with specified name, default value, and usage string.
+// The return value is the address of a complex128 variable that stores the value of the flag.
+func Complex128(name string, value complex128, usage string) *complex128 {
+	return CommandLine.Complex128P(name, "", value, usage)
+}
+
+// Complex128P is like Complex128, but accepts a shorthand letter that can be used after a single dash.
+func Complex128P(name, shorthand string, value complex128, usage string) *complex128 {
+	return CommandLine.Complex128P(name, shorthand, value, usage)
+}

--- a/complex128_slice.go
+++ b/complex128_slice.go
@@ -1,0 +1,168 @@
+// +build go1.15
+
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// -- complex128Slice Value
+type complex128SliceValue struct {
+	value   *[]complex128
+	changed bool
+}
+
+func newComplex128SliceValue(val []complex128, p *[]complex128) *complex128SliceValue {
+	isv := new(complex128SliceValue)
+	isv.value = p
+	*isv.value = val
+	return isv
+}
+
+func (s *complex128SliceValue) Set(val string) error {
+	ss := strings.Split(val, ",")
+	out := make([]complex128, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = strconv.ParseComplex(d, 128)
+		if err != nil {
+			return err
+		}
+
+	}
+	if !s.changed {
+		*s.value = out
+	} else {
+		*s.value = append(*s.value, out...)
+	}
+	s.changed = true
+	return nil
+}
+
+func (s *complex128SliceValue) Type() string {
+	return "complex128Slice"
+}
+
+func (s *complex128SliceValue) String() string {
+	out := make([]string, len(*s.value))
+	for i, d := range *s.value {
+		out[i] = fmt.Sprintf("%f", d)
+	}
+	return "[" + strings.Join(out, ",") + "]"
+}
+
+func (s *complex128SliceValue) fromString(val string) (complex128, error) {
+	return strconv.ParseComplex(val, 128)
+}
+
+func (s *complex128SliceValue) toString(val complex128) string {
+	return fmt.Sprintf("%f", val)
+}
+
+func (s *complex128SliceValue) Append(val string) error {
+	i, err := s.fromString(val)
+	if err != nil {
+		return err
+	}
+	*s.value = append(*s.value, i)
+	return nil
+}
+
+func (s *complex128SliceValue) Replace(val []string) error {
+	out := make([]complex128, len(val))
+	for i, d := range val {
+		var err error
+		out[i], err = s.fromString(d)
+		if err != nil {
+			return err
+		}
+	}
+	*s.value = out
+	return nil
+}
+
+func (s *complex128SliceValue) GetSlice() []string {
+	out := make([]string, len(*s.value))
+	for i, d := range *s.value {
+		out[i] = s.toString(d)
+	}
+	return out
+}
+
+func complex128SliceConv(val string) (interface{}, error) {
+	val = strings.Trim(val, "[]")
+	// Empty string would cause a slice with one (empty) entry
+	if len(val) == 0 {
+		return []complex128{}, nil
+	}
+	ss := strings.Split(val, ",")
+	out := make([]complex128, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = strconv.ParseComplex(d, 128)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	return out, nil
+}
+
+// GetComplex128Slice return the []complex128 value of a flag with the given name
+func (f *FlagSet) GetComplex128Slice(name string) ([]complex128, error) {
+	val, err := f.getFlagType(name, "complex128Slice", complex128SliceConv)
+	if err != nil {
+		return []complex128{}, err
+	}
+	return val.([]complex128), nil
+}
+
+// Complex128SliceVar defines a complex128Slice flag with specified name, default value, and usage string.
+// The argument p points to a []complex128 variable in which to store the value of the flag.
+func (f *FlagSet) Complex128SliceVar(p *[]complex128, name string, value []complex128, usage string) {
+	f.VarP(newComplex128SliceValue(value, p), name, "", usage)
+}
+
+// Complex128SliceVarP is like Complex128SliceVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Complex128SliceVarP(p *[]complex128, name, shorthand string, value []complex128, usage string) {
+	f.VarP(newComplex128SliceValue(value, p), name, shorthand, usage)
+}
+
+// Complex128SliceVar defines a complex128[] flag with specified name, default value, and usage string.
+// The argument p points to a complex128[] variable in which to store the value of the flag.
+func Complex128SliceVar(p *[]complex128, name string, value []complex128, usage string) {
+	CommandLine.VarP(newComplex128SliceValue(value, p), name, "", usage)
+}
+
+// Complex128SliceVarP is like Complex128SliceVar, but accepts a shorthand letter that can be used after a single dash.
+func Complex128SliceVarP(p *[]complex128, name, shorthand string, value []complex128, usage string) {
+	CommandLine.VarP(newComplex128SliceValue(value, p), name, shorthand, usage)
+}
+
+// Complex128Slice defines a []complex128 flag with specified name, default value, and usage string.
+// The return value is the address of a []complex128 variable that stores the value of the flag.
+func (f *FlagSet) Complex128Slice(name string, value []complex128, usage string) *[]complex128 {
+	p := []complex128{}
+	f.Complex128SliceVarP(&p, name, "", value, usage)
+	return &p
+}
+
+// Complex128SliceP is like Complex128Slice, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Complex128SliceP(name, shorthand string, value []complex128, usage string) *[]complex128 {
+	p := []complex128{}
+	f.Complex128SliceVarP(&p, name, shorthand, value, usage)
+	return &p
+}
+
+// Complex128Slice defines a []complex128 flag with specified name, default value, and usage string.
+// The return value is the address of a []complex128 variable that stores the value of the flag.
+func Complex128Slice(name string, value []complex128, usage string) *[]complex128 {
+	return CommandLine.Complex128SliceP(name, "", value, usage)
+}
+
+// Complex128SliceP is like Complex128Slice, but accepts a shorthand letter that can be used after a single dash.
+func Complex128SliceP(name, shorthand string, value []complex128, usage string) *[]complex128 {
+	return CommandLine.Complex128SliceP(name, shorthand, value, usage)
+}

--- a/complex128_slice_test.go
+++ b/complex128_slice_test.go
@@ -1,0 +1,190 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.15
+
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func setUpC128SFlagSet(f64sp *[]complex128) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.Complex128SliceVar(f64sp, "f64s", []complex128{}, "Command separated list!")
+	return f
+}
+
+func setUpC128SFlagSetWithDefault(f64sp *[]complex128) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.Complex128SliceVar(f64sp, "f64s", []complex128{0.0, 1.0}, "Command separated list!")
+	return f
+}
+
+func TestEmptyC128S(t *testing.T) {
+	var f64s []complex128
+	f := setUpC128SFlagSet(&f64s)
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	getC128S, err := f.GetComplex128Slice("f64s")
+	if err != nil {
+		t.Fatal("got an error from GetComplex128Slice():", err)
+	}
+	if len(getC128S) != 0 {
+		t.Fatalf("got f64s %v with len=%d but expected length=0", getC128S, len(getC128S))
+	}
+}
+
+func TestC128S(t *testing.T) {
+	var f64s []complex128
+	f := setUpC128SFlagSet(&f64s)
+
+	vals := []string{"1.0", "2.0", "4.0", "3.0"}
+	arg := fmt.Sprintf("--f64s=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f64s {
+		d, err := strconv.ParseComplex(vals[i], 128)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %s but got: %f", i, vals[i], v)
+		}
+	}
+	getC128S, err := f.GetComplex128Slice("f64s")
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+	for i, v := range getC128S {
+		d, err := strconv.ParseComplex(vals[i], 128)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %s but got: %f from GetComplex128Slice", i, vals[i], v)
+		}
+	}
+}
+
+func TestC128SDefault(t *testing.T) {
+	var f64s []complex128
+	f := setUpC128SFlagSetWithDefault(&f64s)
+
+	vals := []string{"0.0", "1.0"}
+
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f64s {
+		d, err := strconv.ParseComplex(vals[i], 128)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %f but got: %f", i, d, v)
+		}
+	}
+
+	getC128S, err := f.GetComplex128Slice("f64s")
+	if err != nil {
+		t.Fatal("got an error from GetComplex128Slice():", err)
+	}
+	for i, v := range getC128S {
+		d, err := strconv.ParseComplex(vals[i], 128)
+		if err != nil {
+			t.Fatal("got an error from GetComplex128Slice():", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %f from GetComplex128Slice but got: %f", i, d, v)
+		}
+	}
+}
+
+func TestC128SWithDefault(t *testing.T) {
+	var f64s []complex128
+	f := setUpC128SFlagSetWithDefault(&f64s)
+
+	vals := []string{"1.0", "2.0"}
+	arg := fmt.Sprintf("--f64s=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f64s {
+		d, err := strconv.ParseComplex(vals[i], 128)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %f but got: %f", i, d, v)
+		}
+	}
+
+	getC128S, err := f.GetComplex128Slice("f64s")
+	if err != nil {
+		t.Fatal("got an error from GetComplex128Slice():", err)
+	}
+	for i, v := range getC128S {
+		d, err := strconv.ParseComplex(vals[i], 128)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected f64s[%d] to be %f from GetComplex128Slice but got: %f", i, d, v)
+		}
+	}
+}
+
+func TestC128SAsSliceValue(t *testing.T) {
+	var f64s []complex128
+	f := setUpC128SFlagSet(&f64s)
+
+	in := []string{"1.0", "2.0"}
+	argfmt := "--f64s=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	f.VisitAll(func(f *Flag) {
+		if val, ok := f.Value.(SliceValue); ok {
+			_ = val.Replace([]string{"3.1"})
+		}
+	})
+	if len(f64s) != 1 || f64s[0] != 3.1 {
+		t.Fatalf("Expected ss to be overwritten with '3.1', but got: %v", f64s)
+	}
+}
+
+func TestC128SCalledTwice(t *testing.T) {
+	var f64s []complex128
+	f := setUpC128SFlagSet(&f64s)
+
+	in := []string{"1.0,2.0", "3.0", "0+2i", "1,2i,2.5+3.1i"}
+	expected := []complex128{1.0, 2.0, 3.0, complex(0, 2), complex(1, 0), complex(0, 2), complex(2.5, 3.1)}
+	argfmt := "--f64s=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range f64s {
+		if expected[i] != v {
+			t.Fatalf("expected f64s[%d] to be %f but got: %f", i, expected[i], v)
+		}
+	}
+}


### PR DESCRIPTION
This is a first stab at adding complex128 as a flag type. I have basically cloned the float64 code and substituted `Complex` and `complex128` and added a few complex numbers in one unit-test.

Unfortunately, the strconv.ParseComplex function only seems to exist from Go 1.15 onwards, so I have made the complex128 flag code conditional on the `go1.15` tag.