### PR TITLE
Teach pflag to handle unambiguous abbreviated  long-args

### DIFF
--- a/abbrev.go
+++ b/abbrev.go
@@ -1,0 +1,57 @@
+// abbrev.go - generate abbreviations from a wordlist
+//
+// (c) 2014 Sudhi Herle <sw-at-herle.net>
+//
+// Placed in the Public Domain
+// This software does not come with any express or implied
+// warranty; it is provided "as is". No claim  is made to its
+// suitability for any purpose.
+
+package pflag
+
+// Given a wordlist in 'words', generate unique abbreviations of it
+// and return as a map[abbrev]word.
+// e.g.,
+//
+//	given a wordlist ["hello", "help", "sync"],
+//	Abbrev() returns:
+//	  {
+//	     "hello": "hello",
+//	     "hell":  "hell"
+//	     "help":  "help",
+//	     "sync":  "sync",
+//	     "syn":   "sync",
+//	     "sy":    "sync",
+//	     "s":     "sync"
+//	  }
+func abbrev(words []string) map[string]string {
+	seen := make(map[string]int)
+	table := make(map[string]string)
+
+	for _, w := range words {
+		for n := len(w) - 1; n > 0; n -= 1 {
+			ab := w[:n]
+			seen[ab] += 1
+
+			switch seen[ab] {
+			case 1:
+				table[ab] = w
+			case 2:
+				delete(table, ab)
+			default:
+				goto next
+			}
+		}
+	next:
+	}
+
+	// non abbreviations always get entered
+	// This has to be done _after_ the loop above; because
+	// if there are words that are prefixes of other words in
+	// the argument list, we need to ensure we capture them
+	// intact.
+	for _, w := range words {
+		table[w] = w
+	}
+	return table
+}

--- a/abbrev_test.go
+++ b/abbrev_test.go
@@ -1,0 +1,60 @@
+package pflag
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestSimple(t *testing.T) {
+	assert := newAsserter(t)
+
+	words := []string{"hello", "help", "sync", "uint", "uint16", "uint64"}
+	ret := map[string]string{
+		"hello":  "hello",
+		"hell":   "hello",
+		"help":   "help",
+		"sync":   "sync",
+		"syn":    "sync",
+		"sy":     "sync",
+		"s":      "sync",
+		"uint":   "uint",
+		"uint16": "uint16",
+		"uint1":  "uint16",
+		"uint64": "uint64",
+		"uint6":  "uint64",
+	}
+
+	ab := abbrev(words)
+
+	for k, v := range ab {
+		x, ok := ret[k]
+		assert(ok, "unexpected abbrev %s", k)
+		assert(x == v, "abbrev %s: exp %s, saw %s", k, x, v)
+	}
+
+	for k, v := range ret {
+		x, ok := ab[k]
+		assert(ok, "unknown abbrev %s", k)
+		assert(x == v, "abbrev %s: exp %s, saw %s", k, x, v)
+	}
+
+}
+
+// make an assert() function for use in environment 't' and return it
+func newAsserter(t *testing.T) func(cond bool, msg string, args ...interface{}) {
+	return func(cond bool, msg string, args ...interface{}) {
+		if cond {
+			return
+		}
+
+		_, file, line, ok := runtime.Caller(1)
+		if !ok {
+			file = "???"
+			line = 0
+		}
+
+		s := fmt.Sprintf(msg, args...)
+		t.Fatalf("%s: %d: Assertion failed: %s\n", file, line, s)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ package pflag_test
 import (
 	"fmt"
 
-	"github.com/spf13/pflag"
+	"github.com/opencoff/pflag"
 )
 
 func ExampleShorthandLookup() {

--- a/flag.go
+++ b/flag.go
@@ -16,7 +16,7 @@ pflag is a drop-in replacement of Go's native flag package. If you import
 pflag under the name "flag" then all code should continue to function
 with no changes.
 
-	import flag "github.com/spf13/pflag"
+	import flag "github.com/opencoff/pflag"
 
 There is one exception to this: if you directly instantiate the Flag struct
 there is one more field "Shorthand" that you will need to set.

--- a/flag_test.go
+++ b/flag_test.go
@@ -1134,7 +1134,6 @@ func TestMultipleNormalizeFlagNameInvocations(t *testing.T) {
 	}
 }
 
-//
 func TestHiddenFlagInUsage(t *testing.T) {
 	f := NewFlagSet("bob", ContinueOnError)
 	f.Bool("secretFlag", true, "shhh")
@@ -1149,7 +1148,6 @@ func TestHiddenFlagInUsage(t *testing.T) {
 	}
 }
 
-//
 func TestHiddenFlagUsage(t *testing.T) {
 	f := NewFlagSet("bob", ContinueOnError)
 	f.Bool("secretFlag", true, "shhh")
@@ -1238,8 +1236,8 @@ func TestPrintDefaults(t *testing.T) {
 	fs.PrintDefaults()
 	got := buf.String()
 	if got != defaultOutput {
-		fmt.Println("\n" + got)
-		fmt.Println("\n" + defaultOutput)
+		fmt.Print("\n" + got)
+		fmt.Print("\n" + defaultOutput)
 		t.Errorf("got %q want %q\n", got, defaultOutput)
 	}
 }
@@ -1282,4 +1280,33 @@ func TestVisitFlagOrder(t *testing.T) {
 		}
 		i++
 	})
+}
+
+func TestAbbrevFlags(t *testing.T) {
+	f := NewFlagSet("abbrev", ContinueOnError)
+
+	b0 := f.Bool("with-something", false, "bool with something")
+	b1 := f.Bool("with-otherthing", false, "bool with otherthing")
+	b2 := f.Bool("zero-this", false, "zero this thing")
+
+	args := []string{
+		"--with-some",
+		"--with-oth",
+		"--ze",
+	}
+	if err := f.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	if !f.Parsed() {
+		t.Error("f.Parse() = false after Parse")
+	}
+	if *b0 != true {
+		t.Error("with-something flag should be true, is ", *b0)
+	}
+	if *b1 != true {
+		t.Error("with-otherthing flag should be true, is ", *b1)
+	}
+	if *b2 != true {
+		t.Error("zero-this flag should be true, is ", *b2)
+	}
 }

--- a/flag_test.go
+++ b/flag_test.go
@@ -1245,7 +1245,7 @@ func TestPrintDefaults(t *testing.T) {
 func TestVisitAllFlagOrder(t *testing.T) {
 	fs := NewFlagSet("TestVisitAllFlagOrder", ContinueOnError)
 	fs.SortFlags = false
-	// https://github.com/spf13/pflag/issues/120
+	// https://github.com/opencoff/pflag/issues/120
 	fs.SetNormalizeFunc(func(f *FlagSet, name string) NormalizedName {
 		return NormalizedName(name)
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/opencoff/pflag
 
 go 1.20
-
-require github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/spf13/pflag
+module github.com/opencoff/pflag
 
-go 1.12
+go 1.20
+
+require github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=


### PR DESCRIPTION
* add a new abbreviation generator (abbrev.go) with tests
* teach flag.go to build an abbrev table for long args and look it up and add tests to verify new behavior
* Fix "spurious new line" error from use of Println()