### PR TITLE
Print Default Values of String-to-String in Sorted Order

### DIFF
--- a/string_to_string.go
+++ b/string_to_string.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -62,8 +63,15 @@ func (s *stringToStringValue) Type() string {
 }
 
 func (s *stringToStringValue) String() string {
+	keys := make([]string, 0, len(*s.value))
+	for k := range *s.value {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	records := make([]string, 0, len(*s.value)>>1)
-	for k, v := range *s.value {
+	for _, k := range keys {
+		v := (*s.value)[k]
 		records = append(records, k+"="+v)
 	}
 


### PR DESCRIPTION
# Motivation
[Issue 362](https://github.com/spf13/pflag/issues/362) reported by @SOF3

# Changes
Sort keys before stringifying string-to-string flag values.

# Summary
String-to-string default values in usage would print in sorted order of keys.
Eg. `--foo stringToString   usage (default [a=b,c=d])`
In the example as per #362, now, the order will be always `default [a=b,c=d]`

# Related Issues
Closes #362 