### PR TITLE
Fix godoc typo in golangflag.go

### DIFF
--- a/golangflag.go
+++ b/golangflag.go
@@ -58,7 +58,7 @@ func (v *flagValueWrapper) Type() string {
 }
 
 // PFlagFromGoFlag will return a *pflag.Flag given a *flag.Flag
-// If the *flag.Flag.Name was a single character (ex: `v`) it will be accessiblei
+// If the *flag.Flag.Name was a single character (ex: `v`) it will be accessible
 // with both `-v` and `--v` in flags. If the golang flag was more than a single
 // character (ex: `verbose`) it will only be accessible via `--verbose`
 func PFlagFromGoFlag(goflag *goflag.Flag) *Flag {


### PR DESCRIPTION
accessiblei -> accessible