### PR TITLE
Add Parent FlagSet

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -896,6 +896,19 @@ func (f *FlagSet) AddFlagSet(newSet *FlagSet) {
 	})
 }
 
+// AddParentFlagSet adds parent FlagSet to f. If a flag and shorthand is already present in f
+// the flag from parentSet will be ignored.
+func (f *FlagSet) AddParentFlagSet(parentSet *FlagSet) {
+	if parentSet == nil {
+		return
+	}
+	parentSet.VisitAll(func(flag *Flag) {
+		if f.Lookup(flag.Name) == nil && f.ShorthandLookup(flag.Shorthand) == nil {
+			f.AddFlag(flag)
+		}
+	})
+}
+
 // Var defines a flag with the specified name and usage string. The type and
 // value of the flag are represented by the first argument, of type Value, which
 // typically holds a user-defined implementation of Value. For instance, the


### PR DESCRIPTION
Persistent flags (`shorthand`)  of cmd's parents  conflict with cmd's shorthand flags. We faced this issue multiple time within nerdctl (https://github.com/containerd/nerdctl/issues/1334) . This idea of this PR is to ignore the InheritedFlags when there is conflict with `flag` and `shorthand` 
Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>