### PR TITLE
Export all *Value types

### DIFF
--- a/bool_slice.go
+++ b/bool_slice.go
@@ -7,13 +7,13 @@ import (
 )
 
 // -- boolSlice Value
-type boolSliceValue struct {
+type BoolSliceValue struct {
 	value   *[]bool
 	changed bool
 }
 
-func newBoolSliceValue(val []bool, p *[]bool) *boolSliceValue {
-	bsv := new(boolSliceValue)
+func newBoolSliceValue(val []bool, p *[]bool) *BoolSliceValue {
+	bsv := new(BoolSliceValue)
 	bsv.value = p
 	*bsv.value = val
 	return bsv
@@ -21,7 +21,7 @@ func newBoolSliceValue(val []bool, p *[]bool) *boolSliceValue {
 
 // Set converts, and assigns, the comma-separated boolean argument string representation as the []bool value of this flag.
 // If Set is called on a flag that already has a []bool assigned, the newly converted values will be appended.
-func (s *boolSliceValue) Set(val string) error {
+func (s *BoolSliceValue) Set(val string) error {
 
 	// remove all quote characters
 	rmQuote := strings.NewReplacer(`"`, "", `'`, "", "`", "")
@@ -54,12 +54,12 @@ func (s *boolSliceValue) Set(val string) error {
 }
 
 // Type returns a string that uniquely represents this flag's type.
-func (s *boolSliceValue) Type() string {
+func (s *BoolSliceValue) Type() string {
 	return "boolSlice"
 }
 
 // String defines a "native" format for this boolean slice flag value.
-func (s *boolSliceValue) String() string {
+func (s *BoolSliceValue) String() string {
 
 	boolStrSlice := make([]string, len(*s.value))
 	for i, b := range *s.value {
@@ -71,15 +71,15 @@ func (s *boolSliceValue) String() string {
 	return "[" + out + "]"
 }
 
-func (s *boolSliceValue) fromString(val string) (bool, error) {
+func (s *BoolSliceValue) fromString(val string) (bool, error) {
 	return strconv.ParseBool(val)
 }
 
-func (s *boolSliceValue) toString(val bool) string {
+func (s *BoolSliceValue) toString(val bool) string {
 	return strconv.FormatBool(val)
 }
 
-func (s *boolSliceValue) Append(val string) error {
+func (s *BoolSliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func (s *boolSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *boolSliceValue) Replace(val []string) error {
+func (s *BoolSliceValue) Replace(val []string) error {
 	out := make([]bool, len(val))
 	for i, d := range val {
 		var err error
@@ -101,7 +101,7 @@ func (s *boolSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *boolSliceValue) GetSlice() []string {
+func (s *BoolSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- durationSlice Value
-type durationSliceValue struct {
+type DurationSliceValue struct {
 	value   *[]time.Duration
 	changed bool
 }
 
-func newDurationSliceValue(val []time.Duration, p *[]time.Duration) *durationSliceValue {
-	dsv := new(durationSliceValue)
+func newDurationSliceValue(val []time.Duration, p *[]time.Duration) *DurationSliceValue {
+	dsv := new(DurationSliceValue)
 	dsv.value = p
 	*dsv.value = val
 	return dsv
 }
 
-func (s *durationSliceValue) Set(val string) error {
+func (s *DurationSliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]time.Duration, len(ss))
 	for i, d := range ss {
@@ -39,11 +39,11 @@ func (s *durationSliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *durationSliceValue) Type() string {
+func (s *DurationSliceValue) Type() string {
 	return "durationSlice"
 }
 
-func (s *durationSliceValue) String() string {
+func (s *DurationSliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%s", d)
@@ -51,15 +51,15 @@ func (s *durationSliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *durationSliceValue) fromString(val string) (time.Duration, error) {
+func (s *DurationSliceValue) fromString(val string) (time.Duration, error) {
 	return time.ParseDuration(val)
 }
 
-func (s *durationSliceValue) toString(val time.Duration) string {
+func (s *DurationSliceValue) toString(val time.Duration) string {
 	return fmt.Sprintf("%s", val)
 }
 
-func (s *durationSliceValue) Append(val string) error {
+func (s *DurationSliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (s *durationSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *durationSliceValue) Replace(val []string) error {
+func (s *DurationSliceValue) Replace(val []string) error {
 	out := make([]time.Duration, len(val))
 	for i, d := range val {
 		var err error
@@ -81,7 +81,7 @@ func (s *durationSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *durationSliceValue) GetSlice() []string {
+func (s *DurationSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)

--- a/flag.go
+++ b/flag.go
@@ -544,11 +544,11 @@ func (f *Flag) defaultIsZeroValue() bool {
 		return f.DefValue == "0" || f.DefValue == "0s"
 	case *intValue, *int8Value, *int32Value, *int64Value, *uintValue, *uint8Value, *uint16Value, *uint32Value, *uint64Value, *countValue, *float32Value, *float64Value:
 		return f.DefValue == "0"
-	case *stringValue:
+	case *StringValue:
 		return f.DefValue == ""
 	case *ipValue, *ipMaskValue, *ipNetValue:
 		return f.DefValue == "<nil>"
-	case *intSliceValue, *stringSliceValue, *stringArrayValue:
+	case *IntSliceValue, *StringSliceValue, *StringArrayValue:
 		return f.DefValue == "[]"
 	default:
 		switch f.Value.String() {

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- float32Slice Value
-type float32SliceValue struct {
+type Float32SliceValue struct {
 	value   *[]float32
 	changed bool
 }
 
-func newFloat32SliceValue(val []float32, p *[]float32) *float32SliceValue {
-	isv := new(float32SliceValue)
+func newFloat32SliceValue(val []float32, p *[]float32) *Float32SliceValue {
+	isv := new(Float32SliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *float32SliceValue) Set(val string) error {
+func (s *Float32SliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]float32, len(ss))
 	for i, d := range ss {
@@ -41,11 +41,11 @@ func (s *float32SliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *float32SliceValue) Type() string {
+func (s *Float32SliceValue) Type() string {
 	return "float32Slice"
 }
 
-func (s *float32SliceValue) String() string {
+func (s *Float32SliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%f", d)
@@ -53,7 +53,7 @@ func (s *float32SliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *float32SliceValue) fromString(val string) (float32, error) {
+func (s *Float32SliceValue) fromString(val string) (float32, error) {
 	t64, err := strconv.ParseFloat(val, 32)
 	if err != nil {
 		return 0, err
@@ -61,11 +61,11 @@ func (s *float32SliceValue) fromString(val string) (float32, error) {
 	return float32(t64), nil
 }
 
-func (s *float32SliceValue) toString(val float32) string {
+func (s *Float32SliceValue) toString(val float32) string {
 	return fmt.Sprintf("%f", val)
 }
 
-func (s *float32SliceValue) Append(val string) error {
+func (s *Float32SliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (s *float32SliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *float32SliceValue) Replace(val []string) error {
+func (s *Float32SliceValue) Replace(val []string) error {
 	out := make([]float32, len(val))
 	for i, d := range val {
 		var err error
@@ -87,7 +87,7 @@ func (s *float32SliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *float32SliceValue) GetSlice() []string {
+func (s *Float32SliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- float64Slice Value
-type float64SliceValue struct {
+type Float64SliceValue struct {
 	value   *[]float64
 	changed bool
 }
 
-func newFloat64SliceValue(val []float64, p *[]float64) *float64SliceValue {
-	isv := new(float64SliceValue)
+func newFloat64SliceValue(val []float64, p *[]float64) *Float64SliceValue {
+	isv := new(Float64SliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *float64SliceValue) Set(val string) error {
+func (s *Float64SliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]float64, len(ss))
 	for i, d := range ss {
@@ -39,11 +39,11 @@ func (s *float64SliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *float64SliceValue) Type() string {
+func (s *Float64SliceValue) Type() string {
 	return "float64Slice"
 }
 
-func (s *float64SliceValue) String() string {
+func (s *Float64SliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%f", d)
@@ -51,15 +51,15 @@ func (s *float64SliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *float64SliceValue) fromString(val string) (float64, error) {
+func (s *Float64SliceValue) fromString(val string) (float64, error) {
 	return strconv.ParseFloat(val, 64)
 }
 
-func (s *float64SliceValue) toString(val float64) string {
+func (s *Float64SliceValue) toString(val float64) string {
 	return fmt.Sprintf("%f", val)
 }
 
-func (s *float64SliceValue) Append(val string) error {
+func (s *Float64SliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (s *float64SliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *float64SliceValue) Replace(val []string) error {
+func (s *Float64SliceValue) Replace(val []string) error {
 	out := make([]float64, len(val))
 	for i, d := range val {
 		var err error
@@ -81,7 +81,7 @@ func (s *float64SliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *float64SliceValue) GetSlice() []string {
+func (s *Float64SliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- int32Slice Value
-type int32SliceValue struct {
+type Int32SliceValue struct {
 	value   *[]int32
 	changed bool
 }
 
-func newInt32SliceValue(val []int32, p *[]int32) *int32SliceValue {
-	isv := new(int32SliceValue)
+func newInt32SliceValue(val []int32, p *[]int32) *Int32SliceValue {
+	isv := new(Int32SliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *int32SliceValue) Set(val string) error {
+func (s *Int32SliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]int32, len(ss))
 	for i, d := range ss {
@@ -41,11 +41,11 @@ func (s *int32SliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *int32SliceValue) Type() string {
+func (s *Int32SliceValue) Type() string {
 	return "int32Slice"
 }
 
-func (s *int32SliceValue) String() string {
+func (s *Int32SliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%d", d)
@@ -53,7 +53,7 @@ func (s *int32SliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *int32SliceValue) fromString(val string) (int32, error) {
+func (s *Int32SliceValue) fromString(val string) (int32, error) {
 	t64, err := strconv.ParseInt(val, 0, 32)
 	if err != nil {
 		return 0, err
@@ -61,11 +61,11 @@ func (s *int32SliceValue) fromString(val string) (int32, error) {
 	return int32(t64), nil
 }
 
-func (s *int32SliceValue) toString(val int32) string {
+func (s *Int32SliceValue) toString(val int32) string {
 	return fmt.Sprintf("%d", val)
 }
 
-func (s *int32SliceValue) Append(val string) error {
+func (s *Int32SliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (s *int32SliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *int32SliceValue) Replace(val []string) error {
+func (s *Int32SliceValue) Replace(val []string) error {
 	out := make([]int32, len(val))
 	for i, d := range val {
 		var err error
@@ -87,7 +87,7 @@ func (s *int32SliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *int32SliceValue) GetSlice() []string {
+func (s *Int32SliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- int64Slice Value
-type int64SliceValue struct {
+type Int64SliceValue struct {
 	value   *[]int64
 	changed bool
 }
 
-func newInt64SliceValue(val []int64, p *[]int64) *int64SliceValue {
-	isv := new(int64SliceValue)
+func newInt64SliceValue(val []int64, p *[]int64) *Int64SliceValue {
+	isv := new(Int64SliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *int64SliceValue) Set(val string) error {
+func (s *Int64SliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]int64, len(ss))
 	for i, d := range ss {
@@ -39,11 +39,11 @@ func (s *int64SliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *int64SliceValue) Type() string {
+func (s *Int64SliceValue) Type() string {
 	return "int64Slice"
 }
 
-func (s *int64SliceValue) String() string {
+func (s *Int64SliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%d", d)
@@ -51,15 +51,15 @@ func (s *int64SliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *int64SliceValue) fromString(val string) (int64, error) {
+func (s *Int64SliceValue) fromString(val string) (int64, error) {
 	return strconv.ParseInt(val, 0, 64)
 }
 
-func (s *int64SliceValue) toString(val int64) string {
+func (s *Int64SliceValue) toString(val int64) string {
 	return fmt.Sprintf("%d", val)
 }
 
-func (s *int64SliceValue) Append(val string) error {
+func (s *Int64SliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (s *int64SliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *int64SliceValue) Replace(val []string) error {
+func (s *Int64SliceValue) Replace(val []string) error {
 	out := make([]int64, len(val))
 	for i, d := range val {
 		var err error
@@ -81,7 +81,7 @@ func (s *int64SliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *int64SliceValue) GetSlice() []string {
+func (s *Int64SliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)

--- a/int_slice.go
+++ b/int_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- intSlice Value
-type intSliceValue struct {
+type IntSliceValue struct {
 	value   *[]int
 	changed bool
 }
 
-func newIntSliceValue(val []int, p *[]int) *intSliceValue {
-	isv := new(intSliceValue)
+func newIntSliceValue(val []int, p *[]int) *IntSliceValue {
+	isv := new(IntSliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *intSliceValue) Set(val string) error {
+func (s *IntSliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]int, len(ss))
 	for i, d := range ss {
@@ -39,11 +39,11 @@ func (s *intSliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *intSliceValue) Type() string {
+func (s *IntSliceValue) Type() string {
 	return "intSlice"
 }
 
-func (s *intSliceValue) String() string {
+func (s *IntSliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%d", d)
@@ -51,7 +51,7 @@ func (s *intSliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *intSliceValue) Append(val string) error {
+func (s *IntSliceValue) Append(val string) error {
 	i, err := strconv.Atoi(val)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func (s *intSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *intSliceValue) Replace(val []string) error {
+func (s *IntSliceValue) Replace(val []string) error {
 	out := make([]int, len(val))
 	for i, d := range val {
 		var err error
@@ -73,7 +73,7 @@ func (s *intSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *intSliceValue) GetSlice() []string {
+func (s *IntSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = strconv.Itoa(d)

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -8,13 +8,13 @@ import (
 )
 
 // -- ipSlice Value
-type ipSliceValue struct {
+type IpSliceValue struct {
 	value   *[]net.IP
 	changed bool
 }
 
-func newIPSliceValue(val []net.IP, p *[]net.IP) *ipSliceValue {
-	ipsv := new(ipSliceValue)
+func newIPSliceValue(val []net.IP, p *[]net.IP) *IpSliceValue {
+	ipsv := new(IpSliceValue)
 	ipsv.value = p
 	*ipsv.value = val
 	return ipsv
@@ -22,7 +22,7 @@ func newIPSliceValue(val []net.IP, p *[]net.IP) *ipSliceValue {
 
 // Set converts, and assigns, the comma-separated IP argument string representation as the []net.IP value of this flag.
 // If Set is called on a flag that already has a []net.IP assigned, the newly converted values will be appended.
-func (s *ipSliceValue) Set(val string) error {
+func (s *IpSliceValue) Set(val string) error {
 
 	// remove all quote characters
 	rmQuote := strings.NewReplacer(`"`, "", `'`, "", "`", "")
@@ -55,12 +55,12 @@ func (s *ipSliceValue) Set(val string) error {
 }
 
 // Type returns a string that uniquely represents this flag's type.
-func (s *ipSliceValue) Type() string {
+func (s *IpSliceValue) Type() string {
 	return "ipSlice"
 }
 
 // String defines a "native" format for this net.IP slice flag value.
-func (s *ipSliceValue) String() string {
+func (s *IpSliceValue) String() string {
 
 	ipStrSlice := make([]string, len(*s.value))
 	for i, ip := range *s.value {
@@ -72,15 +72,15 @@ func (s *ipSliceValue) String() string {
 	return "[" + out + "]"
 }
 
-func (s *ipSliceValue) fromString(val string) (net.IP, error) {
+func (s *IpSliceValue) fromString(val string) (net.IP, error) {
 	return net.ParseIP(strings.TrimSpace(val)), nil
 }
 
-func (s *ipSliceValue) toString(val net.IP) string {
+func (s *IpSliceValue) toString(val net.IP) string {
 	return val.String()
 }
 
-func (s *ipSliceValue) Append(val string) error {
+func (s *IpSliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ func (s *ipSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *ipSliceValue) Replace(val []string) error {
+func (s *IpSliceValue) Replace(val []string) error {
 	out := make([]net.IP, len(val))
 	for i, d := range val {
 		var err error
@@ -102,7 +102,7 @@ func (s *ipSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *ipSliceValue) GetSlice() []string {
+func (s *IpSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)

--- a/ipnet_slice.go
+++ b/ipnet_slice.go
@@ -8,13 +8,13 @@ import (
 )
 
 // -- ipNetSlice Value
-type ipNetSliceValue struct {
+type IpNetSliceValue struct {
 	value   *[]net.IPNet
 	changed bool
 }
 
-func newIPNetSliceValue(val []net.IPNet, p *[]net.IPNet) *ipNetSliceValue {
-	ipnsv := new(ipNetSliceValue)
+func newIPNetSliceValue(val []net.IPNet, p *[]net.IPNet) *IpNetSliceValue {
+	ipnsv := new(IpNetSliceValue)
 	ipnsv.value = p
 	*ipnsv.value = val
 	return ipnsv
@@ -22,7 +22,7 @@ func newIPNetSliceValue(val []net.IPNet, p *[]net.IPNet) *ipNetSliceValue {
 
 // Set converts, and assigns, the comma-separated IPNet argument string representation as the []net.IPNet value of this flag.
 // If Set is called on a flag that already has a []net.IPNet assigned, the newly converted values will be appended.
-func (s *ipNetSliceValue) Set(val string) error {
+func (s *IpNetSliceValue) Set(val string) error {
 
 	// remove all quote characters
 	rmQuote := strings.NewReplacer(`"`, "", `'`, "", "`", "")
@@ -55,12 +55,12 @@ func (s *ipNetSliceValue) Set(val string) error {
 }
 
 // Type returns a string that uniquely represents this flag's type.
-func (s *ipNetSliceValue) Type() string {
+func (s *IpNetSliceValue) Type() string {
 	return "ipNetSlice"
 }
 
 // String defines a "native" format for this net.IPNet slice flag value.
-func (s *ipNetSliceValue) String() string {
+func (s *IpNetSliceValue) String() string {
 
 	ipNetStrSlice := make([]string, len(*s.value))
 	for i, n := range *s.value {

--- a/string.go
+++ b/string.go
@@ -1,22 +1,22 @@
 package pflag
 
 // -- string Value
-type stringValue string
+type StringValue string
 
-func newStringValue(val string, p *string) *stringValue {
+func newStringValue(val string, p *string) *StringValue {
 	*p = val
-	return (*stringValue)(p)
+	return (*StringValue)(p)
 }
 
-func (s *stringValue) Set(val string) error {
-	*s = stringValue(val)
+func (s *StringValue) Set(val string) error {
+	*s = StringValue(val)
 	return nil
 }
-func (s *stringValue) Type() string {
+func (s *StringValue) Type() string {
 	return "string"
 }
 
-func (s *stringValue) String() string { return string(*s) }
+func (s *StringValue) String() string { return string(*s) }
 
 func stringConv(sval string) (interface{}, error) {
 	return sval, nil

--- a/string_array.go
+++ b/string_array.go
@@ -1,19 +1,19 @@
 package pflag
 
 // -- stringArray Value
-type stringArrayValue struct {
+type StringArrayValue struct {
 	value   *[]string
 	changed bool
 }
 
-func newStringArrayValue(val []string, p *[]string) *stringArrayValue {
-	ssv := new(stringArrayValue)
+func newStringArrayValue(val []string, p *[]string) *StringArrayValue {
+	ssv := new(StringArrayValue)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
 }
 
-func (s *stringArrayValue) Set(val string) error {
+func (s *StringArrayValue) Set(val string) error {
 	if !s.changed {
 		*s.value = []string{val}
 		s.changed = true
@@ -23,12 +23,12 @@ func (s *stringArrayValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringArrayValue) Append(val string) error {
+func (s *StringArrayValue) Append(val string) error {
 	*s.value = append(*s.value, val)
 	return nil
 }
 
-func (s *stringArrayValue) Replace(val []string) error {
+func (s *StringArrayValue) Replace(val []string) error {
 	out := make([]string, len(val))
 	for i, d := range val {
 		out[i] = d
@@ -37,7 +37,7 @@ func (s *stringArrayValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *stringArrayValue) GetSlice() []string {
+func (s *StringArrayValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = d
@@ -45,11 +45,11 @@ func (s *stringArrayValue) GetSlice() []string {
 	return out
 }
 
-func (s *stringArrayValue) Type() string {
+func (s *StringArrayValue) Type() string {
 	return "stringArray"
 }
 
-func (s *stringArrayValue) String() string {
+func (s *StringArrayValue) String() string {
 	str, _ := writeAsCSV(*s.value)
 	return "[" + str + "]"
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -7,13 +7,13 @@ import (
 )
 
 // -- stringSlice Value
-type stringSliceValue struct {
+type StringSliceValue struct {
 	value   *[]string
 	changed bool
 }
 
-func newStringSliceValue(val []string, p *[]string) *stringSliceValue {
-	ssv := new(stringSliceValue)
+func newStringSliceValue(val []string, p *[]string) *StringSliceValue {
+	ssv := new(StringSliceValue)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
@@ -39,7 +39,7 @@ func writeAsCSV(vals []string) (string, error) {
 	return strings.TrimSuffix(b.String(), "\n"), nil
 }
 
-func (s *stringSliceValue) Set(val string) error {
+func (s *StringSliceValue) Set(val string) error {
 	v, err := readAsCSV(val)
 	if err != nil {
 		return err
@@ -53,26 +53,26 @@ func (s *stringSliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringSliceValue) Type() string {
+func (s *StringSliceValue) Type() string {
 	return "stringSlice"
 }
 
-func (s *stringSliceValue) String() string {
+func (s *StringSliceValue) String() string {
 	str, _ := writeAsCSV(*s.value)
 	return "[" + str + "]"
 }
 
-func (s *stringSliceValue) Append(val string) error {
+func (s *StringSliceValue) Append(val string) error {
 	*s.value = append(*s.value, val)
 	return nil
 }
 
-func (s *stringSliceValue) Replace(val []string) error {
+func (s *StringSliceValue) Replace(val []string) error {
 	*s.value = val
 	return nil
 }
 
-func (s *stringSliceValue) GetSlice() []string {
+func (s *StringSliceValue) GetSlice() []string {
 	return *s.value
 }
 

--- a/string_to_int.go
+++ b/string_to_int.go
@@ -8,20 +8,20 @@ import (
 )
 
 // -- stringToInt Value
-type stringToIntValue struct {
+type StringToIntValue struct {
 	value   *map[string]int
 	changed bool
 }
 
-func newStringToIntValue(val map[string]int, p *map[string]int) *stringToIntValue {
-	ssv := new(stringToIntValue)
+func newStringToIntValue(val map[string]int, p *map[string]int) *StringToIntValue {
+	ssv := new(StringToIntValue)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
 }
 
 // Format: a=1,b=2
-func (s *stringToIntValue) Set(val string) error {
+func (s *StringToIntValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make(map[string]int, len(ss))
 	for _, pair := range ss {
@@ -46,11 +46,11 @@ func (s *stringToIntValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringToIntValue) Type() string {
+func (s *StringToIntValue) Type() string {
 	return "stringToInt"
 }
 
-func (s *stringToIntValue) String() string {
+func (s *StringToIntValue) String() string {
 	var buf bytes.Buffer
 	i := 0
 	for k, v := range *s.value {

--- a/string_to_int64.go
+++ b/string_to_int64.go
@@ -8,20 +8,20 @@ import (
 )
 
 // -- stringToInt64 Value
-type stringToInt64Value struct {
+type StringToInt64Value struct {
 	value   *map[string]int64
 	changed bool
 }
 
-func newStringToInt64Value(val map[string]int64, p *map[string]int64) *stringToInt64Value {
-	ssv := new(stringToInt64Value)
+func newStringToInt64Value(val map[string]int64, p *map[string]int64) *StringToInt64Value {
+	ssv := new(StringToInt64Value)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
 }
 
 // Format: a=1,b=2
-func (s *stringToInt64Value) Set(val string) error {
+func (s *StringToInt64Value) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make(map[string]int64, len(ss))
 	for _, pair := range ss {
@@ -46,11 +46,11 @@ func (s *stringToInt64Value) Set(val string) error {
 	return nil
 }
 
-func (s *stringToInt64Value) Type() string {
+func (s *StringToInt64Value) Type() string {
 	return "stringToInt64"
 }
 
-func (s *stringToInt64Value) String() string {
+func (s *StringToInt64Value) String() string {
 	var buf bytes.Buffer
 	i := 0
 	for k, v := range *s.value {

--- a/string_to_string.go
+++ b/string_to_string.go
@@ -8,20 +8,20 @@ import (
 )
 
 // -- stringToString Value
-type stringToStringValue struct {
+type StringToStringValue struct {
 	value   *map[string]string
 	changed bool
 }
 
-func newStringToStringValue(val map[string]string, p *map[string]string) *stringToStringValue {
-	ssv := new(stringToStringValue)
+func newStringToStringValue(val map[string]string, p *map[string]string) *StringToStringValue {
+	ssv := new(StringToStringValue)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
 }
 
 // Format: a=1,b=2
-func (s *stringToStringValue) Set(val string) error {
+func (s *StringToStringValue) Set(val string) error {
 	var ss []string
 	n := strings.Count(val, "=")
 	switch n {
@@ -57,11 +57,11 @@ func (s *stringToStringValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringToStringValue) Type() string {
+func (s *StringToStringValue) Type() string {
 	return "stringToString"
 }
 
-func (s *stringToStringValue) String() string {
+func (s *StringToStringValue) String() string {
 	records := make([]string, 0, len(*s.value)>>1)
 	for k, v := range *s.value {
 		records = append(records, k+"="+v)

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- uintSlice Value
-type uintSliceValue struct {
+type uIntSliceValue struct {
 	value   *[]uint
 	changed bool
 }
 
-func newUintSliceValue(val []uint, p *[]uint) *uintSliceValue {
-	uisv := new(uintSliceValue)
+func newUIntSliceValue(val []uint, p *[]uint) *uIntSliceValue {
+	uisv := new(uIntSliceValue)
 	uisv.value = p
 	*uisv.value = val
 	return uisv
 }
 
-func (s *uintSliceValue) Set(val string) error {
+func (s *uIntSliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]uint, len(ss))
 	for i, d := range ss {
@@ -38,11 +38,11 @@ func (s *uintSliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *uintSliceValue) Type() string {
+func (s *uIntSliceValue) Type() string {
 	return "uintSlice"
 }
 
-func (s *uintSliceValue) String() string {
+func (s *uIntSliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%d", d)
@@ -50,7 +50,7 @@ func (s *uintSliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *uintSliceValue) fromString(val string) (uint, error) {
+func (s *uIntSliceValue) fromString(val string) (uint, error) {
 	t, err := strconv.ParseUint(val, 10, 0)
 	if err != nil {
 		return 0, err
@@ -58,11 +58,11 @@ func (s *uintSliceValue) fromString(val string) (uint, error) {
 	return uint(t), nil
 }
 
-func (s *uintSliceValue) toString(val uint) string {
+func (s *uIntSliceValue) toString(val uint) string {
 	return fmt.Sprintf("%d", val)
 }
 
-func (s *uintSliceValue) Append(val string) error {
+func (s *uIntSliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func (s *uintSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *uintSliceValue) Replace(val []string) error {
+func (s *uIntSliceValue) Replace(val []string) error {
 	out := make([]uint, len(val))
 	for i, d := range val {
 		var err error
@@ -84,7 +84,7 @@ func (s *uintSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *uintSliceValue) GetSlice() []string {
+func (s *uIntSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)
@@ -122,23 +122,23 @@ func (f *FlagSet) GetUintSlice(name string) ([]uint, error) {
 // UintSliceVar defines a uintSlice flag with specified name, default value, and usage string.
 // The argument p points to a []uint variable in which to store the value of the flag.
 func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string) {
-	f.VarP(newUintSliceValue(value, p), name, "", usage)
+	f.VarP(newUIntSliceValue(value, p), name, "", usage)
 }
 
 // UintSliceVarP is like UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string) {
-	f.VarP(newUintSliceValue(value, p), name, shorthand, usage)
+	f.VarP(newUIntSliceValue(value, p), name, shorthand, usage)
 }
 
 // UintSliceVar defines a uint[] flag with specified name, default value, and usage string.
 // The argument p points to a uint[] variable in which to store the value of the flag.
 func UintSliceVar(p *[]uint, name string, value []uint, usage string) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(newUIntSliceValue(value, p), name, "", usage)
 }
 
 // UintSliceVarP is like the UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(newUIntSliceValue(value, p), name, shorthand, usage)
 }
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.


### PR DESCRIPTION
Promote reuse and make it convenient for users to create and add these
Value types hand-crafted pflag.Flag structs when the helper functions
can't be used and the raw pflag.Flag value is desired, so it can be
passed to FlagSet.AddFlag().

Fixes: https://github.com/spf13/pflag/issues/334
Signed-off-by: Joe Groocock <me@frebib.net>