### PR TITLE
Remove Redundant "Unknown-Flag" Error

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -916,7 +916,6 @@ func VarP(value Value, name, shorthand, usage string) {
 func (f *FlagSet) failf(format string, a ...interface{}) error {
 	err := fmt.Errorf(format, a...)
 	if f.errorHandling != ContinueOnError {
-		fmt.Fprintln(f.Output(), err)
 		f.usage()
 	}
 	return err


### PR DESCRIPTION
# Motivation
[Issue 352](https://github.com/spf13/pflag/issues/352) reported by @wimglenn

# Changes
Remove redundant error print function call in `failf`.

# Summary
This deletes the extra error log which gets printed when opted for `ExitOnError` or `PanicOnError`.

# Related Issues
Closes #352 