### PR TITLE
Fix TestPrintDefaults with go >= 1.18

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -1238,8 +1238,8 @@ func TestPrintDefaults(t *testing.T) {
 	fs.PrintDefaults()
 	got := buf.String()
 	if got != defaultOutput {
-		fmt.Println("\n" + got)
-		fmt.Println("\n" + defaultOutput)
+		fmt.Print("\n" + got + "\n")
+		fmt.Print("\n" + defaultOutput + "\n")
 		t.Errorf("got %q want %q\n", got, defaultOutput)
 	}
 }


### PR DESCRIPTION
It no longer accepts Println with a constant ending with a newline:

 Fixes #368

./flag_test.go:1242:3: fmt.Println arg list ends with redundant newline
FAIL    github.com/spf13/pflag [build failed]

Also changing the previous line ven if it si not constant for consistency.