### PR TITLE
Added StringSliceVarMult

### DIFF
--- a/string_slice.go
+++ b/string_slice.go
@@ -3,6 +3,7 @@ package pflag
 import (
 	"bytes"
 	"encoding/csv"
+	"errors"
 	"strings"
 )
 
@@ -124,6 +125,23 @@ func StringSliceVar(p *[]string, name string, value []string, usage string) {
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
 	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+}
+
+// StringSliceVarMult functions similarly to StringSlice but allows the user to place the value of the flag in multiple pointers
+// this is useful in applications where flags are inherited from a parent entity
+func (f *FlagSet) StringSliceVarMult(pointers []*[]string, name string, value []string, usage string) error {
+	if len(pointers) < 2 {
+		return errors.New("must pass at least two pointers to string arrays")
+	}
+	CommandLine.VarP(newStringSliceValue(value, pointers[0]), name, "", usage)
+	mainPointer := pointers[0]
+	for i := range pointers {
+		if pointers[i] == mainPointer {
+			continue
+		}
+		pointers[i] = mainPointer
+	}
+	return nil
 }
 
 // StringSlice defines a string flag with specified name, default value, and usage string.

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -274,3 +274,21 @@ func TestSSAsSliceValue(t *testing.T) {
 		t.Fatalf("Expected ss to be overwritten with 'three', but got: %s", ss)
 	}
 }
+
+func TestSSMultValues(t *testing.T) {
+	var arrOne []string
+	var arrTwo []string
+	var together []*[]string
+
+	together = append(together, &arrOne)
+	together = append(together, &arrTwo)
+
+	f := NewFlagSet("test", ContinueOnError)
+	err := f.StringSliceVarMult(together, "ss", []string{}, "Multple values")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if together[0] != together[1] {
+		t.Fatalf("memory locations not the same for the two arrays")
+	}
+}


### PR DESCRIPTION
the purpose of this new flag declaration is so the user can put the data of the flag
in multiple locations without having to manually assign it in their application.
This is useful with entities that inherit many properties from a parent.

Example usage: 

``` 
testFlagName := "test"
var combined []*[]string
combined = append(combined,  &createOpts.Parent)
combined = append(combined,  &createOpts.Child)
flagSet.StringSliceVarMult(combined, testFlagName, []string{}, "fill multiple entities at once")
```

Signed-off-by: cdoern <cdoern@redhat.com>