### PR TITLE
Prevent help output from escaping default values as go strings

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -411,7 +411,7 @@ func (f *FlagSet) ArgsLenAtDash() int {
 func (f *FlagSet) MarkDeprecated(name string, usageMessage string) error {
 	flag := f.Lookup(name)
 	if flag == nil {
-		return fmt.Errorf("flag %q does not exist", name)
+		return fmt.Errorf(`flag "%v" does not exist`, name)
 	}
 	if usageMessage == "" {
 		return fmt.Errorf("deprecated message for flag %q must be set", name)
@@ -475,7 +475,7 @@ func (f *FlagSet) Set(name, value string) error {
 		} else {
 			flagName = fmt.Sprintf("--%s", flag.Name)
 		}
-		return fmt.Errorf("invalid argument %q for %q flag: %v", value, flagName, err)
+		return fmt.Errorf(`invalid argument "%v" for "%v" flag: %v`, value, flagName, err)
 	}
 
 	if !flag.Changed {
@@ -730,7 +730,7 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 		line += usage
 		if !flag.defaultIsZeroValue() {
 			if flag.Value.Type() == "string" {
-				line += fmt.Sprintf(" (default %q)", flag.DefValue)
+				line += fmt.Sprintf(` (default "%v")`, flag.DefValue)
 			} else {
 				line += fmt.Sprintf(" (default %s)", flag.DefValue)
 			}

--- a/flag_test.go
+++ b/flag_test.go
@@ -1186,6 +1186,7 @@ const defaultOutput = `      --A                         for bootstrapping, allo
       --custom custom             custom Value implementation
       --customP custom            a VarP with default (default 10)
       --maxT timeout              set timeout for dial
+      --slash string              a string with a slash (default "a\slash")
   -v, --verbose count             verbosity
 `
 
@@ -1228,6 +1229,7 @@ func TestPrintDefaults(t *testing.T) {
 	fs.StringSlice("StringSlice", []string{}, "string slice with zero default")
 	fs.StringArray("StringArray", []string{}, "string array with zero default")
 	fs.CountP("verbose", "v", "verbosity")
+	fs.String("slash", "a\\slash", "a string with a slash")
 
 	var cv customValue
 	fs.Var(&cv, "custom", "custom Value implementation")


### PR DESCRIPTION
When creating the help text for a flag, the default value shouldn't be
be excaped. It isn't clear to an end user that we would be escaping those values.

Instead we should be printing the actual value and letting the users decide
when/how to add escaping based on how they're utilzing it.

Fixes #346

Signed-off-by: John Schnake <jschnake@vmware.com>