### PR TITLE
Adding custom validation for any type of flag's value

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ It is optional and for this operation, you should define a function and pass it 
 var flagvar int
 func init() {
 	validation := func(value int) error {
-		if value < 4 {
+		if value <= 4 {
 			return errors.New("int value should be greater than 4")
         	}
 	}

--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ independent sets of flags, such as to implement subcommands
 in a command-line interface. The methods of FlagSet are
 analogous to the top-level functions for the command-line
 flag set.
+## Adding custom validation for flags
+
+You can also add custom validation for validating the flag's value. 
+It is optional and for this operation, you should define a function and pass it as the last parameter to the flag definition function.
+
+```go
+var flagvar int
+func init() {
+	validation := func(value int)error{
+		if value < 4 {
+			return errors.New("int value should be greater than 4")
+        }
+    }
+	
+    flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname", validation)
+````
+
+In the above example if you pass an integer value greater than 4, it returned an error and the value of the flag doesn't set.
 
 ## Setting no option default values for flags
 

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ func init() {
 			return errors.New("int value should be greater than 4")
         }
     }
-	
     flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname", validation)
+}
 ````
 
 In the above example if you pass an integer value greater than 4, it returned an error and the value of the flag doesn't set.

--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ It is optional and for this operation, you should define a function and pass it 
 ```go
 var flagvar int
 func init() {
-	validation := func(value int)error{
+	validation := func(value int) error {
 		if value < 4 {
 			return errors.New("int value should be greater than 4")
-        }
-    }
-    flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname", validation)
+        	}
+	}
+	flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname", validation)
 }
 ````
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/spf13/pflag.svg?branch=master)](https://travis-ci.org/spf13/pflag)
 [![Go Report Card](https://goreportcard.com/badge/github.com/spf13/pflag)](https://goreportcard.com/report/github.com/spf13/pflag)
 [![GoDoc](https://godoc.org/github.com/spf13/pflag?status.svg)](https://godoc.org/github.com/spf13/pflag)
 
@@ -21,11 +22,11 @@ pflag is available using the standard `go get` command.
 
 Install by running:
 
-    go get github.com/erfanmomeniii/pflag
+    go get github.com/spf13/pflag
 
 Run tests by running:
 
-    go test github.com/erfanmomeniii/pflag
+    go test github.com/spf13/pflag
 
 ## Usage
 
@@ -34,7 +35,7 @@ pflag under the name "flag" then all code should continue to function
 with no changes.
 
 ``` go
-import flag "github.com/erfanmomeniii/pflag"
+import flag "github.com/spf13/pflag"
 ```
 
 There is one exception to this: if you directly instantiate the Flag struct
@@ -291,7 +292,7 @@ to support flags defined by third-party dependencies (e.g. `golang/glog`).
 ```go
 import (
 	goflag "flag"
-	flag "github.com/erfanmomeniii/pflag"
+	flag "github.com/spf13/pflag"
 )
 
 var ip *int = flag.Int("flagname", 1234, "help message for flagname")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/spf13/pflag.svg?branch=master)](https://travis-ci.org/spf13/pflag)
 [![Go Report Card](https://goreportcard.com/badge/github.com/spf13/pflag)](https://goreportcard.com/report/github.com/spf13/pflag)
 [![GoDoc](https://godoc.org/github.com/spf13/pflag?status.svg)](https://godoc.org/github.com/spf13/pflag)
 
@@ -22,11 +21,11 @@ pflag is available using the standard `go get` command.
 
 Install by running:
 
-    go get github.com/spf13/pflag
+    go get github.com/erfanmomeniii/pflag
 
 Run tests by running:
 
-    go test github.com/spf13/pflag
+    go test github.com/erfanmomeniii/pflag
 
 ## Usage
 
@@ -35,7 +34,7 @@ pflag under the name "flag" then all code should continue to function
 with no changes.
 
 ``` go
-import flag "github.com/spf13/pflag"
+import flag "github.com/erfanmomeniii/pflag"
 ```
 
 There is one exception to this: if you directly instantiate the Flag struct
@@ -292,7 +291,7 @@ to support flags defined by third-party dependencies (e.g. `golang/glog`).
 ```go
 import (
 	goflag "flag"
-	flag "github.com/spf13/pflag"
+	flag "github.com/erfanmomeniii/pflag"
 )
 
 var ip *int = flag.Int("flagname", 1234, "help message for flagname")

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ flag set.
 ## Adding custom validation for flags
 
 You can also add custom validation for validating the flag's value. 
+
 It is optional and for this operation, you should define a function and pass it as the last parameter to the flag definition function.
 
 ```go

--- a/bool.go
+++ b/bool.go
@@ -46,49 +46,49 @@ func (f *FlagSet) GetBool(name string) (bool, error) {
 
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
-func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {
-	f.BoolVarP(p, name, "", value, usage)
+func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string, validation ...func(value any) error) {
+	f.BoolVarP(p, name, "", value, usage, validation...)
 }
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage)
+func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value any) error) {
+	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage, validation...)
 	flag.NoOptDefVal = "true"
 }
 
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
-func BoolVar(p *bool, name string, value bool, usage string) {
-	BoolVarP(p, name, "", value, usage)
+func BoolVar(p *bool, name string, value bool, usage string, validation ...func(value any) error) {
+	BoolVarP(p, name, "", value, usage, validation...)
 }
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
-func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage)
+func BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value any) error) {
+	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage, validation...)
 	flag.NoOptDefVal = "true"
 }
 
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
-func (f *FlagSet) Bool(name string, value bool, usage string) *bool {
-	return f.BoolP(name, "", value, usage)
+func (f *FlagSet) Bool(name string, value bool, usage string, validation ...func(value any) error) *bool {
+	return f.BoolP(name, "", value, usage, validation...)
 }
 
 // BoolP is like Bool, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string) *bool {
+func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string, validation ...func(value any) error) *bool {
 	p := new(bool)
-	f.BoolVarP(p, name, shorthand, value, usage)
+	f.BoolVarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
-func Bool(name string, value bool, usage string) *bool {
-	return BoolP(name, "", value, usage)
+func Bool(name string, value bool, usage string, validation ...func(value any) error) *bool {
+	return BoolP(name, "", value, usage, validation...)
 }
 
 // BoolP is like Bool, but accepts a shorthand letter that can be used after a single dash.
-func BoolP(name, shorthand string, value bool, usage string) *bool {
-	b := CommandLine.BoolP(name, shorthand, value, usage)
+func BoolP(name, shorthand string, value bool, usage string, validation ...func(value any) error) *bool {
+	b := CommandLine.BoolP(name, shorthand, value, usage, validation...)
 	return b
 }

--- a/bool.go
+++ b/bool.go
@@ -1,6 +1,8 @@
 package pflag
 
-import "strconv"
+import (
+	"strconv"
+)
 
 // optional interface to indicate boolean flags that can be
 // supplied without "=value" text
@@ -46,36 +48,48 @@ func (f *FlagSet) GetBool(name string) (bool, error) {
 
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
-func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string, validation ...func(value interface{}) error) {
+func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string, validation ...func(value bool) error) {
 	f.BoolVarP(p, name, "", value, usage, validation...)
 }
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value interface{}) error) {
-	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value bool) error) {
+	if len(validation) > 0 {
+		validationFunc := (interface{})(validation[0])
+		flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage, validationFunc)
+		flag.NoOptDefVal = "true"
+		return
+	}
+	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage)
 	flag.NoOptDefVal = "true"
 }
 
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
-func BoolVar(p *bool, name string, value bool, usage string, validation ...func(value interface{}) error) {
+func BoolVar(p *bool, name string, value bool, usage string, validation ...func(value bool) error) {
 	BoolVarP(p, name, "", value, usage, validation...)
 }
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
-func BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value interface{}) error) {
-	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage, validation...)
+func BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value bool) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage, validationFunc)
+		flag.NoOptDefVal = "true"
+		return
+	}
+	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage)
 	flag.NoOptDefVal = "true"
 }
 
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
-func (f *FlagSet) Bool(name string, value bool, usage string, validation ...func(value interface{}) error) *bool {
+func (f *FlagSet) Bool(name string, value bool, usage string, validation ...func(value bool) error) *bool {
 	return f.BoolP(name, "", value, usage, validation...)
 }
 
 // BoolP is like Bool, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string, validation ...func(value interface{}) error) *bool {
+func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string, validation ...func(value bool) error) *bool {
 	p := new(bool)
 	f.BoolVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -83,12 +97,12 @@ func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string, valida
 
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
-func Bool(name string, value bool, usage string, validation ...func(value interface{}) error) *bool {
+func Bool(name string, value bool, usage string, validation ...func(value bool) error) *bool {
 	return BoolP(name, "", value, usage, validation...)
 }
 
 // BoolP is like Bool, but accepts a shorthand letter that can be used after a single dash.
-func BoolP(name, shorthand string, value bool, usage string, validation ...func(value interface{}) error) *bool {
+func BoolP(name, shorthand string, value bool, usage string, validation ...func(value bool) error) *bool {
 	b := CommandLine.BoolP(name, shorthand, value, usage, validation...)
 	return b
 }

--- a/bool.go
+++ b/bool.go
@@ -46,36 +46,36 @@ func (f *FlagSet) GetBool(name string) (bool, error) {
 
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
-func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string, validation ...func(value any) error) {
+func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string, validation ...func(value interface{}) error) {
 	f.BoolVarP(p, name, "", value, usage, validation...)
 }
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value any) error) {
+func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value interface{}) error) {
 	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage, validation...)
 	flag.NoOptDefVal = "true"
 }
 
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
-func BoolVar(p *bool, name string, value bool, usage string, validation ...func(value any) error) {
+func BoolVar(p *bool, name string, value bool, usage string, validation ...func(value interface{}) error) {
 	BoolVarP(p, name, "", value, usage, validation...)
 }
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
-func BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value any) error) {
+func BoolVarP(p *bool, name, shorthand string, value bool, usage string, validation ...func(value interface{}) error) {
 	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage, validation...)
 	flag.NoOptDefVal = "true"
 }
 
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
-func (f *FlagSet) Bool(name string, value bool, usage string, validation ...func(value any) error) *bool {
+func (f *FlagSet) Bool(name string, value bool, usage string, validation ...func(value interface{}) error) *bool {
 	return f.BoolP(name, "", value, usage, validation...)
 }
 
 // BoolP is like Bool, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string, validation ...func(value any) error) *bool {
+func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string, validation ...func(value interface{}) error) *bool {
 	p := new(bool)
 	f.BoolVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -83,12 +83,12 @@ func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string, valida
 
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
-func Bool(name string, value bool, usage string, validation ...func(value any) error) *bool {
+func Bool(name string, value bool, usage string, validation ...func(value interface{}) error) *bool {
 	return BoolP(name, "", value, usage, validation...)
 }
 
 // BoolP is like Bool, but accepts a shorthand letter that can be used after a single dash.
-func BoolP(name, shorthand string, value bool, usage string, validation ...func(value any) error) *bool {
+func BoolP(name, shorthand string, value bool, usage string, validation ...func(value interface{}) error) *bool {
 	b := CommandLine.BoolP(name, shorthand, value, usage, validation...)
 	return b
 }

--- a/bool_slice.go
+++ b/bool_slice.go
@@ -138,48 +138,48 @@ func (f *FlagSet) GetBoolSlice(name string) ([]bool, error) {
 
 // BoolSliceVar defines a boolSlice flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
-func (f *FlagSet) BoolSliceVar(p *[]bool, name string, value []bool, usage string) {
-	f.VarP(newBoolSliceValue(value, p), name, "", usage)
+func (f *FlagSet) BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value any) error) {
+	f.VarP(newBoolSliceValue(value, p), name, "", usage, validation...)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string) {
-	f.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value any) error) {
+	f.VarP(newBoolSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // BoolSliceVar defines a []bool flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
-func BoolSliceVar(p *[]bool, name string, value []bool, usage string) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, "", usage)
+func BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newBoolSliceValue(value, p), name, "", usage, validation...)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
+func BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newBoolSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.
 // The return value is the address of a []bool variable that stores the value of the flag.
-func (f *FlagSet) BoolSlice(name string, value []bool, usage string) *[]bool {
+func (f *FlagSet) BoolSlice(name string, value []bool, usage string, validation ...func(value any) error) *[]bool {
 	p := []bool{}
-	f.BoolSliceVarP(&p, name, "", value, usage)
+	f.BoolSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // BoolSliceP is like BoolSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolSliceP(name, shorthand string, value []bool, usage string) *[]bool {
+func (f *FlagSet) BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value any) error) *[]bool {
 	p := []bool{}
-	f.BoolSliceVarP(&p, name, shorthand, value, usage)
+	f.BoolSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.
 // The return value is the address of a []bool variable that stores the value of the flag.
-func BoolSlice(name string, value []bool, usage string) *[]bool {
-	return CommandLine.BoolSliceP(name, "", value, usage)
+func BoolSlice(name string, value []bool, usage string, validation ...func(value any) error) *[]bool {
+	return CommandLine.BoolSliceP(name, "", value, usage, validation...)
 }
 
 // BoolSliceP is like BoolSlice, but accepts a shorthand letter that can be used after a single dash.
-func BoolSliceP(name, shorthand string, value []bool, usage string) *[]bool {
-	return CommandLine.BoolSliceP(name, shorthand, value, usage)
+func BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value any) error) *[]bool {
+	return CommandLine.BoolSliceP(name, shorthand, value, usage, validation...)
 }

--- a/bool_slice.go
+++ b/bool_slice.go
@@ -138,36 +138,56 @@ func (f *FlagSet) GetBoolSlice(name string) ([]bool, error) {
 
 // BoolSliceVar defines a boolSlice flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
-func (f *FlagSet) BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newBoolSliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value []bool) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newBoolSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newBoolSliceValue(value, p), name, "", usage)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newBoolSliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value []bool) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newBoolSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
 }
 
 // BoolSliceVar defines a []bool flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
-func BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, "", usage, validation...)
+func BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value []bool) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newBoolSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newBoolSliceValue(value, p), name, "", usage)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, shorthand, usage, validation...)
+func BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value []bool) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newBoolSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
 }
 
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.
 // The return value is the address of a []bool variable that stores the value of the flag.
-func (f *FlagSet) BoolSlice(name string, value []bool, usage string, validation ...func(value interface{}) error) *[]bool {
+func (f *FlagSet) BoolSlice(name string, value []bool, usage string, validation ...func(value []bool) error) *[]bool {
 	p := []bool{}
 	f.BoolSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // BoolSliceP is like BoolSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value interface{}) error) *[]bool {
+func (f *FlagSet) BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value []bool) error) *[]bool {
 	p := []bool{}
 	f.BoolSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -175,11 +195,11 @@ func (f *FlagSet) BoolSliceP(name, shorthand string, value []bool, usage string,
 
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.
 // The return value is the address of a []bool variable that stores the value of the flag.
-func BoolSlice(name string, value []bool, usage string, validation ...func(value interface{}) error) *[]bool {
+func BoolSlice(name string, value []bool, usage string, validation ...func(value []bool) error) *[]bool {
 	return CommandLine.BoolSliceP(name, "", value, usage, validation...)
 }
 
 // BoolSliceP is like BoolSlice, but accepts a shorthand letter that can be used after a single dash.
-func BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value interface{}) error) *[]bool {
+func BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value []bool) error) *[]bool {
 	return CommandLine.BoolSliceP(name, shorthand, value, usage, validation...)
 }

--- a/bool_slice.go
+++ b/bool_slice.go
@@ -138,36 +138,36 @@ func (f *FlagSet) GetBoolSlice(name string) ([]bool, error) {
 
 // BoolSliceVar defines a boolSlice flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
-func (f *FlagSet) BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value any) error) {
+func (f *FlagSet) BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newBoolSliceValue(value, p), name, "", usage, validation...)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value any) error) {
+func (f *FlagSet) BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newBoolSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // BoolSliceVar defines a []bool flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
-func BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value any) error) {
+func BoolSliceVar(p *[]bool, name string, value []bool, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newBoolSliceValue(value, p), name, "", usage, validation...)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value any) error) {
+func BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newBoolSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.
 // The return value is the address of a []bool variable that stores the value of the flag.
-func (f *FlagSet) BoolSlice(name string, value []bool, usage string, validation ...func(value any) error) *[]bool {
+func (f *FlagSet) BoolSlice(name string, value []bool, usage string, validation ...func(value interface{}) error) *[]bool {
 	p := []bool{}
 	f.BoolSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // BoolSliceP is like BoolSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value any) error) *[]bool {
+func (f *FlagSet) BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value interface{}) error) *[]bool {
 	p := []bool{}
 	f.BoolSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -175,11 +175,11 @@ func (f *FlagSet) BoolSliceP(name, shorthand string, value []bool, usage string,
 
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.
 // The return value is the address of a []bool variable that stores the value of the flag.
-func BoolSlice(name string, value []bool, usage string, validation ...func(value any) error) *[]bool {
+func BoolSlice(name string, value []bool, usage string, validation ...func(value interface{}) error) *[]bool {
 	return CommandLine.BoolSliceP(name, "", value, usage, validation...)
 }
 
 // BoolSliceP is like BoolSlice, but accepts a shorthand letter that can be used after a single dash.
-func BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value any) error) *[]bool {
+func BoolSliceP(name, shorthand string, value []bool, usage string, validation ...func(value interface{}) error) *[]bool {
 	return CommandLine.BoolSliceP(name, shorthand, value, usage, validation...)
 }

--- a/bytes.go
+++ b/bytes.go
@@ -62,50 +62,50 @@ func (f *FlagSet) GetBytesHex(name string) ([]byte, error) {
 
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string) {
-	f.VarP(newBytesHexValue(value, p), name, "", usage)
+func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value any) error) {
+	f.VarP(newBytesHexValue(value, p), name, "", usage, validation...)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	f.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value any) error) {
+	f.VarP(newBytesHexValue(value, p), name, shorthand, usage, validation...)
 }
 
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func BytesHexVar(p *[]byte, name string, value []byte, usage string) {
-	CommandLine.VarP(newBytesHexValue(value, p), name, "", usage)
+func BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newBytesHexValue(value, p), name, "", usage, validation...)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
-func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage, validation...)
 }
 
 // BytesHex defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func (f *FlagSet) BytesHex(name string, value []byte, usage string) *[]byte {
+func (f *FlagSet) BytesHex(name string, value []byte, usage string, validation ...func(value any) error) *[]byte {
 	p := new([]byte)
-	f.BytesHexVarP(p, name, "", value, usage)
+	f.BytesHexVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string) *[]byte {
+func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value any) error) *[]byte {
 	p := new([]byte)
-	f.BytesHexVarP(p, name, shorthand, value, usage)
+	f.BytesHexVarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // BytesHex defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func BytesHex(name string, value []byte, usage string) *[]byte {
-	return CommandLine.BytesHexP(name, "", value, usage)
+func BytesHex(name string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+	return CommandLine.BytesHexP(name, "", value, usage, validation...)
 }
 
 // BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
-func BytesHexP(name, shorthand string, value []byte, usage string) *[]byte {
-	return CommandLine.BytesHexP(name, shorthand, value, usage)
+func BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+	return CommandLine.BytesHexP(name, shorthand, value, usage, validation...)
 }
 
 // BytesBase64 adapts []byte for use as a flag. Value of flag is Base64 encoded
@@ -162,48 +162,48 @@ func (f *FlagSet) GetBytesBase64(name string) ([]byte, error) {
 
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func (f *FlagSet) BytesBase64Var(p *[]byte, name string, value []byte, usage string) {
-	f.VarP(newBytesBase64Value(value, p), name, "", usage)
+func (f *FlagSet) BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value any) error) {
+	f.VarP(newBytesBase64Value(value, p), name, "", usage, validation...)
 }
 
 // BytesBase64VarP is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	f.VarP(newBytesBase64Value(value, p), name, shorthand, usage)
+func (f *FlagSet) BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value any) error) {
+	f.VarP(newBytesBase64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func BytesBase64Var(p *[]byte, name string, value []byte, usage string) {
-	CommandLine.VarP(newBytesBase64Value(value, p), name, "", usage)
+func BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newBytesBase64Value(value, p), name, "", usage, validation...)
 }
 
 // BytesBase64VarP is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash.
-func BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	CommandLine.VarP(newBytesBase64Value(value, p), name, shorthand, usage)
+func BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newBytesBase64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // BytesBase64 defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func (f *FlagSet) BytesBase64(name string, value []byte, usage string) *[]byte {
+func (f *FlagSet) BytesBase64(name string, value []byte, usage string, validation ...func(value any) error) *[]byte {
 	p := new([]byte)
-	f.BytesBase64VarP(p, name, "", value, usage)
+	f.BytesBase64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // BytesBase64P is like BytesBase64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesBase64P(name, shorthand string, value []byte, usage string) *[]byte {
+func (f *FlagSet) BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value any) error) *[]byte {
 	p := new([]byte)
-	f.BytesBase64VarP(p, name, shorthand, value, usage)
+	f.BytesBase64VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // BytesBase64 defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func BytesBase64(name string, value []byte, usage string) *[]byte {
-	return CommandLine.BytesBase64P(name, "", value, usage)
+func BytesBase64(name string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+	return CommandLine.BytesBase64P(name, "", value, usage, validation...)
 }
 
 // BytesBase64P is like BytesBase64, but accepts a shorthand letter that can be used after a single dash.
-func BytesBase64P(name, shorthand string, value []byte, usage string) *[]byte {
-	return CommandLine.BytesBase64P(name, shorthand, value, usage)
+func BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+	return CommandLine.BytesBase64P(name, shorthand, value, usage, validation...)
 }

--- a/bytes.go
+++ b/bytes.go
@@ -62,36 +62,36 @@ func (f *FlagSet) GetBytesHex(name string) ([]byte, error) {
 
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value any) error) {
+func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newBytesHexValue(value, p), name, "", usage, validation...)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value any) error) {
+func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newBytesHexValue(value, p), name, shorthand, usage, validation...)
 }
 
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value any) error) {
+func BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newBytesHexValue(value, p), name, "", usage, validation...)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
-func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value any) error) {
+func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage, validation...)
 }
 
 // BytesHex defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func (f *FlagSet) BytesHex(name string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+func (f *FlagSet) BytesHex(name string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
 	p := new([]byte)
 	f.BytesHexVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
 	p := new([]byte)
 	f.BytesHexVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -99,12 +99,12 @@ func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string, 
 
 // BytesHex defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func BytesHex(name string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+func BytesHex(name string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
 	return CommandLine.BytesHexP(name, "", value, usage, validation...)
 }
 
 // BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
-func BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+func BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
 	return CommandLine.BytesHexP(name, shorthand, value, usage, validation...)
 }
 
@@ -162,36 +162,36 @@ func (f *FlagSet) GetBytesBase64(name string) ([]byte, error) {
 
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func (f *FlagSet) BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value any) error) {
+func (f *FlagSet) BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newBytesBase64Value(value, p), name, "", usage, validation...)
 }
 
 // BytesBase64VarP is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value any) error) {
+func (f *FlagSet) BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newBytesBase64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value any) error) {
+func BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newBytesBase64Value(value, p), name, "", usage, validation...)
 }
 
 // BytesBase64VarP is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash.
-func BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value any) error) {
+func BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newBytesBase64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // BytesBase64 defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func (f *FlagSet) BytesBase64(name string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+func (f *FlagSet) BytesBase64(name string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
 	p := new([]byte)
 	f.BytesBase64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // BytesBase64P is like BytesBase64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+func (f *FlagSet) BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
 	p := new([]byte)
 	f.BytesBase64VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -199,11 +199,11 @@ func (f *FlagSet) BytesBase64P(name, shorthand string, value []byte, usage strin
 
 // BytesBase64 defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func BytesBase64(name string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+func BytesBase64(name string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
 	return CommandLine.BytesBase64P(name, "", value, usage, validation...)
 }
 
 // BytesBase64P is like BytesBase64, but accepts a shorthand letter that can be used after a single dash.
-func BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value any) error) *[]byte {
+func BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
 	return CommandLine.BytesBase64P(name, shorthand, value, usage, validation...)
 }

--- a/bytes.go
+++ b/bytes.go
@@ -62,36 +62,56 @@ func (f *FlagSet) GetBytesHex(name string) ([]byte, error) {
 
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newBytesHexValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value []byte) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newBytesHexValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newBytesHexValue(value, p), name, "", usage)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newBytesHexValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value []byte) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newBytesHexValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newBytesHexValue(value, p), name, shorthand, usage)
 }
 
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newBytesHexValue(value, p), name, "", usage, validation...)
+func BytesHexVar(p *[]byte, name string, value []byte, usage string, validation ...func(value []byte) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newBytesHexValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newBytesHexValue(value, p), name, "", usage)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
-func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage, validation...)
+func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value []byte) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage)
 }
 
 // BytesHex defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func (f *FlagSet) BytesHex(name string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
+func (f *FlagSet) BytesHex(name string, value []byte, usage string, validation ...func(value []byte) error) *[]byte {
 	p := new([]byte)
 	f.BytesHexVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
+func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value []byte) error) *[]byte {
 	p := new([]byte)
 	f.BytesHexVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -99,12 +119,12 @@ func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string, 
 
 // BytesHex defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func BytesHex(name string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
+func BytesHex(name string, value []byte, usage string, validation ...func(value []byte) error) *[]byte {
 	return CommandLine.BytesHexP(name, "", value, usage, validation...)
 }
 
 // BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
-func BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
+func BytesHexP(name, shorthand string, value []byte, usage string, validation ...func(value []byte) error) *[]byte {
 	return CommandLine.BytesHexP(name, shorthand, value, usage, validation...)
 }
 
@@ -162,36 +182,52 @@ func (f *FlagSet) GetBytesBase64(name string) ([]byte, error) {
 
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func (f *FlagSet) BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newBytesBase64Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value []byte) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		f.VarP(newBytesBase64Value(value, p), name, "", usage, validationFunc)
+	}
+	f.VarP(newBytesBase64Value(value, p), name, "", usage)
 }
 
 // BytesBase64VarP is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newBytesBase64Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value []byte) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		f.VarP(newBytesBase64Value(value, p), name, shorthand, usage, validationFunc)
+	}
+	f.VarP(newBytesBase64Value(value, p), name, shorthand, usage)
 }
 
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
-func BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newBytesBase64Value(value, p), name, "", usage, validation...)
+func BytesBase64Var(p *[]byte, name string, value []byte, usage string, validation ...func(value []byte) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		CommandLine.VarP(newBytesBase64Value(value, p), name, "", usage, validationFunc)
+	}
+	CommandLine.VarP(newBytesBase64Value(value, p), name, "", usage)
 }
 
 // BytesBase64VarP is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash.
-func BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newBytesBase64Value(value, p), name, shorthand, usage, validation...)
+func BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string, validation ...func(value []byte) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		CommandLine.VarP(newBytesBase64Value(value, p), name, shorthand, usage, validationFunc)
+	}
+	CommandLine.VarP(newBytesBase64Value(value, p), name, shorthand, usage)
 }
 
 // BytesBase64 defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func (f *FlagSet) BytesBase64(name string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
+func (f *FlagSet) BytesBase64(name string, value []byte, usage string, validation ...func(value []byte) error) *[]byte {
 	p := new([]byte)
 	f.BytesBase64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // BytesBase64P is like BytesBase64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
+func (f *FlagSet) BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value []byte) error) *[]byte {
 	p := new([]byte)
 	f.BytesBase64VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -199,11 +235,11 @@ func (f *FlagSet) BytesBase64P(name, shorthand string, value []byte, usage strin
 
 // BytesBase64 defines an []byte flag with specified name, default value, and usage string.
 // The return value is the address of an []byte variable that stores the value of the flag.
-func BytesBase64(name string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
+func BytesBase64(name string, value []byte, usage string, validation ...func(value []byte) error) *[]byte {
 	return CommandLine.BytesBase64P(name, "", value, usage, validation...)
 }
 
 // BytesBase64P is like BytesBase64, but accepts a shorthand letter that can be used after a single dash.
-func BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value interface{}) error) *[]byte {
+func BytesBase64P(name, shorthand string, value []byte, usage string, validation ...func(value []byte) error) *[]byte {
 	return CommandLine.BytesBase64P(name, shorthand, value, usage, validation...)
 }

--- a/count.go
+++ b/count.go
@@ -47,50 +47,50 @@ func (f *FlagSet) GetCount(name string) (int, error) {
 // CountVar defines a count flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 // A count flag will add 1 to its value every time it is found on the command line
-func (f *FlagSet) CountVar(p *int, name string, usage string) {
-	f.CountVarP(p, name, "", usage)
+func (f *FlagSet) CountVar(p *int, name string, usage string, validation ...func(value any) error) {
+	f.CountVarP(p, name, "", usage, validation...)
 }
 
 // CountVarP is like CountVar only take a shorthand for the flag name.
-func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string) {
-	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage)
+func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string, validation ...func(value any) error) {
+	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage, validation...)
 	flag.NoOptDefVal = "+1"
 }
 
 // CountVar like CountVar only the flag is placed on the CommandLine instead of a given flag set
-func CountVar(p *int, name string, usage string) {
-	CommandLine.CountVar(p, name, usage)
+func CountVar(p *int, name string, usage string, validation ...func(value any) error) {
+	CommandLine.CountVar(p, name, usage, validation...)
 }
 
 // CountVarP is like CountVar only take a shorthand for the flag name.
-func CountVarP(p *int, name, shorthand string, usage string) {
-	CommandLine.CountVarP(p, name, shorthand, usage)
+func CountVarP(p *int, name, shorthand string, usage string, validation ...func(value any) error) {
+	CommandLine.CountVarP(p, name, shorthand, usage, validation...)
 }
 
 // Count defines a count flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 // A count flag will add 1 to its value every time it is found on the command line
-func (f *FlagSet) Count(name string, usage string) *int {
+func (f *FlagSet) Count(name string, usage string, validation ...func(value any) error) *int {
 	p := new(int)
-	f.CountVarP(p, name, "", usage)
+	f.CountVarP(p, name, "", usage, validation...)
 	return p
 }
 
 // CountP is like Count only takes a shorthand for the flag name.
-func (f *FlagSet) CountP(name, shorthand string, usage string) *int {
+func (f *FlagSet) CountP(name, shorthand string, usage string, validation ...func(value any) error) *int {
 	p := new(int)
-	f.CountVarP(p, name, shorthand, usage)
+	f.CountVarP(p, name, shorthand, usage, validation...)
 	return p
 }
 
 // Count defines a count flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 // A count flag will add 1 to its value evey time it is found on the command line
-func Count(name string, usage string) *int {
-	return CommandLine.CountP(name, "", usage)
+func Count(name string, usage string, validation ...func(value any) error) *int {
+	return CommandLine.CountP(name, "", usage, validation...)
 }
 
 // CountP is like Count only takes a shorthand for the flag name.
-func CountP(name, shorthand string, usage string) *int {
-	return CommandLine.CountP(name, shorthand, usage)
+func CountP(name, shorthand string, usage string, validation ...func(value any) error) *int {
+	return CommandLine.CountP(name, shorthand, usage, validation...)
 }

--- a/count.go
+++ b/count.go
@@ -47,37 +47,43 @@ func (f *FlagSet) GetCount(name string) (int, error) {
 // CountVar defines a count flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 // A count flag will add 1 to its value every time it is found on the command line
-func (f *FlagSet) CountVar(p *int, name string, usage string, validation ...func(value interface{}) error) {
+func (f *FlagSet) CountVar(p *int, name string, usage string, validation ...func(value int) error) {
 	f.CountVarP(p, name, "", usage, validation...)
 }
 
 // CountVarP is like CountVar only take a shorthand for the flag name.
-func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string, validation ...func(value interface{}) error) {
-	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage, validation...)
+func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string, validation ...func(value int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		flag := f.VarPF(newCountValue(0, p), name, shorthand, usage, validationFunc)
+		flag.NoOptDefVal = "+1"
+		return
+	}
+	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage)
 	flag.NoOptDefVal = "+1"
 }
 
 // CountVar like CountVar only the flag is placed on the CommandLine instead of a given flag set
-func CountVar(p *int, name string, usage string, validation ...func(value interface{}) error) {
+func CountVar(p *int, name string, usage string, validation ...func(value int) error) {
 	CommandLine.CountVar(p, name, usage, validation...)
 }
 
 // CountVarP is like CountVar only take a shorthand for the flag name.
-func CountVarP(p *int, name, shorthand string, usage string, validation ...func(value interface{}) error) {
+func CountVarP(p *int, name, shorthand string, usage string, validation ...func(value int) error) {
 	CommandLine.CountVarP(p, name, shorthand, usage, validation...)
 }
 
 // Count defines a count flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 // A count flag will add 1 to its value every time it is found on the command line
-func (f *FlagSet) Count(name string, usage string, validation ...func(value interface{}) error) *int {
+func (f *FlagSet) Count(name string, usage string, validation ...func(value int) error) *int {
 	p := new(int)
 	f.CountVarP(p, name, "", usage, validation...)
 	return p
 }
 
 // CountP is like Count only takes a shorthand for the flag name.
-func (f *FlagSet) CountP(name, shorthand string, usage string, validation ...func(value interface{}) error) *int {
+func (f *FlagSet) CountP(name, shorthand string, usage string, validation ...func(value int) error) *int {
 	p := new(int)
 	f.CountVarP(p, name, shorthand, usage, validation...)
 	return p
@@ -86,11 +92,11 @@ func (f *FlagSet) CountP(name, shorthand string, usage string, validation ...fun
 // Count defines a count flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 // A count flag will add 1 to its value evey time it is found on the command line
-func Count(name string, usage string, validation ...func(value interface{}) error) *int {
+func Count(name string, usage string, validation ...func(value int) error) *int {
 	return CommandLine.CountP(name, "", usage, validation...)
 }
 
 // CountP is like Count only takes a shorthand for the flag name.
-func CountP(name, shorthand string, usage string, validation ...func(value interface{}) error) *int {
+func CountP(name, shorthand string, usage string, validation ...func(value int) error) *int {
 	return CommandLine.CountP(name, shorthand, usage, validation...)
 }

--- a/count.go
+++ b/count.go
@@ -47,37 +47,37 @@ func (f *FlagSet) GetCount(name string) (int, error) {
 // CountVar defines a count flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 // A count flag will add 1 to its value every time it is found on the command line
-func (f *FlagSet) CountVar(p *int, name string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) CountVar(p *int, name string, usage string, validation ...func(value interface{}) error) {
 	f.CountVarP(p, name, "", usage, validation...)
 }
 
 // CountVarP is like CountVar only take a shorthand for the flag name.
-func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string, validation ...func(value interface{}) error) {
 	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage, validation...)
 	flag.NoOptDefVal = "+1"
 }
 
 // CountVar like CountVar only the flag is placed on the CommandLine instead of a given flag set
-func CountVar(p *int, name string, usage string, validation ...func(value any) error) {
+func CountVar(p *int, name string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.CountVar(p, name, usage, validation...)
 }
 
 // CountVarP is like CountVar only take a shorthand for the flag name.
-func CountVarP(p *int, name, shorthand string, usage string, validation ...func(value any) error) {
+func CountVarP(p *int, name, shorthand string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.CountVarP(p, name, shorthand, usage, validation...)
 }
 
 // Count defines a count flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 // A count flag will add 1 to its value every time it is found on the command line
-func (f *FlagSet) Count(name string, usage string, validation ...func(value any) error) *int {
+func (f *FlagSet) Count(name string, usage string, validation ...func(value interface{}) error) *int {
 	p := new(int)
 	f.CountVarP(p, name, "", usage, validation...)
 	return p
 }
 
 // CountP is like Count only takes a shorthand for the flag name.
-func (f *FlagSet) CountP(name, shorthand string, usage string, validation ...func(value any) error) *int {
+func (f *FlagSet) CountP(name, shorthand string, usage string, validation ...func(value interface{}) error) *int {
 	p := new(int)
 	f.CountVarP(p, name, shorthand, usage, validation...)
 	return p
@@ -86,11 +86,11 @@ func (f *FlagSet) CountP(name, shorthand string, usage string, validation ...fun
 // Count defines a count flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 // A count flag will add 1 to its value evey time it is found on the command line
-func Count(name string, usage string, validation ...func(value any) error) *int {
+func Count(name string, usage string, validation ...func(value interface{}) error) *int {
 	return CommandLine.CountP(name, "", usage, validation...)
 }
 
 // CountP is like Count only takes a shorthand for the flag name.
-func CountP(name, shorthand string, usage string, validation ...func(value any) error) *int {
+func CountP(name, shorthand string, usage string, validation ...func(value interface{}) error) *int {
 	return CommandLine.CountP(name, shorthand, usage, validation...)
 }

--- a/duration.go
+++ b/duration.go
@@ -39,36 +39,56 @@ func (f *FlagSet) GetDuration(name string) (time.Duration, error) {
 
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
-func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newDurationValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value time.Duration) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newDurationValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newDurationValue(value, p), name, "", usage)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newDurationValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value time.Duration) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newDurationValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newDurationValue(value, p), name, shorthand, usage)
 }
 
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
-func DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newDurationValue(value, p), name, "", usage, validation...)
+func DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value time.Duration) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newDurationValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newDurationValue(value, p), name, "", usage)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
-func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage, validation...)
+func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value time.Duration) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage)
 }
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a time.Duration variable that stores the value of the flag.
-func (f *FlagSet) Duration(name string, value time.Duration, usage string, validation ...func(value interface{}) error) *time.Duration {
+func (f *FlagSet) Duration(name string, value time.Duration, usage string, validation ...func(value time.Duration) error) *time.Duration {
 	p := new(time.Duration)
 	f.DurationVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value interface{}) error) *time.Duration {
+func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value time.Duration) error) *time.Duration {
 	p := new(time.Duration)
 	f.DurationVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -76,11 +96,11 @@ func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage s
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a time.Duration variable that stores the value of the flag.
-func Duration(name string, value time.Duration, usage string, validation ...func(value interface{}) error) *time.Duration {
+func Duration(name string, value time.Duration, usage string, validation ...func(value time.Duration) error) *time.Duration {
 	return CommandLine.DurationP(name, "", value, usage, validation...)
 }
 
 // DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
-func DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value interface{}) error) *time.Duration {
+func DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value time.Duration) error) *time.Duration {
 	return CommandLine.DurationP(name, shorthand, value, usage, validation...)
 }

--- a/duration.go
+++ b/duration.go
@@ -39,48 +39,48 @@ func (f *FlagSet) GetDuration(name string) (time.Duration, error) {
 
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
-func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
-	f.VarP(newDurationValue(value, p), name, "", usage)
+func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value any) error) {
+	f.VarP(newDurationValue(value, p), name, "", usage, validation...)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
-	f.VarP(newDurationValue(value, p), name, shorthand, usage)
+func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value any) error) {
+	f.VarP(newDurationValue(value, p), name, shorthand, usage, validation...)
 }
 
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
-func DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
-	CommandLine.VarP(newDurationValue(value, p), name, "", usage)
+func DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newDurationValue(value, p), name, "", usage, validation...)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
-func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
-	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage)
+func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a time.Duration variable that stores the value of the flag.
-func (f *FlagSet) Duration(name string, value time.Duration, usage string) *time.Duration {
+func (f *FlagSet) Duration(name string, value time.Duration, usage string, validation ...func(value any) error) *time.Duration {
 	p := new(time.Duration)
-	f.DurationVarP(p, name, "", value, usage)
+	f.DurationVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage string) *time.Duration {
+func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value any) error) *time.Duration {
 	p := new(time.Duration)
-	f.DurationVarP(p, name, shorthand, value, usage)
+	f.DurationVarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a time.Duration variable that stores the value of the flag.
-func Duration(name string, value time.Duration, usage string) *time.Duration {
-	return CommandLine.DurationP(name, "", value, usage)
+func Duration(name string, value time.Duration, usage string, validation ...func(value any) error) *time.Duration {
+	return CommandLine.DurationP(name, "", value, usage, validation...)
 }
 
 // DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
-func DurationP(name, shorthand string, value time.Duration, usage string) *time.Duration {
-	return CommandLine.DurationP(name, shorthand, value, usage)
+func DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value any) error) *time.Duration {
+	return CommandLine.DurationP(name, shorthand, value, usage, validation...)
 }

--- a/duration.go
+++ b/duration.go
@@ -39,36 +39,36 @@ func (f *FlagSet) GetDuration(name string) (time.Duration, error) {
 
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
-func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value any) error) {
+func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newDurationValue(value, p), name, "", usage, validation...)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value any) error) {
+func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newDurationValue(value, p), name, shorthand, usage, validation...)
 }
 
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
-func DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value any) error) {
+func DurationVar(p *time.Duration, name string, value time.Duration, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newDurationValue(value, p), name, "", usage, validation...)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
-func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value any) error) {
+func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a time.Duration variable that stores the value of the flag.
-func (f *FlagSet) Duration(name string, value time.Duration, usage string, validation ...func(value any) error) *time.Duration {
+func (f *FlagSet) Duration(name string, value time.Duration, usage string, validation ...func(value interface{}) error) *time.Duration {
 	p := new(time.Duration)
 	f.DurationVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value any) error) *time.Duration {
+func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value interface{}) error) *time.Duration {
 	p := new(time.Duration)
 	f.DurationVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -76,11 +76,11 @@ func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage s
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a time.Duration variable that stores the value of the flag.
-func Duration(name string, value time.Duration, usage string, validation ...func(value any) error) *time.Duration {
+func Duration(name string, value time.Duration, usage string, validation ...func(value interface{}) error) *time.Duration {
 	return CommandLine.DurationP(name, "", value, usage, validation...)
 }
 
 // DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
-func DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value any) error) *time.Duration {
+func DurationP(name, shorthand string, value time.Duration, usage string, validation ...func(value interface{}) error) *time.Duration {
 	return CommandLine.DurationP(name, shorthand, value, usage, validation...)
 }

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -119,36 +119,36 @@ func (f *FlagSet) GetDurationSlice(name string) ([]time.Duration, error) {
 
 // DurationSliceVar defines a durationSlice flag with specified name, default value, and usage string.
 // The argument p points to a []time.Duration variable in which to store the value of the flag.
-func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value any) error) {
+func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newDurationSliceValue(value, p), name, "", usage, validation...)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value any) error) {
+func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // DurationSliceVar defines a duration[] flag with specified name, default value, and usage string.
 // The argument p points to a duration[] variable in which to store the value of the flag.
-func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value any) error) {
+func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage, validation...)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value any) error) {
+func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a []time.Duration variable that stores the value of the flag.
-func (f *FlagSet) DurationSlice(name string, value []time.Duration, usage string, validation ...func(value any) error) *[]time.Duration {
+func (f *FlagSet) DurationSlice(name string, value []time.Duration, usage string, validation ...func(value interface{}) error) *[]time.Duration {
 	p := []time.Duration{}
 	f.DurationSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value any) error) *[]time.Duration {
+func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value interface{}) error) *[]time.Duration {
 	p := []time.Duration{}
 	f.DurationSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -156,11 +156,11 @@ func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, 
 
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a []time.Duration variable that stores the value of the flag.
-func DurationSlice(name string, value []time.Duration, usage string, validation ...func(value any) error) *[]time.Duration {
+func DurationSlice(name string, value []time.Duration, usage string, validation ...func(value interface{}) error) *[]time.Duration {
 	return CommandLine.DurationSliceP(name, "", value, usage, validation...)
 }
 
 // DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
-func DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value any) error) *[]time.Duration {
+func DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value interface{}) error) *[]time.Duration {
 	return CommandLine.DurationSliceP(name, shorthand, value, usage, validation...)
 }

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -119,48 +119,48 @@ func (f *FlagSet) GetDurationSlice(name string) ([]time.Duration, error) {
 
 // DurationSliceVar defines a durationSlice flag with specified name, default value, and usage string.
 // The argument p points to a []time.Duration variable in which to store the value of the flag.
-func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
-	f.VarP(newDurationSliceValue(value, p), name, "", usage)
+func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value any) error) {
+	f.VarP(newDurationSliceValue(value, p), name, "", usage, validation...)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
-	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value any) error) {
+	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // DurationSliceVar defines a duration[] flag with specified name, default value, and usage string.
 // The argument p points to a duration[] variable in which to store the value of the flag.
-func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
-	CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage)
+func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage, validation...)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
-	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a []time.Duration variable that stores the value of the flag.
-func (f *FlagSet) DurationSlice(name string, value []time.Duration, usage string) *[]time.Duration {
+func (f *FlagSet) DurationSlice(name string, value []time.Duration, usage string, validation ...func(value any) error) *[]time.Duration {
 	p := []time.Duration{}
-	f.DurationSliceVarP(&p, name, "", value, usage)
+	f.DurationSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
+func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value any) error) *[]time.Duration {
 	p := []time.Duration{}
-	f.DurationSliceVarP(&p, name, shorthand, value, usage)
+	f.DurationSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a []time.Duration variable that stores the value of the flag.
-func DurationSlice(name string, value []time.Duration, usage string) *[]time.Duration {
-	return CommandLine.DurationSliceP(name, "", value, usage)
+func DurationSlice(name string, value []time.Duration, usage string, validation ...func(value any) error) *[]time.Duration {
+	return CommandLine.DurationSliceP(name, "", value, usage, validation...)
 }
 
 // DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
-func DurationSliceP(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
-	return CommandLine.DurationSliceP(name, shorthand, value, usage)
+func DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value any) error) *[]time.Duration {
+	return CommandLine.DurationSliceP(name, shorthand, value, usage, validation...)
 }

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -119,36 +119,56 @@ func (f *FlagSet) GetDurationSlice(name string) ([]time.Duration, error) {
 
 // DurationSliceVar defines a durationSlice flag with specified name, default value, and usage string.
 // The argument p points to a []time.Duration variable in which to store the value of the flag.
-func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newDurationSliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value []time.Duration) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newDurationSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newDurationSliceValue(value, p), name, "", usage)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value []time.Duration) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newDurationSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
 }
 
 // DurationSliceVar defines a duration[] flag with specified name, default value, and usage string.
 // The argument p points to a duration[] variable in which to store the value of the flag.
-func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage, validation...)
+func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string, validation ...func(value []time.Duration) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage, validation...)
+func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string, validation ...func(value []time.Duration) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
 }
 
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a []time.Duration variable that stores the value of the flag.
-func (f *FlagSet) DurationSlice(name string, value []time.Duration, usage string, validation ...func(value interface{}) error) *[]time.Duration {
+func (f *FlagSet) DurationSlice(name string, value []time.Duration, usage string, validation ...func(value []time.Duration) error) *[]time.Duration {
 	p := []time.Duration{}
 	f.DurationSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value interface{}) error) *[]time.Duration {
+func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value []time.Duration) error) *[]time.Duration {
 	p := []time.Duration{}
 	f.DurationSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -156,11 +176,11 @@ func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, 
 
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a []time.Duration variable that stores the value of the flag.
-func DurationSlice(name string, value []time.Duration, usage string, validation ...func(value interface{}) error) *[]time.Duration {
+func DurationSlice(name string, value []time.Duration, usage string, validation ...func(value []time.Duration) error) *[]time.Duration {
 	return CommandLine.DurationSliceP(name, "", value, usage, validation...)
 }
 
 // DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
-func DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value interface{}) error) *[]time.Duration {
+func DurationSliceP(name, shorthand string, value []time.Duration, usage string, validation ...func(value []time.Duration) error) *[]time.Duration {
 	return CommandLine.DurationSliceP(name, shorthand, value, usage, validation...)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ package pflag_test
 import (
 	"fmt"
 
-	"github.com/erfanmomeniii/pflag"
+	"github.com/spf13/pflag"
 )
 
 func ExampleShorthandLookup() {

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ package pflag_test
 import (
 	"fmt"
 
-	"github.com/spf13/pflag"
+	"github.com/erfanmomeniii/pflag"
 )
 
 func ExampleShorthandLookup() {

--- a/flag.go
+++ b/flag.go
@@ -16,7 +16,7 @@ pflag is a drop-in replacement of Go's native flag package. If you import
 pflag under the name "flag" then all code should continue to function
 with no changes.
 
-	import flag "github.com/spf13/pflag"
+	import flag "github.com/erfanmomeniii/pflag"
 
 There is one exception to this: if you directly instantiate the Flag struct
 there is one more field "Shorthand" that you will need to set.

--- a/flag.go
+++ b/flag.go
@@ -16,7 +16,7 @@ pflag is a drop-in replacement of Go's native flag package. If you import
 pflag under the name "flag" then all code should continue to function
 with no changes.
 
-	import flag "github.com/erfanmomeniii/pflag"
+	import flag "github.com/spf13/pflag"
 
 There is one exception to this: if you directly instantiate the Flag struct
 there is one more field "Shorthand" that you will need to set.

--- a/flag.go
+++ b/flag.go
@@ -182,18 +182,18 @@ type FlagSet struct {
 
 // A Flag represents the state of a flag.
 type Flag struct {
-	Name                string                // name as it appears on command line
-	Shorthand           string                // one-letter abbreviated flag
-	Usage               string                // help message
-	Value               Value                 // value as set
-	DefValue            string                // default value (as text); for usage message
-	Changed             bool                  // If the user set the value (or if left to default)
-	NoOptDefVal         string                // default value (as text); if the flag is on the command line without any options
-	Deprecated          string                // If this flag is deprecated, this string is the new or now thing to use
-	Hidden              bool                  // used by cobra.Command to allow flags to be hidden from help/usage text
-	ShorthandDeprecated string                // If the shorthand of this flag is deprecated, this string is the new or now thing to use
-	Annotations         map[string][]string   // used by cobra.Command bash autocomple code
-	Validation          func(value any) error // If you want to add custom validation for the value of the flag
+	Name                string                        // name as it appears on command line
+	Shorthand           string                        // one-letter abbreviated flag
+	Usage               string                        // help message
+	Value               Value                         // value as set
+	DefValue            string                        // default value (as text); for usage message
+	Changed             bool                          // If the user set the value (or if left to default)
+	NoOptDefVal         string                        // default value (as text); if the flag is on the command line without any options
+	Deprecated          string                        // If this flag is deprecated, this string is the new or now thing to use
+	Hidden              bool                          // used by cobra.Command to allow flags to be hidden from help/usage text
+	ShorthandDeprecated string                        // If the shorthand of this flag is deprecated, this string is the new or now thing to use
+	Annotations         map[string][]string           // used by cobra.Command bash autocomple code
+	Validation          func(value interface{}) error // If you want to add custom validation for the value of the flag
 }
 
 // Value is the interface to the dynamic value stored in a flag.
@@ -843,12 +843,12 @@ func Args() []string { return CommandLine.args }
 // caller could create a flag that turns a comma-separated string into a slice
 // of strings by giving the slice the methods of Value; in particular, Set would
 // decompose the comma-separated string into the slice.
-func (f *FlagSet) Var(value Value, name string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Var(value Value, name string, usage string, validation ...func(value interface{}) error) {
 	f.VarP(value, name, "", usage, validation[0])
 }
 
 // VarPF is like VarP, but returns the flag created
-func (f *FlagSet) VarPF(value Value, name, shorthand, usage string, validation ...func(value any) error) *Flag {
+func (f *FlagSet) VarPF(value Value, name, shorthand, usage string, validation ...func(value interface{}) error) *Flag {
 	// Remember the default value as a string; it won't change.
 	flag := &Flag{
 		Name:       name,
@@ -863,7 +863,7 @@ func (f *FlagSet) VarPF(value Value, name, shorthand, usage string, validation .
 }
 
 // VarP is like Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) VarP(value Value, name, shorthand, usage string, validation ...func(value any) error) {
+func (f *FlagSet) VarP(value Value, name, shorthand, usage string, validation ...func(value interface{}) error) {
 	f.VarPF(value, name, shorthand, usage, validation[0])
 }
 
@@ -925,12 +925,12 @@ func (f *FlagSet) AddFlagSet(newSet *FlagSet) {
 // caller could create a flag that turns a comma-separated string into a slice
 // of strings by giving the slice the methods of Value; in particular, Set would
 // decompose the comma-separated string into the slice.
-func Var(value Value, name string, usage string, validation ...func(value any) error) {
+func Var(value Value, name string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(value, name, "", usage, validation[0])
 }
 
 // VarP is like Var, but accepts a shorthand letter that can be used after a single dash.
-func VarP(value Value, name, shorthand, usage string, validation ...func(value any) error) {
+func VarP(value Value, name, shorthand, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(value, name, shorthand, usage, validation[0])
 }
 

--- a/flag.go
+++ b/flag.go
@@ -844,11 +844,17 @@ func Args() []string { return CommandLine.args }
 // of strings by giving the slice the methods of Value; in particular, Set would
 // decompose the comma-separated string into the slice.
 func (f *FlagSet) Var(value Value, name string, usage string, validation ...func(value interface{}) error) {
-	f.VarP(value, name, "", usage, validation[0])
+	f.VarP(value, name, "", usage, validation...)
 }
 
 // VarPF is like VarP, but returns the flag created
 func (f *FlagSet) VarPF(value Value, name, shorthand, usage string, validation ...func(value interface{}) error) *Flag {
+	var validationFunc func(value interface{}) error
+
+	if len(validation) > 0 {
+		validationFunc = validation[0]
+	}
+
 	// Remember the default value as a string; it won't change.
 	flag := &Flag{
 		Name:       name,
@@ -856,7 +862,7 @@ func (f *FlagSet) VarPF(value Value, name, shorthand, usage string, validation .
 		Usage:      usage,
 		Value:      value,
 		DefValue:   value.String(),
-		Validation: validation[0],
+		Validation: validationFunc,
 	}
 	f.AddFlag(flag)
 	return flag
@@ -864,7 +870,7 @@ func (f *FlagSet) VarPF(value Value, name, shorthand, usage string, validation .
 
 // VarP is like Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) VarP(value Value, name, shorthand, usage string, validation ...func(value interface{}) error) {
-	f.VarPF(value, name, shorthand, usage, validation[0])
+	f.VarPF(value, name, shorthand, usage, validation...)
 }
 
 // AddFlag will add the flag to the FlagSet

--- a/float32.go
+++ b/float32.go
@@ -41,36 +41,36 @@ func (f *FlagSet) GetFloat32(name string) (float32, error) {
 
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
-func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newFloat32Value(value, p), name, "", usage, validation...)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newFloat32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
-func Float32Var(p *float32, name string, value float32, usage string, validation ...func(value any) error) {
+func Float32Var(p *float32, name string, value float32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newFloat32Value(value, p), name, "", usage, validation...)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
-func Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value any) error) {
+func Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.
 // The return value is the address of a float32 variable that stores the value of the flag.
-func (f *FlagSet) Float32(name string, value float32, usage string, validation ...func(value any) error) *float32 {
+func (f *FlagSet) Float32(name string, value float32, usage string, validation ...func(value interface{}) error) *float32 {
 	p := new(float32)
 	f.Float32VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string, validation ...func(value any) error) *float32 {
+func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string, validation ...func(value interface{}) error) *float32 {
 	p := new(float32)
 	f.Float32VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +78,11 @@ func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string, 
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.
 // The return value is the address of a float32 variable that stores the value of the flag.
-func Float32(name string, value float32, usage string, validation ...func(value any) error) *float32 {
+func Float32(name string, value float32, usage string, validation ...func(value interface{}) error) *float32 {
 	return CommandLine.Float32P(name, "", value, usage, validation...)
 }
 
 // Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
-func Float32P(name, shorthand string, value float32, usage string, validation ...func(value any) error) *float32 {
+func Float32P(name, shorthand string, value float32, usage string, validation ...func(value interface{}) error) *float32 {
 	return CommandLine.Float32P(name, shorthand, value, usage, validation...)
 }

--- a/float32.go
+++ b/float32.go
@@ -41,48 +41,48 @@ func (f *FlagSet) GetFloat32(name string) (float32, error) {
 
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
-func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string) {
-	f.VarP(newFloat32Value(value, p), name, "", usage)
+func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string, validation ...func(value any) error) {
+	f.VarP(newFloat32Value(value, p), name, "", usage, validation...)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
-	f.VarP(newFloat32Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value any) error) {
+	f.VarP(newFloat32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
-func Float32Var(p *float32, name string, value float32, usage string) {
-	CommandLine.VarP(newFloat32Value(value, p), name, "", usage)
+func Float32Var(p *float32, name string, value float32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newFloat32Value(value, p), name, "", usage, validation...)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
-func Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
-	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage)
+func Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.
 // The return value is the address of a float32 variable that stores the value of the flag.
-func (f *FlagSet) Float32(name string, value float32, usage string) *float32 {
+func (f *FlagSet) Float32(name string, value float32, usage string, validation ...func(value any) error) *float32 {
 	p := new(float32)
-	f.Float32VarP(p, name, "", value, usage)
+	f.Float32VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string) *float32 {
+func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string, validation ...func(value any) error) *float32 {
 	p := new(float32)
-	f.Float32VarP(p, name, shorthand, value, usage)
+	f.Float32VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.
 // The return value is the address of a float32 variable that stores the value of the flag.
-func Float32(name string, value float32, usage string) *float32 {
-	return CommandLine.Float32P(name, "", value, usage)
+func Float32(name string, value float32, usage string, validation ...func(value any) error) *float32 {
+	return CommandLine.Float32P(name, "", value, usage, validation...)
 }
 
 // Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
-func Float32P(name, shorthand string, value float32, usage string) *float32 {
-	return CommandLine.Float32P(name, shorthand, value, usage)
+func Float32P(name, shorthand string, value float32, usage string, validation ...func(value any) error) *float32 {
+	return CommandLine.Float32P(name, shorthand, value, usage, validation...)
 }

--- a/float32.go
+++ b/float32.go
@@ -41,36 +41,56 @@ func (f *FlagSet) GetFloat32(name string) (float32, error) {
 
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
-func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newFloat32Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string, validation ...func(value float32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newFloat32Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newFloat32Value(value, p), name, "", usage)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newFloat32Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value float32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newFloat32Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newFloat32Value(value, p), name, shorthand, usage)
 }
 
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
-func Float32Var(p *float32, name string, value float32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newFloat32Value(value, p), name, "", usage, validation...)
+func Float32Var(p *float32, name string, value float32, usage string, validation ...func(value float32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newFloat32Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newFloat32Value(value, p), name, "", usage)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
-func Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage, validation...)
+func Float32VarP(p *float32, name, shorthand string, value float32, usage string, validation ...func(value float32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage)
 }
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.
 // The return value is the address of a float32 variable that stores the value of the flag.
-func (f *FlagSet) Float32(name string, value float32, usage string, validation ...func(value interface{}) error) *float32 {
+func (f *FlagSet) Float32(name string, value float32, usage string, validation ...func(value float32) error) *float32 {
 	p := new(float32)
 	f.Float32VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string, validation ...func(value interface{}) error) *float32 {
+func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string, validation ...func(value float32) error) *float32 {
 	p := new(float32)
 	f.Float32VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +98,11 @@ func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string, 
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.
 // The return value is the address of a float32 variable that stores the value of the flag.
-func Float32(name string, value float32, usage string, validation ...func(value interface{}) error) *float32 {
+func Float32(name string, value float32, usage string, validation ...func(value float32) error) *float32 {
 	return CommandLine.Float32P(name, "", value, usage, validation...)
 }
 
 // Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
-func Float32P(name, shorthand string, value float32, usage string, validation ...func(value interface{}) error) *float32 {
+func Float32P(name, shorthand string, value float32, usage string, validation ...func(value float32) error) *float32 {
 	return CommandLine.Float32P(name, shorthand, value, usage, validation...)
 }

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -127,48 +127,48 @@ func (f *FlagSet) GetFloat32Slice(name string) ([]float32, error) {
 
 // Float32SliceVar defines a float32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float32 variable in which to store the value of the flag.
-func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
-	f.VarP(newFloat32SliceValue(value, p), name, "", usage)
+func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value any) error) {
+	f.VarP(newFloat32SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string) {
-	f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value any) error) {
+	f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Float32SliceVar defines a float32[] flag with specified name, default value, and usage string.
 // The argument p points to a float32[] variable in which to store the value of the flag.
-func Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
-	CommandLine.VarP(newFloat32SliceValue(value, p), name, "", usage)
+func Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newFloat32SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string) {
-	CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
+func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.
 // The return value is the address of a []float32 variable that stores the value of the flag.
-func (f *FlagSet) Float32Slice(name string, value []float32, usage string) *[]float32 {
+func (f *FlagSet) Float32Slice(name string, value []float32, usage string, validation ...func(value any) error) *[]float32 {
 	p := []float32{}
-	f.Float32SliceVarP(&p, name, "", value, usage)
+	f.Float32SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage string) *[]float32 {
+func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value any) error) *[]float32 {
 	p := []float32{}
-	f.Float32SliceVarP(&p, name, shorthand, value, usage)
+	f.Float32SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.
 // The return value is the address of a []float32 variable that stores the value of the flag.
-func Float32Slice(name string, value []float32, usage string) *[]float32 {
-	return CommandLine.Float32SliceP(name, "", value, usage)
+func Float32Slice(name string, value []float32, usage string, validation ...func(value any) error) *[]float32 {
+	return CommandLine.Float32SliceP(name, "", value, usage, validation...)
 }
 
 // Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
-func Float32SliceP(name, shorthand string, value []float32, usage string) *[]float32 {
-	return CommandLine.Float32SliceP(name, shorthand, value, usage)
+func Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value any) error) *[]float32 {
+	return CommandLine.Float32SliceP(name, shorthand, value, usage, validation...)
 }

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -127,36 +127,36 @@ func (f *FlagSet) GetFloat32Slice(name string) ([]float32, error) {
 
 // Float32SliceVar defines a float32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float32 variable in which to store the value of the flag.
-func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newFloat32SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Float32SliceVar defines a float32[] flag with specified name, default value, and usage string.
 // The argument p points to a float32[] variable in which to store the value of the flag.
-func Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value any) error) {
+func Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newFloat32SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value any) error) {
+func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.
 // The return value is the address of a []float32 variable that stores the value of the flag.
-func (f *FlagSet) Float32Slice(name string, value []float32, usage string, validation ...func(value any) error) *[]float32 {
+func (f *FlagSet) Float32Slice(name string, value []float32, usage string, validation ...func(value interface{}) error) *[]float32 {
 	p := []float32{}
 	f.Float32SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value any) error) *[]float32 {
+func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value interface{}) error) *[]float32 {
 	p := []float32{}
 	f.Float32SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -164,11 +164,11 @@ func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage s
 
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.
 // The return value is the address of a []float32 variable that stores the value of the flag.
-func Float32Slice(name string, value []float32, usage string, validation ...func(value any) error) *[]float32 {
+func Float32Slice(name string, value []float32, usage string, validation ...func(value interface{}) error) *[]float32 {
 	return CommandLine.Float32SliceP(name, "", value, usage, validation...)
 }
 
 // Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
-func Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value any) error) *[]float32 {
+func Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value interface{}) error) *[]float32 {
 	return CommandLine.Float32SliceP(name, shorthand, value, usage, validation...)
 }

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -127,36 +127,56 @@ func (f *FlagSet) GetFloat32Slice(name string) ([]float32, error) {
 
 // Float32SliceVar defines a float32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float32 variable in which to store the value of the flag.
-func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newFloat32SliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value []float32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newFloat32SliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newFloat32SliceValue(value, p), name, "", usage)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value []float32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float32SliceVar defines a float32[] flag with specified name, default value, and usage string.
 // The argument p points to a float32[] variable in which to store the value of the flag.
-func Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newFloat32SliceValue(value, p), name, "", usage, validation...)
+func Float32SliceVar(p *[]float32, name string, value []float32, usage string, validation ...func(value []float32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newFloat32SliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newFloat32SliceValue(value, p), name, "", usage)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage, validation...)
+func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string, validation ...func(value []float32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.
 // The return value is the address of a []float32 variable that stores the value of the flag.
-func (f *FlagSet) Float32Slice(name string, value []float32, usage string, validation ...func(value interface{}) error) *[]float32 {
+func (f *FlagSet) Float32Slice(name string, value []float32, usage string, validation ...func(value []float32) error) *[]float32 {
 	p := []float32{}
 	f.Float32SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value interface{}) error) *[]float32 {
+func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value []float32) error) *[]float32 {
 	p := []float32{}
 	f.Float32SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -164,11 +184,11 @@ func (f *FlagSet) Float32SliceP(name, shorthand string, value []float32, usage s
 
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.
 // The return value is the address of a []float32 variable that stores the value of the flag.
-func Float32Slice(name string, value []float32, usage string, validation ...func(value interface{}) error) *[]float32 {
+func Float32Slice(name string, value []float32, usage string, validation ...func(value []float32) error) *[]float32 {
 	return CommandLine.Float32SliceP(name, "", value, usage, validation...)
 }
 
 // Float32SliceP is like Float32Slice, but accepts a shorthand letter that can be used after a single dash.
-func Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value interface{}) error) *[]float32 {
+func Float32SliceP(name, shorthand string, value []float32, usage string, validation ...func(value []float32) error) *[]float32 {
 	return CommandLine.Float32SliceP(name, shorthand, value, usage, validation...)
 }

--- a/float64.go
+++ b/float64.go
@@ -37,36 +37,36 @@ func (f *FlagSet) GetFloat64(name string) (float64, error) {
 
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
-func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newFloat64Value(value, p), name, "", usage, validation...)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newFloat64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
-func Float64Var(p *float64, name string, value float64, usage string, validation ...func(value any) error) {
+func Float64Var(p *float64, name string, value float64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newFloat64Value(value, p), name, "", usage, validation...)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
-func Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value any) error) {
+func Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.
 // The return value is the address of a float64 variable that stores the value of the flag.
-func (f *FlagSet) Float64(name string, value float64, usage string, validation ...func(value any) error) *float64 {
+func (f *FlagSet) Float64(name string, value float64, usage string, validation ...func(value interface{}) error) *float64 {
 	p := new(float64)
 	f.Float64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string, validation ...func(value any) error) *float64 {
+func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string, validation ...func(value interface{}) error) *float64 {
 	p := new(float64)
 	f.Float64VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -74,11 +74,11 @@ func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string, 
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.
 // The return value is the address of a float64 variable that stores the value of the flag.
-func Float64(name string, value float64, usage string, validation ...func(value any) error) *float64 {
+func Float64(name string, value float64, usage string, validation ...func(value interface{}) error) *float64 {
 	return CommandLine.Float64P(name, "", value, usage, validation...)
 }
 
 // Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
-func Float64P(name, shorthand string, value float64, usage string, validation ...func(value any) error) *float64 {
+func Float64P(name, shorthand string, value float64, usage string, validation ...func(value interface{}) error) *float64 {
 	return CommandLine.Float64P(name, shorthand, value, usage, validation...)
 }

--- a/float64.go
+++ b/float64.go
@@ -37,36 +37,56 @@ func (f *FlagSet) GetFloat64(name string) (float64, error) {
 
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
-func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newFloat64Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string, validation ...func(value float64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newFloat64Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newFloat64Value(value, p), name, "", usage)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newFloat64Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value float64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newFloat64Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newFloat64Value(value, p), name, shorthand, usage)
 }
 
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
-func Float64Var(p *float64, name string, value float64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newFloat64Value(value, p), name, "", usage, validation...)
+func Float64Var(p *float64, name string, value float64, usage string, validation ...func(value float64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newFloat64Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newFloat64Value(value, p), name, "", usage)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
-func Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage, validation...)
+func Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value float64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage)
 }
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.
 // The return value is the address of a float64 variable that stores the value of the flag.
-func (f *FlagSet) Float64(name string, value float64, usage string, validation ...func(value interface{}) error) *float64 {
+func (f *FlagSet) Float64(name string, value float64, usage string, validation ...func(value float64) error) *float64 {
 	p := new(float64)
 	f.Float64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string, validation ...func(value interface{}) error) *float64 {
+func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string, validation ...func(value float64) error) *float64 {
 	p := new(float64)
 	f.Float64VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -74,11 +94,11 @@ func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string, 
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.
 // The return value is the address of a float64 variable that stores the value of the flag.
-func Float64(name string, value float64, usage string, validation ...func(value interface{}) error) *float64 {
+func Float64(name string, value float64, usage string, validation ...func(value float64) error) *float64 {
 	return CommandLine.Float64P(name, "", value, usage, validation...)
 }
 
 // Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
-func Float64P(name, shorthand string, value float64, usage string, validation ...func(value interface{}) error) *float64 {
+func Float64P(name, shorthand string, value float64, usage string, validation ...func(value float64) error) *float64 {
 	return CommandLine.Float64P(name, shorthand, value, usage, validation...)
 }

--- a/float64.go
+++ b/float64.go
@@ -37,48 +37,48 @@ func (f *FlagSet) GetFloat64(name string) (float64, error) {
 
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
-func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string) {
-	f.VarP(newFloat64Value(value, p), name, "", usage)
+func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string, validation ...func(value any) error) {
+	f.VarP(newFloat64Value(value, p), name, "", usage, validation...)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
-	f.VarP(newFloat64Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value any) error) {
+	f.VarP(newFloat64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
-func Float64Var(p *float64, name string, value float64, usage string) {
-	CommandLine.VarP(newFloat64Value(value, p), name, "", usage)
+func Float64Var(p *float64, name string, value float64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newFloat64Value(value, p), name, "", usage, validation...)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
-func Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
-	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage)
+func Float64VarP(p *float64, name, shorthand string, value float64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.
 // The return value is the address of a float64 variable that stores the value of the flag.
-func (f *FlagSet) Float64(name string, value float64, usage string) *float64 {
+func (f *FlagSet) Float64(name string, value float64, usage string, validation ...func(value any) error) *float64 {
 	p := new(float64)
-	f.Float64VarP(p, name, "", value, usage)
+	f.Float64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string) *float64 {
+func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string, validation ...func(value any) error) *float64 {
 	p := new(float64)
-	f.Float64VarP(p, name, shorthand, value, usage)
+	f.Float64VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.
 // The return value is the address of a float64 variable that stores the value of the flag.
-func Float64(name string, value float64, usage string) *float64 {
-	return CommandLine.Float64P(name, "", value, usage)
+func Float64(name string, value float64, usage string, validation ...func(value any) error) *float64 {
+	return CommandLine.Float64P(name, "", value, usage, validation...)
 }
 
 // Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
-func Float64P(name, shorthand string, value float64, usage string) *float64 {
-	return CommandLine.Float64P(name, shorthand, value, usage)
+func Float64P(name, shorthand string, value float64, usage string, validation ...func(value any) error) *float64 {
+	return CommandLine.Float64P(name, shorthand, value, usage, validation...)
 }

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -119,36 +119,36 @@ func (f *FlagSet) GetFloat64Slice(name string) ([]float64, error) {
 
 // Float64SliceVar defines a float64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float64 variable in which to store the value of the flag.
-func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newFloat64SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Float64SliceVar defines a float64[] flag with specified name, default value, and usage string.
 // The argument p points to a float64[] variable in which to store the value of the flag.
-func Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value any) error) {
+func Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newFloat64SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value any) error) {
+func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.
 // The return value is the address of a []float64 variable that stores the value of the flag.
-func (f *FlagSet) Float64Slice(name string, value []float64, usage string, validation ...func(value any) error) *[]float64 {
+func (f *FlagSet) Float64Slice(name string, value []float64, usage string, validation ...func(value interface{}) error) *[]float64 {
 	p := []float64{}
 	f.Float64SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value any) error) *[]float64 {
+func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value interface{}) error) *[]float64 {
 	p := []float64{}
 	f.Float64SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -156,11 +156,11 @@ func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage s
 
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.
 // The return value is the address of a []float64 variable that stores the value of the flag.
-func Float64Slice(name string, value []float64, usage string, validation ...func(value any) error) *[]float64 {
+func Float64Slice(name string, value []float64, usage string, validation ...func(value interface{}) error) *[]float64 {
 	return CommandLine.Float64SliceP(name, "", value, usage, validation...)
 }
 
 // Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
-func Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value any) error) *[]float64 {
+func Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value interface{}) error) *[]float64 {
 	return CommandLine.Float64SliceP(name, shorthand, value, usage, validation...)
 }

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -119,48 +119,48 @@ func (f *FlagSet) GetFloat64Slice(name string) ([]float64, error) {
 
 // Float64SliceVar defines a float64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float64 variable in which to store the value of the flag.
-func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
-	f.VarP(newFloat64SliceValue(value, p), name, "", usage)
+func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value any) error) {
+	f.VarP(newFloat64SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string) {
-	f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value any) error) {
+	f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Float64SliceVar defines a float64[] flag with specified name, default value, and usage string.
 // The argument p points to a float64[] variable in which to store the value of the flag.
-func Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
-	CommandLine.VarP(newFloat64SliceValue(value, p), name, "", usage)
+func Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newFloat64SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string) {
-	CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
+func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.
 // The return value is the address of a []float64 variable that stores the value of the flag.
-func (f *FlagSet) Float64Slice(name string, value []float64, usage string) *[]float64 {
+func (f *FlagSet) Float64Slice(name string, value []float64, usage string, validation ...func(value any) error) *[]float64 {
 	p := []float64{}
-	f.Float64SliceVarP(&p, name, "", value, usage)
+	f.Float64SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage string) *[]float64 {
+func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value any) error) *[]float64 {
 	p := []float64{}
-	f.Float64SliceVarP(&p, name, shorthand, value, usage)
+	f.Float64SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.
 // The return value is the address of a []float64 variable that stores the value of the flag.
-func Float64Slice(name string, value []float64, usage string) *[]float64 {
-	return CommandLine.Float64SliceP(name, "", value, usage)
+func Float64Slice(name string, value []float64, usage string, validation ...func(value any) error) *[]float64 {
+	return CommandLine.Float64SliceP(name, "", value, usage, validation...)
 }
 
 // Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
-func Float64SliceP(name, shorthand string, value []float64, usage string) *[]float64 {
-	return CommandLine.Float64SliceP(name, shorthand, value, usage)
+func Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value any) error) *[]float64 {
+	return CommandLine.Float64SliceP(name, shorthand, value, usage, validation...)
 }

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -119,36 +119,56 @@ func (f *FlagSet) GetFloat64Slice(name string) ([]float64, error) {
 
 // Float64SliceVar defines a float64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float64 variable in which to store the value of the flag.
-func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newFloat64SliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value []float64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newFloat64SliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newFloat64SliceValue(value, p), name, "", usage)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value []float64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float64SliceVar defines a float64[] flag with specified name, default value, and usage string.
 // The argument p points to a float64[] variable in which to store the value of the flag.
-func Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newFloat64SliceValue(value, p), name, "", usage, validation...)
+func Float64SliceVar(p *[]float64, name string, value []float64, usage string, validation ...func(value []float64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newFloat64SliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newFloat64SliceValue(value, p), name, "", usage)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage, validation...)
+func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string, validation ...func(value []float64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.
 // The return value is the address of a []float64 variable that stores the value of the flag.
-func (f *FlagSet) Float64Slice(name string, value []float64, usage string, validation ...func(value interface{}) error) *[]float64 {
+func (f *FlagSet) Float64Slice(name string, value []float64, usage string, validation ...func(value []float64) error) *[]float64 {
 	p := []float64{}
 	f.Float64SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value interface{}) error) *[]float64 {
+func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value []float64) error) *[]float64 {
 	p := []float64{}
 	f.Float64SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -156,11 +176,11 @@ func (f *FlagSet) Float64SliceP(name, shorthand string, value []float64, usage s
 
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.
 // The return value is the address of a []float64 variable that stores the value of the flag.
-func Float64Slice(name string, value []float64, usage string, validation ...func(value interface{}) error) *[]float64 {
+func Float64Slice(name string, value []float64, usage string, validation ...func(value []float64) error) *[]float64 {
 	return CommandLine.Float64SliceP(name, "", value, usage, validation...)
 }
 
 // Float64SliceP is like Float64Slice, but accepts a shorthand letter that can be used after a single dash.
-func Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value interface{}) error) *[]float64 {
+func Float64SliceP(name, shorthand string, value []float64, usage string, validation ...func(value []float64) error) *[]float64 {
 	return CommandLine.Float64SliceP(name, shorthand, value, usage, validation...)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/erfanmomeniii/pflag
+module github.com/spf13/pflag
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/spf13/pflag
+module github.com/erfanmomeniii/pflag
 
 go 1.12

--- a/int.go
+++ b/int.go
@@ -37,36 +37,36 @@ func (f *FlagSet) GetInt(name string) (int, error) {
 
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
-func (f *FlagSet) IntVar(p *int, name string, value int, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IntVar(p *int, name string, value int, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIntValue(value, p), name, "", usage, validation...)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIntValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
-func IntVar(p *int, name string, value int, usage string, validation ...func(value any) error) {
+func IntVar(p *int, name string, value int, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIntValue(value, p), name, "", usage, validation...)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
-func IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value any) error) {
+func IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int defines an int flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
-func (f *FlagSet) Int(name string, value int, usage string, validation ...func(value any) error) *int {
+func (f *FlagSet) Int(name string, value int, usage string, validation ...func(value interface{}) error) *int {
 	p := new(int)
 	f.IntVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntP(name, shorthand string, value int, usage string, validation ...func(value any) error) *int {
+func (f *FlagSet) IntP(name, shorthand string, value int, usage string, validation ...func(value interface{}) error) *int {
 	p := new(int)
 	f.IntVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -74,11 +74,11 @@ func (f *FlagSet) IntP(name, shorthand string, value int, usage string, validati
 
 // Int defines an int flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
-func Int(name string, value int, usage string, validation ...func(value any) error) *int {
+func Int(name string, value int, usage string, validation ...func(value interface{}) error) *int {
 	return CommandLine.IntP(name, "", value, usage, validation...)
 }
 
 // IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
-func IntP(name, shorthand string, value int, usage string, validation ...func(value any) error) *int {
+func IntP(name, shorthand string, value int, usage string, validation ...func(value interface{}) error) *int {
 	return CommandLine.IntP(name, shorthand, value, usage, validation...)
 }

--- a/int.go
+++ b/int.go
@@ -37,48 +37,48 @@ func (f *FlagSet) GetInt(name string) (int, error) {
 
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
-func (f *FlagSet) IntVar(p *int, name string, value int, usage string) {
-	f.VarP(newIntValue(value, p), name, "", usage)
+func (f *FlagSet) IntVar(p *int, name string, value int, usage string, validation ...func(value any) error) {
+	f.VarP(newIntValue(value, p), name, "", usage, validation...)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string) {
-	f.VarP(newIntValue(value, p), name, shorthand, usage)
+func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value any) error) {
+	f.VarP(newIntValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
-func IntVar(p *int, name string, value int, usage string) {
-	CommandLine.VarP(newIntValue(value, p), name, "", usage)
+func IntVar(p *int, name string, value int, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIntValue(value, p), name, "", usage, validation...)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
-func IntVarP(p *int, name, shorthand string, value int, usage string) {
-	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage)
+func IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int defines an int flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
-func (f *FlagSet) Int(name string, value int, usage string) *int {
+func (f *FlagSet) Int(name string, value int, usage string, validation ...func(value any) error) *int {
 	p := new(int)
-	f.IntVarP(p, name, "", value, usage)
+	f.IntVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntP(name, shorthand string, value int, usage string) *int {
+func (f *FlagSet) IntP(name, shorthand string, value int, usage string, validation ...func(value any) error) *int {
 	p := new(int)
-	f.IntVarP(p, name, shorthand, value, usage)
+	f.IntVarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Int defines an int flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
-func Int(name string, value int, usage string) *int {
-	return CommandLine.IntP(name, "", value, usage)
+func Int(name string, value int, usage string, validation ...func(value any) error) *int {
+	return CommandLine.IntP(name, "", value, usage, validation...)
 }
 
 // IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
-func IntP(name, shorthand string, value int, usage string) *int {
-	return CommandLine.IntP(name, shorthand, value, usage)
+func IntP(name, shorthand string, value int, usage string, validation ...func(value any) error) *int {
+	return CommandLine.IntP(name, shorthand, value, usage, validation...)
 }

--- a/int.go
+++ b/int.go
@@ -37,36 +37,56 @@ func (f *FlagSet) GetInt(name string) (int, error) {
 
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
-func (f *FlagSet) IntVar(p *int, name string, value int, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIntValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) IntVar(p *int, name string, value int, usage string, validation ...func(value int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIntValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newIntValue(value, p), name, "", usage)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIntValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIntValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newIntValue(value, p), name, shorthand, usage)
 }
 
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
-func IntVar(p *int, name string, value int, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIntValue(value, p), name, "", usage, validation...)
+func IntVar(p *int, name string, value int, usage string, validation ...func(value int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIntValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIntValue(value, p), name, "", usage)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
-func IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage, validation...)
+func IntVarP(p *int, name, shorthand string, value int, usage string, validation ...func(value int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIntValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage)
 }
 
 // Int defines an int flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
-func (f *FlagSet) Int(name string, value int, usage string, validation ...func(value interface{}) error) *int {
+func (f *FlagSet) Int(name string, value int, usage string, validation ...func(value int) error) *int {
 	p := new(int)
 	f.IntVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntP(name, shorthand string, value int, usage string, validation ...func(value interface{}) error) *int {
+func (f *FlagSet) IntP(name, shorthand string, value int, usage string, validation ...func(value int) error) *int {
 	p := new(int)
 	f.IntVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -74,11 +94,11 @@ func (f *FlagSet) IntP(name, shorthand string, value int, usage string, validati
 
 // Int defines an int flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
-func Int(name string, value int, usage string, validation ...func(value interface{}) error) *int {
+func Int(name string, value int, usage string, validation ...func(value int) error) *int {
 	return CommandLine.IntP(name, "", value, usage, validation...)
 }
 
 // IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
-func IntP(name, shorthand string, value int, usage string, validation ...func(value interface{}) error) *int {
+func IntP(name, shorthand string, value int, usage string, validation ...func(value int) error) *int {
 	return CommandLine.IntP(name, shorthand, value, usage, validation...)
 }

--- a/int16.go
+++ b/int16.go
@@ -41,48 +41,48 @@ func (f *FlagSet) GetInt16(name string) (int16, error) {
 
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
-func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string) {
-	f.VarP(newInt16Value(value, p), name, "", usage)
+func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string, validation ...func(value any) error) {
+	f.VarP(newInt16Value(value, p), name, "", usage, validation...)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage string) {
-	f.VarP(newInt16Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value any) error) {
+	f.VarP(newInt16Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
-func Int16Var(p *int16, name string, value int16, usage string) {
-	CommandLine.VarP(newInt16Value(value, p), name, "", usage)
+func Int16Var(p *int16, name string, value int16, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt16Value(value, p), name, "", usage, validation...)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
-func Int16VarP(p *int16, name, shorthand string, value int16, usage string) {
-	CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage)
+func Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int16 defines an int16 flag with specified name, default value, and usage string.
 // The return value is the address of an int16 variable that stores the value of the flag.
-func (f *FlagSet) Int16(name string, value int16, usage string) *int16 {
+func (f *FlagSet) Int16(name string, value int16, usage string, validation ...func(value any) error) *int16 {
 	p := new(int16)
-	f.Int16VarP(p, name, "", value, usage)
+	f.Int16VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string) *int16 {
+func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string, validation ...func(value any) error) *int16 {
 	p := new(int16)
-	f.Int16VarP(p, name, shorthand, value, usage)
+	f.Int16VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Int16 defines an int16 flag with specified name, default value, and usage string.
 // The return value is the address of an int16 variable that stores the value of the flag.
-func Int16(name string, value int16, usage string) *int16 {
-	return CommandLine.Int16P(name, "", value, usage)
+func Int16(name string, value int16, usage string, validation ...func(value any) error) *int16 {
+	return CommandLine.Int16P(name, "", value, usage, validation...)
 }
 
 // Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
-func Int16P(name, shorthand string, value int16, usage string) *int16 {
-	return CommandLine.Int16P(name, shorthand, value, usage)
+func Int16P(name, shorthand string, value int16, usage string, validation ...func(value any) error) *int16 {
+	return CommandLine.Int16P(name, shorthand, value, usage, validation...)
 }

--- a/int16.go
+++ b/int16.go
@@ -41,36 +41,36 @@ func (f *FlagSet) GetInt16(name string) (int16, error) {
 
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
-func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt16Value(value, p), name, "", usage, validation...)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt16Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
-func Int16Var(p *int16, name string, value int16, usage string, validation ...func(value any) error) {
+func Int16Var(p *int16, name string, value int16, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt16Value(value, p), name, "", usage, validation...)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
-func Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value any) error) {
+func Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int16 defines an int16 flag with specified name, default value, and usage string.
 // The return value is the address of an int16 variable that stores the value of the flag.
-func (f *FlagSet) Int16(name string, value int16, usage string, validation ...func(value any) error) *int16 {
+func (f *FlagSet) Int16(name string, value int16, usage string, validation ...func(value interface{}) error) *int16 {
 	p := new(int16)
 	f.Int16VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string, validation ...func(value any) error) *int16 {
+func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string, validation ...func(value interface{}) error) *int16 {
 	p := new(int16)
 	f.Int16VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +78,11 @@ func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string, vali
 
 // Int16 defines an int16 flag with specified name, default value, and usage string.
 // The return value is the address of an int16 variable that stores the value of the flag.
-func Int16(name string, value int16, usage string, validation ...func(value any) error) *int16 {
+func Int16(name string, value int16, usage string, validation ...func(value interface{}) error) *int16 {
 	return CommandLine.Int16P(name, "", value, usage, validation...)
 }
 
 // Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
-func Int16P(name, shorthand string, value int16, usage string, validation ...func(value any) error) *int16 {
+func Int16P(name, shorthand string, value int16, usage string, validation ...func(value interface{}) error) *int16 {
 	return CommandLine.Int16P(name, shorthand, value, usage, validation...)
 }

--- a/int16.go
+++ b/int16.go
@@ -41,36 +41,56 @@ func (f *FlagSet) GetInt16(name string) (int16, error) {
 
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
-func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt16Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string, validation ...func(value int16) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt16Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newInt16Value(value, p), name, "", usage)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt16Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value int16) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt16Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newInt16Value(value, p), name, shorthand, usage)
 }
 
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
-func Int16Var(p *int16, name string, value int16, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt16Value(value, p), name, "", usage, validation...)
+func Int16Var(p *int16, name string, value int16, usage string, validation ...func(value int16) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt16Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt16Value(value, p), name, "", usage)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
-func Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage, validation...)
+func Int16VarP(p *int16, name, shorthand string, value int16, usage string, validation ...func(value int16) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage)
 }
 
 // Int16 defines an int16 flag with specified name, default value, and usage string.
 // The return value is the address of an int16 variable that stores the value of the flag.
-func (f *FlagSet) Int16(name string, value int16, usage string, validation ...func(value interface{}) error) *int16 {
+func (f *FlagSet) Int16(name string, value int16, usage string, validation ...func(value int16) error) *int16 {
 	p := new(int16)
 	f.Int16VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string, validation ...func(value interface{}) error) *int16 {
+func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string, validation ...func(value int16) error) *int16 {
 	p := new(int16)
 	f.Int16VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +98,11 @@ func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string, vali
 
 // Int16 defines an int16 flag with specified name, default value, and usage string.
 // The return value is the address of an int16 variable that stores the value of the flag.
-func Int16(name string, value int16, usage string, validation ...func(value interface{}) error) *int16 {
+func Int16(name string, value int16, usage string, validation ...func(value int16) error) *int16 {
 	return CommandLine.Int16P(name, "", value, usage, validation...)
 }
 
 // Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
-func Int16P(name, shorthand string, value int16, usage string, validation ...func(value interface{}) error) *int16 {
+func Int16P(name, shorthand string, value int16, usage string, validation ...func(value int16) error) *int16 {
 	return CommandLine.Int16P(name, shorthand, value, usage, validation...)
 }

--- a/int32.go
+++ b/int32.go
@@ -41,36 +41,56 @@ func (f *FlagSet) GetInt32(name string) (int32, error) {
 
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
-func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt32Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string, validation ...func(value int32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt32Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newInt32Value(value, p), name, "", usage)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt32Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value int32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt32Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newInt32Value(value, p), name, shorthand, usage)
 }
 
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
-func Int32Var(p *int32, name string, value int32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt32Value(value, p), name, "", usage, validation...)
+func Int32Var(p *int32, name string, value int32, usage string, validation ...func(value int32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt32Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt32Value(value, p), name, "", usage)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
-func Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage, validation...)
+func Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value int32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage)
 }
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.
 // The return value is the address of an int32 variable that stores the value of the flag.
-func (f *FlagSet) Int32(name string, value int32, usage string, validation ...func(value interface{}) error) *int32 {
+func (f *FlagSet) Int32(name string, value int32, usage string, validation ...func(value int32) error) *int32 {
 	p := new(int32)
 	f.Int32VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string, validation ...func(value interface{}) error) *int32 {
+func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string, validation ...func(value int32) error) *int32 {
 	p := new(int32)
 	f.Int32VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +98,11 @@ func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string, vali
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.
 // The return value is the address of an int32 variable that stores the value of the flag.
-func Int32(name string, value int32, usage string, validation ...func(value interface{}) error) *int32 {
+func Int32(name string, value int32, usage string, validation ...func(value int32) error) *int32 {
 	return CommandLine.Int32P(name, "", value, usage, validation...)
 }
 
 // Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
-func Int32P(name, shorthand string, value int32, usage string, validation ...func(value interface{}) error) *int32 {
+func Int32P(name, shorthand string, value int32, usage string, validation ...func(value int32) error) *int32 {
 	return CommandLine.Int32P(name, shorthand, value, usage, validation...)
 }

--- a/int32.go
+++ b/int32.go
@@ -41,36 +41,36 @@ func (f *FlagSet) GetInt32(name string) (int32, error) {
 
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
-func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt32Value(value, p), name, "", usage, validation...)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
-func Int32Var(p *int32, name string, value int32, usage string, validation ...func(value any) error) {
+func Int32Var(p *int32, name string, value int32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt32Value(value, p), name, "", usage, validation...)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
-func Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value any) error) {
+func Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.
 // The return value is the address of an int32 variable that stores the value of the flag.
-func (f *FlagSet) Int32(name string, value int32, usage string, validation ...func(value any) error) *int32 {
+func (f *FlagSet) Int32(name string, value int32, usage string, validation ...func(value interface{}) error) *int32 {
 	p := new(int32)
 	f.Int32VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string, validation ...func(value any) error) *int32 {
+func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string, validation ...func(value interface{}) error) *int32 {
 	p := new(int32)
 	f.Int32VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +78,11 @@ func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string, vali
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.
 // The return value is the address of an int32 variable that stores the value of the flag.
-func Int32(name string, value int32, usage string, validation ...func(value any) error) *int32 {
+func Int32(name string, value int32, usage string, validation ...func(value interface{}) error) *int32 {
 	return CommandLine.Int32P(name, "", value, usage, validation...)
 }
 
 // Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
-func Int32P(name, shorthand string, value int32, usage string, validation ...func(value any) error) *int32 {
+func Int32P(name, shorthand string, value int32, usage string, validation ...func(value interface{}) error) *int32 {
 	return CommandLine.Int32P(name, shorthand, value, usage, validation...)
 }

--- a/int32.go
+++ b/int32.go
@@ -41,48 +41,48 @@ func (f *FlagSet) GetInt32(name string) (int32, error) {
 
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
-func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string) {
-	f.VarP(newInt32Value(value, p), name, "", usage)
+func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string, validation ...func(value any) error) {
+	f.VarP(newInt32Value(value, p), name, "", usage, validation...)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
-	f.VarP(newInt32Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value any) error) {
+	f.VarP(newInt32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
-func Int32Var(p *int32, name string, value int32, usage string) {
-	CommandLine.VarP(newInt32Value(value, p), name, "", usage)
+func Int32Var(p *int32, name string, value int32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt32Value(value, p), name, "", usage, validation...)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
-func Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
-	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage)
+func Int32VarP(p *int32, name, shorthand string, value int32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.
 // The return value is the address of an int32 variable that stores the value of the flag.
-func (f *FlagSet) Int32(name string, value int32, usage string) *int32 {
+func (f *FlagSet) Int32(name string, value int32, usage string, validation ...func(value any) error) *int32 {
 	p := new(int32)
-	f.Int32VarP(p, name, "", value, usage)
+	f.Int32VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string) *int32 {
+func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string, validation ...func(value any) error) *int32 {
 	p := new(int32)
-	f.Int32VarP(p, name, shorthand, value, usage)
+	f.Int32VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.
 // The return value is the address of an int32 variable that stores the value of the flag.
-func Int32(name string, value int32, usage string) *int32 {
-	return CommandLine.Int32P(name, "", value, usage)
+func Int32(name string, value int32, usage string, validation ...func(value any) error) *int32 {
+	return CommandLine.Int32P(name, "", value, usage, validation...)
 }
 
 // Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
-func Int32P(name, shorthand string, value int32, usage string) *int32 {
-	return CommandLine.Int32P(name, shorthand, value, usage)
+func Int32P(name, shorthand string, value int32, usage string, validation ...func(value any) error) *int32 {
+	return CommandLine.Int32P(name, shorthand, value, usage, validation...)
 }

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -127,48 +127,48 @@ func (f *FlagSet) GetInt32Slice(name string) ([]int32, error) {
 
 // Int32SliceVar defines a int32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int32 variable in which to store the value of the flag.
-func (f *FlagSet) Int32SliceVar(p *[]int32, name string, value []int32, usage string) {
-	f.VarP(newInt32SliceValue(value, p), name, "", usage)
+func (f *FlagSet) Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value any) error) {
+	f.VarP(newInt32SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string) {
-	f.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value any) error) {
+	f.VarP(newInt32SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int32SliceVar defines a int32[] flag with specified name, default value, and usage string.
 // The argument p points to a int32[] variable in which to store the value of the flag.
-func Int32SliceVar(p *[]int32, name string, value []int32, usage string) {
-	CommandLine.VarP(newInt32SliceValue(value, p), name, "", usage)
+func Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt32SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string) {
-	CommandLine.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
+func Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt32SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.
 // The return value is the address of a []int32 variable that stores the value of the flag.
-func (f *FlagSet) Int32Slice(name string, value []int32, usage string) *[]int32 {
+func (f *FlagSet) Int32Slice(name string, value []int32, usage string, validation ...func(value any) error) *[]int32 {
 	p := []int32{}
-	f.Int32SliceVarP(&p, name, "", value, usage)
+	f.Int32SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Int32SliceP is like Int32Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32SliceP(name, shorthand string, value []int32, usage string) *[]int32 {
+func (f *FlagSet) Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value any) error) *[]int32 {
 	p := []int32{}
-	f.Int32SliceVarP(&p, name, shorthand, value, usage)
+	f.Int32SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.
 // The return value is the address of a []int32 variable that stores the value of the flag.
-func Int32Slice(name string, value []int32, usage string) *[]int32 {
-	return CommandLine.Int32SliceP(name, "", value, usage)
+func Int32Slice(name string, value []int32, usage string, validation ...func(value any) error) *[]int32 {
+	return CommandLine.Int32SliceP(name, "", value, usage, validation...)
 }
 
 // Int32SliceP is like Int32Slice, but accepts a shorthand letter that can be used after a single dash.
-func Int32SliceP(name, shorthand string, value []int32, usage string) *[]int32 {
-	return CommandLine.Int32SliceP(name, shorthand, value, usage)
+func Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value any) error) *[]int32 {
+	return CommandLine.Int32SliceP(name, shorthand, value, usage, validation...)
 }

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -127,36 +127,56 @@ func (f *FlagSet) GetInt32Slice(name string) ([]int32, error) {
 
 // Int32SliceVar defines a int32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int32 variable in which to store the value of the flag.
-func (f *FlagSet) Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt32SliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value []int32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt32SliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newInt32SliceValue(value, p), name, "", usage)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt32SliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value []int32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt32SliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int32SliceVar defines a int32[] flag with specified name, default value, and usage string.
 // The argument p points to a int32[] variable in which to store the value of the flag.
-func Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt32SliceValue(value, p), name, "", usage, validation...)
+func Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value []int32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt32SliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt32SliceValue(value, p), name, "", usage)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt32SliceValue(value, p), name, shorthand, usage, validation...)
+func Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value []int32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt32SliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.
 // The return value is the address of a []int32 variable that stores the value of the flag.
-func (f *FlagSet) Int32Slice(name string, value []int32, usage string, validation ...func(value interface{}) error) *[]int32 {
+func (f *FlagSet) Int32Slice(name string, value []int32, usage string, validation ...func(value []int32) error) *[]int32 {
 	p := []int32{}
 	f.Int32SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Int32SliceP is like Int32Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value interface{}) error) *[]int32 {
+func (f *FlagSet) Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value []int32) error) *[]int32 {
 	p := []int32{}
 	f.Int32SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -164,11 +184,11 @@ func (f *FlagSet) Int32SliceP(name, shorthand string, value []int32, usage strin
 
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.
 // The return value is the address of a []int32 variable that stores the value of the flag.
-func Int32Slice(name string, value []int32, usage string, validation ...func(value interface{}) error) *[]int32 {
+func Int32Slice(name string, value []int32, usage string, validation ...func(value []int32) error) *[]int32 {
 	return CommandLine.Int32SliceP(name, "", value, usage, validation...)
 }
 
 // Int32SliceP is like Int32Slice, but accepts a shorthand letter that can be used after a single dash.
-func Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value interface{}) error) *[]int32 {
+func Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value []int32) error) *[]int32 {
 	return CommandLine.Int32SliceP(name, shorthand, value, usage, validation...)
 }

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -127,36 +127,36 @@ func (f *FlagSet) GetInt32Slice(name string) ([]int32, error) {
 
 // Int32SliceVar defines a int32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int32 variable in which to store the value of the flag.
-func (f *FlagSet) Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt32SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt32SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int32SliceVar defines a int32[] flag with specified name, default value, and usage string.
 // The argument p points to a int32[] variable in which to store the value of the flag.
-func Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value any) error) {
+func Int32SliceVar(p *[]int32, name string, value []int32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt32SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value any) error) {
+func Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt32SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.
 // The return value is the address of a []int32 variable that stores the value of the flag.
-func (f *FlagSet) Int32Slice(name string, value []int32, usage string, validation ...func(value any) error) *[]int32 {
+func (f *FlagSet) Int32Slice(name string, value []int32, usage string, validation ...func(value interface{}) error) *[]int32 {
 	p := []int32{}
 	f.Int32SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Int32SliceP is like Int32Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value any) error) *[]int32 {
+func (f *FlagSet) Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value interface{}) error) *[]int32 {
 	p := []int32{}
 	f.Int32SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -164,11 +164,11 @@ func (f *FlagSet) Int32SliceP(name, shorthand string, value []int32, usage strin
 
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.
 // The return value is the address of a []int32 variable that stores the value of the flag.
-func Int32Slice(name string, value []int32, usage string, validation ...func(value any) error) *[]int32 {
+func Int32Slice(name string, value []int32, usage string, validation ...func(value interface{}) error) *[]int32 {
 	return CommandLine.Int32SliceP(name, "", value, usage, validation...)
 }
 
 // Int32SliceP is like Int32Slice, but accepts a shorthand letter that can be used after a single dash.
-func Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value any) error) *[]int32 {
+func Int32SliceP(name, shorthand string, value []int32, usage string, validation ...func(value interface{}) error) *[]int32 {
 	return CommandLine.Int32SliceP(name, shorthand, value, usage, validation...)
 }

--- a/int64.go
+++ b/int64.go
@@ -37,36 +37,36 @@ func (f *FlagSet) GetInt64(name string) (int64, error) {
 
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
-func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt64Value(value, p), name, "", usage, validation...)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
-func Int64Var(p *int64, name string, value int64, usage string, validation ...func(value any) error) {
+func Int64Var(p *int64, name string, value int64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt64Value(value, p), name, "", usage, validation...)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
-func Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value any) error) {
+func Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.
 // The return value is the address of an int64 variable that stores the value of the flag.
-func (f *FlagSet) Int64(name string, value int64, usage string, validation ...func(value any) error) *int64 {
+func (f *FlagSet) Int64(name string, value int64, usage string, validation ...func(value interface{}) error) *int64 {
 	p := new(int64)
 	f.Int64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string, validation ...func(value any) error) *int64 {
+func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string, validation ...func(value interface{}) error) *int64 {
 	p := new(int64)
 	f.Int64VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -74,11 +74,11 @@ func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string, vali
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.
 // The return value is the address of an int64 variable that stores the value of the flag.
-func Int64(name string, value int64, usage string, validation ...func(value any) error) *int64 {
+func Int64(name string, value int64, usage string, validation ...func(value interface{}) error) *int64 {
 	return CommandLine.Int64P(name, "", value, usage, validation...)
 }
 
 // Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
-func Int64P(name, shorthand string, value int64, usage string, validation ...func(value any) error) *int64 {
+func Int64P(name, shorthand string, value int64, usage string, validation ...func(value interface{}) error) *int64 {
 	return CommandLine.Int64P(name, shorthand, value, usage, validation...)
 }

--- a/int64.go
+++ b/int64.go
@@ -37,48 +37,48 @@ func (f *FlagSet) GetInt64(name string) (int64, error) {
 
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
-func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string) {
-	f.VarP(newInt64Value(value, p), name, "", usage)
+func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string, validation ...func(value any) error) {
+	f.VarP(newInt64Value(value, p), name, "", usage, validation...)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
-	f.VarP(newInt64Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value any) error) {
+	f.VarP(newInt64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
-func Int64Var(p *int64, name string, value int64, usage string) {
-	CommandLine.VarP(newInt64Value(value, p), name, "", usage)
+func Int64Var(p *int64, name string, value int64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt64Value(value, p), name, "", usage, validation...)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
-func Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
-	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage)
+func Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.
 // The return value is the address of an int64 variable that stores the value of the flag.
-func (f *FlagSet) Int64(name string, value int64, usage string) *int64 {
+func (f *FlagSet) Int64(name string, value int64, usage string, validation ...func(value any) error) *int64 {
 	p := new(int64)
-	f.Int64VarP(p, name, "", value, usage)
+	f.Int64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string) *int64 {
+func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string, validation ...func(value any) error) *int64 {
 	p := new(int64)
-	f.Int64VarP(p, name, shorthand, value, usage)
+	f.Int64VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.
 // The return value is the address of an int64 variable that stores the value of the flag.
-func Int64(name string, value int64, usage string) *int64 {
-	return CommandLine.Int64P(name, "", value, usage)
+func Int64(name string, value int64, usage string, validation ...func(value any) error) *int64 {
+	return CommandLine.Int64P(name, "", value, usage, validation...)
 }
 
 // Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
-func Int64P(name, shorthand string, value int64, usage string) *int64 {
-	return CommandLine.Int64P(name, shorthand, value, usage)
+func Int64P(name, shorthand string, value int64, usage string, validation ...func(value any) error) *int64 {
+	return CommandLine.Int64P(name, shorthand, value, usage, validation...)
 }

--- a/int64.go
+++ b/int64.go
@@ -37,36 +37,56 @@ func (f *FlagSet) GetInt64(name string) (int64, error) {
 
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
-func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt64Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string, validation ...func(value int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt64Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newInt64Value(value, p), name, "", usage)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt64Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt64Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newInt64Value(value, p), name, shorthand, usage)
 }
 
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
-func Int64Var(p *int64, name string, value int64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt64Value(value, p), name, "", usage, validation...)
+func Int64Var(p *int64, name string, value int64, usage string, validation ...func(value int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt64Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt64Value(value, p), name, "", usage)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
-func Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage, validation...)
+func Int64VarP(p *int64, name, shorthand string, value int64, usage string, validation ...func(value int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage)
 }
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.
 // The return value is the address of an int64 variable that stores the value of the flag.
-func (f *FlagSet) Int64(name string, value int64, usage string, validation ...func(value interface{}) error) *int64 {
+func (f *FlagSet) Int64(name string, value int64, usage string, validation ...func(value int64) error) *int64 {
 	p := new(int64)
 	f.Int64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string, validation ...func(value interface{}) error) *int64 {
+func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string, validation ...func(value int64) error) *int64 {
 	p := new(int64)
 	f.Int64VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -74,11 +94,11 @@ func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string, vali
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.
 // The return value is the address of an int64 variable that stores the value of the flag.
-func Int64(name string, value int64, usage string, validation ...func(value interface{}) error) *int64 {
+func Int64(name string, value int64, usage string, validation ...func(value int64) error) *int64 {
 	return CommandLine.Int64P(name, "", value, usage, validation...)
 }
 
 // Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
-func Int64P(name, shorthand string, value int64, usage string, validation ...func(value interface{}) error) *int64 {
+func Int64P(name, shorthand string, value int64, usage string, validation ...func(value int64) error) *int64 {
 	return CommandLine.Int64P(name, shorthand, value, usage, validation...)
 }

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -119,36 +119,36 @@ func (f *FlagSet) GetInt64Slice(name string) ([]int64, error) {
 
 // Int64SliceVar defines a int64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int64 variable in which to store the value of the flag.
-func (f *FlagSet) Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt64SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt64SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int64SliceVar defines a int64[] flag with specified name, default value, and usage string.
 // The argument p points to a int64[] variable in which to store the value of the flag.
-func Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value any) error) {
+func Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt64SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value any) error) {
+func Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt64SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.
 // The return value is the address of a []int64 variable that stores the value of the flag.
-func (f *FlagSet) Int64Slice(name string, value []int64, usage string, validation ...func(value any) error) *[]int64 {
+func (f *FlagSet) Int64Slice(name string, value []int64, usage string, validation ...func(value interface{}) error) *[]int64 {
 	p := []int64{}
 	f.Int64SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Int64SliceP is like Int64Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value any) error) *[]int64 {
+func (f *FlagSet) Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value interface{}) error) *[]int64 {
 	p := []int64{}
 	f.Int64SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -156,11 +156,11 @@ func (f *FlagSet) Int64SliceP(name, shorthand string, value []int64, usage strin
 
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.
 // The return value is the address of a []int64 variable that stores the value of the flag.
-func Int64Slice(name string, value []int64, usage string, validation ...func(value any) error) *[]int64 {
+func Int64Slice(name string, value []int64, usage string, validation ...func(value interface{}) error) *[]int64 {
 	return CommandLine.Int64SliceP(name, "", value, usage, validation...)
 }
 
 // Int64SliceP is like Int64Slice, but accepts a shorthand letter that can be used after a single dash.
-func Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value any) error) *[]int64 {
+func Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value interface{}) error) *[]int64 {
 	return CommandLine.Int64SliceP(name, shorthand, value, usage, validation...)
 }

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -119,36 +119,56 @@ func (f *FlagSet) GetInt64Slice(name string) ([]int64, error) {
 
 // Int64SliceVar defines a int64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int64 variable in which to store the value of the flag.
-func (f *FlagSet) Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt64SliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value []int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt64SliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newInt64SliceValue(value, p), name, "", usage)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt64SliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value []int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt64SliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int64SliceVar defines a int64[] flag with specified name, default value, and usage string.
 // The argument p points to a int64[] variable in which to store the value of the flag.
-func Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt64SliceValue(value, p), name, "", usage, validation...)
+func Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value []int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt64SliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt64SliceValue(value, p), name, "", usage)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt64SliceValue(value, p), name, shorthand, usage, validation...)
+func Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value []int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt64SliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.
 // The return value is the address of a []int64 variable that stores the value of the flag.
-func (f *FlagSet) Int64Slice(name string, value []int64, usage string, validation ...func(value interface{}) error) *[]int64 {
+func (f *FlagSet) Int64Slice(name string, value []int64, usage string, validation ...func(value []int64) error) *[]int64 {
 	p := []int64{}
 	f.Int64SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Int64SliceP is like Int64Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value interface{}) error) *[]int64 {
+func (f *FlagSet) Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value []int64) error) *[]int64 {
 	p := []int64{}
 	f.Int64SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -156,11 +176,11 @@ func (f *FlagSet) Int64SliceP(name, shorthand string, value []int64, usage strin
 
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.
 // The return value is the address of a []int64 variable that stores the value of the flag.
-func Int64Slice(name string, value []int64, usage string, validation ...func(value interface{}) error) *[]int64 {
+func Int64Slice(name string, value []int64, usage string, validation ...func(value []int64) error) *[]int64 {
 	return CommandLine.Int64SliceP(name, "", value, usage, validation...)
 }
 
 // Int64SliceP is like Int64Slice, but accepts a shorthand letter that can be used after a single dash.
-func Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value interface{}) error) *[]int64 {
+func Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value []int64) error) *[]int64 {
 	return CommandLine.Int64SliceP(name, shorthand, value, usage, validation...)
 }

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -119,48 +119,48 @@ func (f *FlagSet) GetInt64Slice(name string) ([]int64, error) {
 
 // Int64SliceVar defines a int64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int64 variable in which to store the value of the flag.
-func (f *FlagSet) Int64SliceVar(p *[]int64, name string, value []int64, usage string) {
-	f.VarP(newInt64SliceValue(value, p), name, "", usage)
+func (f *FlagSet) Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value any) error) {
+	f.VarP(newInt64SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string) {
-	f.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value any) error) {
+	f.VarP(newInt64SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int64SliceVar defines a int64[] flag with specified name, default value, and usage string.
 // The argument p points to a int64[] variable in which to store the value of the flag.
-func Int64SliceVar(p *[]int64, name string, value []int64, usage string) {
-	CommandLine.VarP(newInt64SliceValue(value, p), name, "", usage)
+func Int64SliceVar(p *[]int64, name string, value []int64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt64SliceValue(value, p), name, "", usage, validation...)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
-func Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string) {
-	CommandLine.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
+func Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt64SliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.
 // The return value is the address of a []int64 variable that stores the value of the flag.
-func (f *FlagSet) Int64Slice(name string, value []int64, usage string) *[]int64 {
+func (f *FlagSet) Int64Slice(name string, value []int64, usage string, validation ...func(value any) error) *[]int64 {
 	p := []int64{}
-	f.Int64SliceVarP(&p, name, "", value, usage)
+	f.Int64SliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // Int64SliceP is like Int64Slice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int64SliceP(name, shorthand string, value []int64, usage string) *[]int64 {
+func (f *FlagSet) Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value any) error) *[]int64 {
 	p := []int64{}
-	f.Int64SliceVarP(&p, name, shorthand, value, usage)
+	f.Int64SliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.
 // The return value is the address of a []int64 variable that stores the value of the flag.
-func Int64Slice(name string, value []int64, usage string) *[]int64 {
-	return CommandLine.Int64SliceP(name, "", value, usage)
+func Int64Slice(name string, value []int64, usage string, validation ...func(value any) error) *[]int64 {
+	return CommandLine.Int64SliceP(name, "", value, usage, validation...)
 }
 
 // Int64SliceP is like Int64Slice, but accepts a shorthand letter that can be used after a single dash.
-func Int64SliceP(name, shorthand string, value []int64, usage string) *[]int64 {
-	return CommandLine.Int64SliceP(name, shorthand, value, usage)
+func Int64SliceP(name, shorthand string, value []int64, usage string, validation ...func(value any) error) *[]int64 {
+	return CommandLine.Int64SliceP(name, shorthand, value, usage, validation...)
 }

--- a/int8.go
+++ b/int8.go
@@ -41,36 +41,56 @@ func (f *FlagSet) GetInt8(name string) (int8, error) {
 
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
-func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt8Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string, validation ...func(value int8) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt8Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newInt8Value(value, p), name, "", usage)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newInt8Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value int8) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newInt8Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newInt8Value(value, p), name, shorthand, usage)
 }
 
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
-func Int8Var(p *int8, name string, value int8, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt8Value(value, p), name, "", usage, validation...)
+func Int8Var(p *int8, name string, value int8, usage string, validation ...func(value int8) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt8Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt8Value(value, p), name, "", usage)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
-func Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage, validation...)
+func Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value int8) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage)
 }
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.
 // The return value is the address of an int8 variable that stores the value of the flag.
-func (f *FlagSet) Int8(name string, value int8, usage string, validation ...func(value interface{}) error) *int8 {
+func (f *FlagSet) Int8(name string, value int8, usage string, validation ...func(value int8) error) *int8 {
 	p := new(int8)
 	f.Int8VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string, validation ...func(value interface{}) error) *int8 {
+func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string, validation ...func(value int8) error) *int8 {
 	p := new(int8)
 	f.Int8VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +98,11 @@ func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string, valida
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.
 // The return value is the address of an int8 variable that stores the value of the flag.
-func Int8(name string, value int8, usage string, validation ...func(value interface{}) error) *int8 {
+func Int8(name string, value int8, usage string, validation ...func(value int8) error) *int8 {
 	return CommandLine.Int8P(name, "", value, usage, validation...)
 }
 
 // Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
-func Int8P(name, shorthand string, value int8, usage string, validation ...func(value interface{}) error) *int8 {
+func Int8P(name, shorthand string, value int8, usage string, validation ...func(value int8) error) *int8 {
 	return CommandLine.Int8P(name, shorthand, value, usage, validation...)
 }

--- a/int8.go
+++ b/int8.go
@@ -41,36 +41,36 @@ func (f *FlagSet) GetInt8(name string) (int8, error) {
 
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
-func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt8Value(value, p), name, "", usage, validation...)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newInt8Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
-func Int8Var(p *int8, name string, value int8, usage string, validation ...func(value any) error) {
+func Int8Var(p *int8, name string, value int8, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt8Value(value, p), name, "", usage, validation...)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
-func Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value any) error) {
+func Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.
 // The return value is the address of an int8 variable that stores the value of the flag.
-func (f *FlagSet) Int8(name string, value int8, usage string, validation ...func(value any) error) *int8 {
+func (f *FlagSet) Int8(name string, value int8, usage string, validation ...func(value interface{}) error) *int8 {
 	p := new(int8)
 	f.Int8VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string, validation ...func(value any) error) *int8 {
+func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string, validation ...func(value interface{}) error) *int8 {
 	p := new(int8)
 	f.Int8VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +78,11 @@ func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string, valida
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.
 // The return value is the address of an int8 variable that stores the value of the flag.
-func Int8(name string, value int8, usage string, validation ...func(value any) error) *int8 {
+func Int8(name string, value int8, usage string, validation ...func(value interface{}) error) *int8 {
 	return CommandLine.Int8P(name, "", value, usage, validation...)
 }
 
 // Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
-func Int8P(name, shorthand string, value int8, usage string, validation ...func(value any) error) *int8 {
+func Int8P(name, shorthand string, value int8, usage string, validation ...func(value interface{}) error) *int8 {
 	return CommandLine.Int8P(name, shorthand, value, usage, validation...)
 }

--- a/int8.go
+++ b/int8.go
@@ -41,48 +41,48 @@ func (f *FlagSet) GetInt8(name string) (int8, error) {
 
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
-func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string) {
-	f.VarP(newInt8Value(value, p), name, "", usage)
+func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string, validation ...func(value any) error) {
+	f.VarP(newInt8Value(value, p), name, "", usage, validation...)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
-	f.VarP(newInt8Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value any) error) {
+	f.VarP(newInt8Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
-func Int8Var(p *int8, name string, value int8, usage string) {
-	CommandLine.VarP(newInt8Value(value, p), name, "", usage)
+func Int8Var(p *int8, name string, value int8, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt8Value(value, p), name, "", usage, validation...)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
-func Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
-	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage)
+func Int8VarP(p *int8, name, shorthand string, value int8, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.
 // The return value is the address of an int8 variable that stores the value of the flag.
-func (f *FlagSet) Int8(name string, value int8, usage string) *int8 {
+func (f *FlagSet) Int8(name string, value int8, usage string, validation ...func(value any) error) *int8 {
 	p := new(int8)
-	f.Int8VarP(p, name, "", value, usage)
+	f.Int8VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string) *int8 {
+func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string, validation ...func(value any) error) *int8 {
 	p := new(int8)
-	f.Int8VarP(p, name, shorthand, value, usage)
+	f.Int8VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.
 // The return value is the address of an int8 variable that stores the value of the flag.
-func Int8(name string, value int8, usage string) *int8 {
-	return CommandLine.Int8P(name, "", value, usage)
+func Int8(name string, value int8, usage string, validation ...func(value any) error) *int8 {
+	return CommandLine.Int8P(name, "", value, usage, validation...)
 }
 
 // Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
-func Int8P(name, shorthand string, value int8, usage string) *int8 {
-	return CommandLine.Int8P(name, shorthand, value, usage)
+func Int8P(name, shorthand string, value int8, usage string, validation ...func(value any) error) *int8 {
+	return CommandLine.Int8P(name, shorthand, value, usage, validation...)
 }

--- a/int_slice.go
+++ b/int_slice.go
@@ -111,36 +111,36 @@ func (f *FlagSet) GetIntSlice(name string) ([]int, error) {
 
 // IntSliceVar defines a intSlice flag with specified name, default value, and usage string.
 // The argument p points to a []int variable in which to store the value of the flag.
-func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIntSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIntSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IntSliceVar defines a int[] flag with specified name, default value, and usage string.
 // The argument p points to a int[] variable in which to store the value of the flag.
-func IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value any) error) {
+func IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIntSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value any) error) {
+func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IntSlice defines a []int flag with specified name, default value, and usage string.
 // The return value is the address of a []int variable that stores the value of the flag.
-func (f *FlagSet) IntSlice(name string, value []int, usage string, validation ...func(value any) error) *[]int {
+func (f *FlagSet) IntSlice(name string, value []int, usage string, validation ...func(value interface{}) error) *[]int {
 	p := []int{}
 	f.IntSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value any) error) *[]int {
+func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value interface{}) error) *[]int {
 	p := []int{}
 	f.IntSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -148,11 +148,11 @@ func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string, v
 
 // IntSlice defines a []int flag with specified name, default value, and usage string.
 // The return value is the address of a []int variable that stores the value of the flag.
-func IntSlice(name string, value []int, usage string, validation ...func(value any) error) *[]int {
+func IntSlice(name string, value []int, usage string, validation ...func(value interface{}) error) *[]int {
 	return CommandLine.IntSliceP(name, "", value, usage, validation...)
 }
 
 // IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
-func IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value any) error) *[]int {
+func IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value interface{}) error) *[]int {
 	return CommandLine.IntSliceP(name, shorthand, value, usage, validation...)
 }

--- a/int_slice.go
+++ b/int_slice.go
@@ -111,48 +111,48 @@ func (f *FlagSet) GetIntSlice(name string) ([]int, error) {
 
 // IntSliceVar defines a intSlice flag with specified name, default value, and usage string.
 // The argument p points to a []int variable in which to store the value of the flag.
-func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string) {
-	f.VarP(newIntSliceValue(value, p), name, "", usage)
+func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value any) error) {
+	f.VarP(newIntSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string) {
-	f.VarP(newIntSliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value any) error) {
+	f.VarP(newIntSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IntSliceVar defines a int[] flag with specified name, default value, and usage string.
 // The argument p points to a int[] variable in which to store the value of the flag.
-func IntSliceVar(p *[]int, name string, value []int, usage string) {
-	CommandLine.VarP(newIntSliceValue(value, p), name, "", usage)
+func IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIntSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string) {
-	CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage)
+func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IntSlice defines a []int flag with specified name, default value, and usage string.
 // The return value is the address of a []int variable that stores the value of the flag.
-func (f *FlagSet) IntSlice(name string, value []int, usage string) *[]int {
+func (f *FlagSet) IntSlice(name string, value []int, usage string, validation ...func(value any) error) *[]int {
 	p := []int{}
-	f.IntSliceVarP(&p, name, "", value, usage)
+	f.IntSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string) *[]int {
+func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value any) error) *[]int {
 	p := []int{}
-	f.IntSliceVarP(&p, name, shorthand, value, usage)
+	f.IntSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // IntSlice defines a []int flag with specified name, default value, and usage string.
 // The return value is the address of a []int variable that stores the value of the flag.
-func IntSlice(name string, value []int, usage string) *[]int {
-	return CommandLine.IntSliceP(name, "", value, usage)
+func IntSlice(name string, value []int, usage string, validation ...func(value any) error) *[]int {
+	return CommandLine.IntSliceP(name, "", value, usage, validation...)
 }
 
 // IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
-func IntSliceP(name, shorthand string, value []int, usage string) *[]int {
-	return CommandLine.IntSliceP(name, shorthand, value, usage)
+func IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value any) error) *[]int {
+	return CommandLine.IntSliceP(name, shorthand, value, usage, validation...)
 }

--- a/int_slice.go
+++ b/int_slice.go
@@ -111,36 +111,56 @@ func (f *FlagSet) GetIntSlice(name string) ([]int, error) {
 
 // IntSliceVar defines a intSlice flag with specified name, default value, and usage string.
 // The argument p points to a []int variable in which to store the value of the flag.
-func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIntSliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value []int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIntSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newIntSliceValue(value, p), name, "", usage)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIntSliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value []int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIntSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newIntSliceValue(value, p), name, shorthand, usage)
 }
 
 // IntSliceVar defines a int[] flag with specified name, default value, and usage string.
 // The argument p points to a int[] variable in which to store the value of the flag.
-func IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIntSliceValue(value, p), name, "", usage, validation...)
+func IntSliceVar(p *[]int, name string, value []int, usage string, validation ...func(value []int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIntSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIntSliceValue(value, p), name, "", usage)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage, validation...)
+func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string, validation ...func(value []int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage)
 }
 
 // IntSlice defines a []int flag with specified name, default value, and usage string.
 // The return value is the address of a []int variable that stores the value of the flag.
-func (f *FlagSet) IntSlice(name string, value []int, usage string, validation ...func(value interface{}) error) *[]int {
+func (f *FlagSet) IntSlice(name string, value []int, usage string, validation ...func(value []int) error) *[]int {
 	p := []int{}
 	f.IntSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value interface{}) error) *[]int {
+func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value []int) error) *[]int {
 	p := []int{}
 	f.IntSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -148,11 +168,11 @@ func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string, v
 
 // IntSlice defines a []int flag with specified name, default value, and usage string.
 // The return value is the address of a []int variable that stores the value of the flag.
-func IntSlice(name string, value []int, usage string, validation ...func(value interface{}) error) *[]int {
+func IntSlice(name string, value []int, usage string, validation ...func(value []int) error) *[]int {
 	return CommandLine.IntSliceP(name, "", value, usage, validation...)
 }
 
 // IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
-func IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value interface{}) error) *[]int {
+func IntSliceP(name, shorthand string, value []int, usage string, validation ...func(value []int) error) *[]int {
 	return CommandLine.IntSliceP(name, shorthand, value, usage, validation...)
 }

--- a/ip.go
+++ b/ip.go
@@ -50,36 +50,56 @@ func (f *FlagSet) GetIP(name string) (net.IP, error) {
 
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
-func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value net.IP) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIPValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newIPValue(value, p), name, "", usage)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value net.IP) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIPValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newIPValue(value, p), name, shorthand, usage)
 }
 
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
-func IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPValue(value, p), name, "", usage, validation...)
+func IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value net.IP) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIPValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIPValue(value, p), name, "", usage)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
-func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage, validation...)
+func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value net.IP) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIPValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage)
 }
 
 // IP defines an net.IP flag with specified name, default value, and usage string.
 // The return value is the address of an net.IP variable that stores the value of the flag.
-func (f *FlagSet) IP(name string, value net.IP, usage string, validation ...func(value interface{}) error) *net.IP {
+func (f *FlagSet) IP(name string, value net.IP, usage string, validation ...func(value net.IP) error) *net.IP {
 	p := new(net.IP)
 	f.IPVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string, validation ...func(value interface{}) error) *net.IP {
+func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string, validation ...func(value net.IP) error) *net.IP {
 	p := new(net.IP)
 	f.IPVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -87,11 +107,11 @@ func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string, valida
 
 // IP defines an net.IP flag with specified name, default value, and usage string.
 // The return value is the address of an net.IP variable that stores the value of the flag.
-func IP(name string, value net.IP, usage string, validation ...func(value interface{}) error) *net.IP {
+func IP(name string, value net.IP, usage string, validation ...func(value net.IP) error) *net.IP {
 	return CommandLine.IPP(name, "", value, usage, validation...)
 }
 
 // IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
-func IPP(name, shorthand string, value net.IP, usage string, validation ...func(value interface{}) error) *net.IP {
+func IPP(name, shorthand string, value net.IP, usage string, validation ...func(value net.IP) error) *net.IP {
 	return CommandLine.IPP(name, shorthand, value, usage, validation...)
 }

--- a/ip.go
+++ b/ip.go
@@ -50,36 +50,36 @@ func (f *FlagSet) GetIP(name string) (net.IP, error) {
 
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
-func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPValue(value, p), name, "", usage, validation...)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
-func IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value any) error) {
+func IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPValue(value, p), name, "", usage, validation...)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
-func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value any) error) {
+func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IP defines an net.IP flag with specified name, default value, and usage string.
 // The return value is the address of an net.IP variable that stores the value of the flag.
-func (f *FlagSet) IP(name string, value net.IP, usage string, validation ...func(value any) error) *net.IP {
+func (f *FlagSet) IP(name string, value net.IP, usage string, validation ...func(value interface{}) error) *net.IP {
 	p := new(net.IP)
 	f.IPVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string, validation ...func(value any) error) *net.IP {
+func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string, validation ...func(value interface{}) error) *net.IP {
 	p := new(net.IP)
 	f.IPVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -87,11 +87,11 @@ func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string, valida
 
 // IP defines an net.IP flag with specified name, default value, and usage string.
 // The return value is the address of an net.IP variable that stores the value of the flag.
-func IP(name string, value net.IP, usage string, validation ...func(value any) error) *net.IP {
+func IP(name string, value net.IP, usage string, validation ...func(value interface{}) error) *net.IP {
 	return CommandLine.IPP(name, "", value, usage, validation...)
 }
 
 // IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
-func IPP(name, shorthand string, value net.IP, usage string, validation ...func(value any) error) *net.IP {
+func IPP(name, shorthand string, value net.IP, usage string, validation ...func(value interface{}) error) *net.IP {
 	return CommandLine.IPP(name, shorthand, value, usage, validation...)
 }

--- a/ip.go
+++ b/ip.go
@@ -50,48 +50,48 @@ func (f *FlagSet) GetIP(name string) (net.IP, error) {
 
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
-func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string) {
-	f.VarP(newIPValue(value, p), name, "", usage)
+func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value any) error) {
+	f.VarP(newIPValue(value, p), name, "", usage, validation...)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
-	f.VarP(newIPValue(value, p), name, shorthand, usage)
+func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value any) error) {
+	f.VarP(newIPValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
-func IPVar(p *net.IP, name string, value net.IP, usage string) {
-	CommandLine.VarP(newIPValue(value, p), name, "", usage)
+func IPVar(p *net.IP, name string, value net.IP, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPValue(value, p), name, "", usage, validation...)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
-func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
-	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage)
+func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IP defines an net.IP flag with specified name, default value, and usage string.
 // The return value is the address of an net.IP variable that stores the value of the flag.
-func (f *FlagSet) IP(name string, value net.IP, usage string) *net.IP {
+func (f *FlagSet) IP(name string, value net.IP, usage string, validation ...func(value any) error) *net.IP {
 	p := new(net.IP)
-	f.IPVarP(p, name, "", value, usage)
+	f.IPVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string) *net.IP {
+func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string, validation ...func(value any) error) *net.IP {
 	p := new(net.IP)
-	f.IPVarP(p, name, shorthand, value, usage)
+	f.IPVarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // IP defines an net.IP flag with specified name, default value, and usage string.
 // The return value is the address of an net.IP variable that stores the value of the flag.
-func IP(name string, value net.IP, usage string) *net.IP {
-	return CommandLine.IPP(name, "", value, usage)
+func IP(name string, value net.IP, usage string, validation ...func(value any) error) *net.IP {
+	return CommandLine.IPP(name, "", value, usage, validation...)
 }
 
 // IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
-func IPP(name, shorthand string, value net.IP, usage string) *net.IP {
-	return CommandLine.IPP(name, shorthand, value, usage)
+func IPP(name, shorthand string, value net.IP, usage string, validation ...func(value any) error) *net.IP {
+	return CommandLine.IPP(name, shorthand, value, usage, validation...)
 }

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -139,36 +139,36 @@ func (f *FlagSet) GetIPSlice(name string) ([]net.IP, error) {
 
 // IPSliceVar defines a ipSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
-func (f *FlagSet) IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPSliceVar defines a []net.IP flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
-func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value any) error) {
+func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value any) error) {
+func IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of that flag.
-func (f *FlagSet) IPSlice(name string, value []net.IP, usage string, validation ...func(value any) error) *[]net.IP {
+func (f *FlagSet) IPSlice(name string, value []net.IP, usage string, validation ...func(value interface{}) error) *[]net.IP {
 	p := []net.IP{}
 	f.IPSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // IPSliceP is like IPSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value any) error) *[]net.IP {
+func (f *FlagSet) IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value interface{}) error) *[]net.IP {
 	p := []net.IP{}
 	f.IPSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -176,11 +176,11 @@ func (f *FlagSet) IPSliceP(name, shorthand string, value []net.IP, usage string,
 
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of the flag.
-func IPSlice(name string, value []net.IP, usage string, validation ...func(value any) error) *[]net.IP {
+func IPSlice(name string, value []net.IP, usage string, validation ...func(value interface{}) error) *[]net.IP {
 	return CommandLine.IPSliceP(name, "", value, usage, validation...)
 }
 
 // IPSliceP is like IPSlice, but accepts a shorthand letter that can be used after a single dash.
-func IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value any) error) *[]net.IP {
+func IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value interface{}) error) *[]net.IP {
 	return CommandLine.IPSliceP(name, shorthand, value, usage, validation...)
 }

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -139,36 +139,56 @@ func (f *FlagSet) GetIPSlice(name string) ([]net.IP, error) {
 
 // IPSliceVar defines a ipSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
-func (f *FlagSet) IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPSliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value []net.IP) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIPSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newIPSliceValue(value, p), name, "", usage)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPSliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value []net.IP) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIPSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newIPSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPSliceVar defines a []net.IP flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
-func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPSliceValue(value, p), name, "", usage, validation...)
+func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value []net.IP) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIPSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIPSliceValue(value, p), name, "", usage)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPSliceValue(value, p), name, shorthand, usage, validation...)
+func IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value []net.IP) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIPSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIPSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of that flag.
-func (f *FlagSet) IPSlice(name string, value []net.IP, usage string, validation ...func(value interface{}) error) *[]net.IP {
+func (f *FlagSet) IPSlice(name string, value []net.IP, usage string, validation ...func(value []net.IP) error) *[]net.IP {
 	p := []net.IP{}
 	f.IPSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // IPSliceP is like IPSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value interface{}) error) *[]net.IP {
+func (f *FlagSet) IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value []net.IP) error) *[]net.IP {
 	p := []net.IP{}
 	f.IPSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -176,11 +196,11 @@ func (f *FlagSet) IPSliceP(name, shorthand string, value []net.IP, usage string,
 
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of the flag.
-func IPSlice(name string, value []net.IP, usage string, validation ...func(value interface{}) error) *[]net.IP {
+func IPSlice(name string, value []net.IP, usage string, validation ...func(value []net.IP) error) *[]net.IP {
 	return CommandLine.IPSliceP(name, "", value, usage, validation...)
 }
 
 // IPSliceP is like IPSlice, but accepts a shorthand letter that can be used after a single dash.
-func IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value interface{}) error) *[]net.IP {
+func IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value []net.IP) error) *[]net.IP {
 	return CommandLine.IPSliceP(name, shorthand, value, usage, validation...)
 }

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -139,48 +139,48 @@ func (f *FlagSet) GetIPSlice(name string) ([]net.IP, error) {
 
 // IPSliceVar defines a ipSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
-func (f *FlagSet) IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string) {
-	f.VarP(newIPSliceValue(value, p), name, "", usage)
+func (f *FlagSet) IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value any) error) {
+	f.VarP(newIPSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string) {
-	f.VarP(newIPSliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value any) error) {
+	f.VarP(newIPSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPSliceVar defines a []net.IP flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
-func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string) {
-	CommandLine.VarP(newIPSliceValue(value, p), name, "", usage)
+func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string) {
-	CommandLine.VarP(newIPSliceValue(value, p), name, shorthand, usage)
+func IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of that flag.
-func (f *FlagSet) IPSlice(name string, value []net.IP, usage string) *[]net.IP {
+func (f *FlagSet) IPSlice(name string, value []net.IP, usage string, validation ...func(value any) error) *[]net.IP {
 	p := []net.IP{}
-	f.IPSliceVarP(&p, name, "", value, usage)
+	f.IPSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // IPSliceP is like IPSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPSliceP(name, shorthand string, value []net.IP, usage string) *[]net.IP {
+func (f *FlagSet) IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value any) error) *[]net.IP {
 	p := []net.IP{}
-	f.IPSliceVarP(&p, name, shorthand, value, usage)
+	f.IPSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of the flag.
-func IPSlice(name string, value []net.IP, usage string) *[]net.IP {
-	return CommandLine.IPSliceP(name, "", value, usage)
+func IPSlice(name string, value []net.IP, usage string, validation ...func(value any) error) *[]net.IP {
+	return CommandLine.IPSliceP(name, "", value, usage, validation...)
 }
 
 // IPSliceP is like IPSlice, but accepts a shorthand letter that can be used after a single dash.
-func IPSliceP(name, shorthand string, value []net.IP, usage string) *[]net.IP {
-	return CommandLine.IPSliceP(name, shorthand, value, usage)
+func IPSliceP(name, shorthand string, value []net.IP, usage string, validation ...func(value any) error) *[]net.IP {
+	return CommandLine.IPSliceP(name, shorthand, value, usage, validation...)
 }

--- a/ipmask.go
+++ b/ipmask.go
@@ -75,36 +75,56 @@ func (f *FlagSet) GetIPv4Mask(name string) (net.IPMask, error) {
 
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
-func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPMaskValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value net.IPMask) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIPMaskValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newIPMaskValue(value, p), name, "", usage)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPMaskValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value net.IPMask) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newIPMaskValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newIPMaskValue(value, p), name, shorthand, usage)
 }
 
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
-func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPMaskValue(value, p), name, "", usage, validation...)
+func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value net.IPMask) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIPMaskValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIPMaskValue(value, p), name, "", usage)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
-func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage, validation...)
+func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value net.IPMask) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage)
 }
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPMask variable that stores the value of the flag.
-func (f *FlagSet) IPMask(name string, value net.IPMask, usage string, validation ...func(value interface{}) error) *net.IPMask {
+func (f *FlagSet) IPMask(name string, value net.IPMask, usage string, validation ...func(value net.IPMask) error) *net.IPMask {
 	p := new(net.IPMask)
 	f.IPMaskVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IPMaskP is like IPMask, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value interface{}) error) *net.IPMask {
+func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value net.IPMask) error) *net.IPMask {
 	p := new(net.IPMask)
 	f.IPMaskVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -112,11 +132,11 @@ func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPMask variable that stores the value of the flag.
-func IPMask(name string, value net.IPMask, usage string, validation ...func(value interface{}) error) *net.IPMask {
+func IPMask(name string, value net.IPMask, usage string, validation ...func(value net.IPMask) error) *net.IPMask {
 	return CommandLine.IPMaskP(name, "", value, usage, validation...)
 }
 
 // IPMaskP is like IP, but accepts a shorthand letter that can be used after a single dash.
-func IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value interface{}) error) *net.IPMask {
+func IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value net.IPMask) error) *net.IPMask {
 	return CommandLine.IPMaskP(name, shorthand, value, usage, validation...)
 }

--- a/ipmask.go
+++ b/ipmask.go
@@ -75,48 +75,48 @@ func (f *FlagSet) GetIPv4Mask(name string) (net.IPMask, error) {
 
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
-func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
-	f.VarP(newIPMaskValue(value, p), name, "", usage)
+func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value any) error) {
+	f.VarP(newIPMaskValue(value, p), name, "", usage, validation...)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
-	f.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value any) error) {
+	f.VarP(newIPMaskValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
-func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
-	CommandLine.VarP(newIPMaskValue(value, p), name, "", usage)
+func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPMaskValue(value, p), name, "", usage, validation...)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
-func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
-	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPMask variable that stores the value of the flag.
-func (f *FlagSet) IPMask(name string, value net.IPMask, usage string) *net.IPMask {
+func (f *FlagSet) IPMask(name string, value net.IPMask, usage string, validation ...func(value any) error) *net.IPMask {
 	p := new(net.IPMask)
-	f.IPMaskVarP(p, name, "", value, usage)
+	f.IPMaskVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IPMaskP is like IPMask, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
+func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value any) error) *net.IPMask {
 	p := new(net.IPMask)
-	f.IPMaskVarP(p, name, shorthand, value, usage)
+	f.IPMaskVarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPMask variable that stores the value of the flag.
-func IPMask(name string, value net.IPMask, usage string) *net.IPMask {
-	return CommandLine.IPMaskP(name, "", value, usage)
+func IPMask(name string, value net.IPMask, usage string, validation ...func(value any) error) *net.IPMask {
+	return CommandLine.IPMaskP(name, "", value, usage, validation...)
 }
 
 // IPMaskP is like IP, but accepts a shorthand letter that can be used after a single dash.
-func IPMaskP(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
-	return CommandLine.IPMaskP(name, shorthand, value, usage)
+func IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value any) error) *net.IPMask {
+	return CommandLine.IPMaskP(name, shorthand, value, usage, validation...)
 }

--- a/ipmask.go
+++ b/ipmask.go
@@ -75,36 +75,36 @@ func (f *FlagSet) GetIPv4Mask(name string) (net.IPMask, error) {
 
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
-func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPMaskValue(value, p), name, "", usage, validation...)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPMaskValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
-func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value any) error) {
+func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPMaskValue(value, p), name, "", usage, validation...)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
-func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value any) error) {
+func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPMask variable that stores the value of the flag.
-func (f *FlagSet) IPMask(name string, value net.IPMask, usage string, validation ...func(value any) error) *net.IPMask {
+func (f *FlagSet) IPMask(name string, value net.IPMask, usage string, validation ...func(value interface{}) error) *net.IPMask {
 	p := new(net.IPMask)
 	f.IPMaskVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IPMaskP is like IPMask, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value any) error) *net.IPMask {
+func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value interface{}) error) *net.IPMask {
 	p := new(net.IPMask)
 	f.IPMaskVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -112,11 +112,11 @@ func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPMask variable that stores the value of the flag.
-func IPMask(name string, value net.IPMask, usage string, validation ...func(value any) error) *net.IPMask {
+func IPMask(name string, value net.IPMask, usage string, validation ...func(value interface{}) error) *net.IPMask {
 	return CommandLine.IPMaskP(name, "", value, usage, validation...)
 }
 
 // IPMaskP is like IP, but accepts a shorthand letter that can be used after a single dash.
-func IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value any) error) *net.IPMask {
+func IPMaskP(name, shorthand string, value net.IPMask, usage string, validation ...func(value interface{}) error) *net.IPMask {
 	return CommandLine.IPMaskP(name, shorthand, value, usage, validation...)
 }

--- a/ipnet.go
+++ b/ipnet.go
@@ -51,36 +51,36 @@ func (f *FlagSet) GetIPNet(name string) (net.IPNet, error) {
 
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
-func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPNetValue(value, p), name, "", usage, validation...)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPNetValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
-func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value any) error) {
+func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPNetValue(value, p), name, "", usage, validation...)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
-func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value any) error) {
+func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPNet variable that stores the value of the flag.
-func (f *FlagSet) IPNet(name string, value net.IPNet, usage string, validation ...func(value any) error) *net.IPNet {
+func (f *FlagSet) IPNet(name string, value net.IPNet, usage string, validation ...func(value interface{}) error) *net.IPNet {
 	p := new(net.IPNet)
 	f.IPNetVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value any) error) *net.IPNet {
+func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value interface{}) error) *net.IPNet {
 	p := new(net.IPNet)
 	f.IPNetVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -88,11 +88,11 @@ func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string, 
 
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPNet variable that stores the value of the flag.
-func IPNet(name string, value net.IPNet, usage string, validation ...func(value any) error) *net.IPNet {
+func IPNet(name string, value net.IPNet, usage string, validation ...func(value interface{}) error) *net.IPNet {
 	return CommandLine.IPNetP(name, "", value, usage, validation...)
 }
 
 // IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
-func IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value any) error) *net.IPNet {
+func IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value interface{}) error) *net.IPNet {
 	return CommandLine.IPNetP(name, shorthand, value, usage, validation...)
 }

--- a/ipnet.go
+++ b/ipnet.go
@@ -51,48 +51,48 @@ func (f *FlagSet) GetIPNet(name string) (net.IPNet, error) {
 
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
-func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
-	f.VarP(newIPNetValue(value, p), name, "", usage)
+func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value any) error) {
+	f.VarP(newIPNetValue(value, p), name, "", usage, validation...)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
-	f.VarP(newIPNetValue(value, p), name, shorthand, usage)
+func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value any) error) {
+	f.VarP(newIPNetValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
-func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetValue(value, p), name, "", usage)
+func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPNetValue(value, p), name, "", usage, validation...)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
-func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage)
+func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPNet variable that stores the value of the flag.
-func (f *FlagSet) IPNet(name string, value net.IPNet, usage string) *net.IPNet {
+func (f *FlagSet) IPNet(name string, value net.IPNet, usage string, validation ...func(value any) error) *net.IPNet {
 	p := new(net.IPNet)
-	f.IPNetVarP(p, name, "", value, usage)
+	f.IPNetVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string) *net.IPNet {
+func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value any) error) *net.IPNet {
 	p := new(net.IPNet)
-	f.IPNetVarP(p, name, shorthand, value, usage)
+	f.IPNetVarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPNet variable that stores the value of the flag.
-func IPNet(name string, value net.IPNet, usage string) *net.IPNet {
-	return CommandLine.IPNetP(name, "", value, usage)
+func IPNet(name string, value net.IPNet, usage string, validation ...func(value any) error) *net.IPNet {
+	return CommandLine.IPNetP(name, "", value, usage, validation...)
 }
 
 // IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
-func IPNetP(name, shorthand string, value net.IPNet, usage string) *net.IPNet {
-	return CommandLine.IPNetP(name, shorthand, value, usage)
+func IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value any) error) *net.IPNet {
+	return CommandLine.IPNetP(name, shorthand, value, usage, validation...)
 }

--- a/ipnet.go
+++ b/ipnet.go
@@ -51,36 +51,52 @@ func (f *FlagSet) GetIPNet(name string) (net.IPNet, error) {
 
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
-func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPNetValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value net.IPNet) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		f.VarP(newIPNetValue(value, p), name, "", usage, validationFunc)
+	}
+	f.VarP(newIPNetValue(value, p), name, "", usage)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPNetValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value net.IPNet) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		f.VarP(newIPNetValue(value, p), name, shorthand, usage, validationFunc)
+	}
+	f.VarP(newIPNetValue(value, p), name, shorthand, usage)
 }
 
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
-func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPNetValue(value, p), name, "", usage, validation...)
+func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string, validation ...func(value net.IPNet) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		CommandLine.VarP(newIPNetValue(value, p), name, "", usage, validationFunc)
+	}
+	CommandLine.VarP(newIPNetValue(value, p), name, "", usage)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
-func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage, validation...)
+func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string, validation ...func(value net.IPNet) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage, validationFunc)
+	}
+	CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage)
 }
 
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPNet variable that stores the value of the flag.
-func (f *FlagSet) IPNet(name string, value net.IPNet, usage string, validation ...func(value interface{}) error) *net.IPNet {
+func (f *FlagSet) IPNet(name string, value net.IPNet, usage string, validation ...func(value net.IPNet) error) *net.IPNet {
 	p := new(net.IPNet)
 	f.IPNetVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value interface{}) error) *net.IPNet {
+func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value net.IPNet) error) *net.IPNet {
 	p := new(net.IPNet)
 	f.IPNetVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -88,11 +104,11 @@ func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string, 
 
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPNet variable that stores the value of the flag.
-func IPNet(name string, value net.IPNet, usage string, validation ...func(value interface{}) error) *net.IPNet {
+func IPNet(name string, value net.IPNet, usage string, validation ...func(value net.IPNet) error) *net.IPNet {
 	return CommandLine.IPNetP(name, "", value, usage, validation...)
 }
 
 // IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
-func IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value interface{}) error) *net.IPNet {
+func IPNetP(name, shorthand string, value net.IPNet, usage string, validation ...func(value net.IPNet) error) *net.IPNet {
 	return CommandLine.IPNetP(name, shorthand, value, usage, validation...)
 }

--- a/ipnet_slice.go
+++ b/ipnet_slice.go
@@ -100,36 +100,36 @@ func (f *FlagSet) GetIPNetSlice(name string) ([]net.IPNet, error) {
 
 // IPNetSliceVar defines a ipNetSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IPNet variable in which to store the value of the flag.
-func (f *FlagSet) IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPNetSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IPNetSliceVarP is like IPNetSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value any) error) {
+func (f *FlagSet) IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newIPNetSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPNetSliceVar defines a []net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to a []net.IPNet variable in which to store the value of the flag.
-func IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value any) error) {
+func IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPNetSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IPNetSliceVarP is like IPNetSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value any) error) {
+func IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newIPNetSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPNetSlice defines a []net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IPNet variable that stores the value of that flag.
-func (f *FlagSet) IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value any) error) *[]net.IPNet {
+func (f *FlagSet) IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value interface{}) error) *[]net.IPNet {
 	p := []net.IPNet{}
 	f.IPNetSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // IPNetSliceP is like IPNetSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value any) error) *[]net.IPNet {
+func (f *FlagSet) IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value interface{}) error) *[]net.IPNet {
 	p := []net.IPNet{}
 	f.IPNetSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -137,11 +137,11 @@ func (f *FlagSet) IPNetSliceP(name, shorthand string, value []net.IPNet, usage s
 
 // IPNetSlice defines a []net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of the flag.
-func IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value any) error) *[]net.IPNet {
+func IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value interface{}) error) *[]net.IPNet {
 	return CommandLine.IPNetSliceP(name, "", value, usage, validation...)
 }
 
 // IPNetSliceP is like IPNetSlice, but accepts a shorthand letter that can be used after a single dash.
-func IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value any) error) *[]net.IPNet {
+func IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value interface{}) error) *[]net.IPNet {
 	return CommandLine.IPNetSliceP(name, shorthand, value, usage, validation...)
 }

--- a/ipnet_slice.go
+++ b/ipnet_slice.go
@@ -100,36 +100,52 @@ func (f *FlagSet) GetIPNetSlice(name string) ([]net.IPNet, error) {
 
 // IPNetSliceVar defines a ipNetSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IPNet variable in which to store the value of the flag.
-func (f *FlagSet) IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPNetSliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value []net.IPNet) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		f.VarP(newIPNetSliceValue(value, p), name, "", usage, validationFunc)
+	}
+	f.VarP(newIPNetSliceValue(value, p), name, "", usage)
 }
 
 // IPNetSliceVarP is like IPNetSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newIPNetSliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value []net.IPNet) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		f.VarP(newIPNetSliceValue(value, p), name, shorthand, usage, validationFunc)
+	}
+	f.VarP(newIPNetSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPNetSliceVar defines a []net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to a []net.IPNet variable in which to store the value of the flag.
-func IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPNetSliceValue(value, p), name, "", usage, validation...)
+func IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value []net.IPNet) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		CommandLine.VarP(newIPNetSliceValue(value, p), name, "", usage, validationFunc)
+	}
+	CommandLine.VarP(newIPNetSliceValue(value, p), name, "", usage)
 }
 
 // IPNetSliceVarP is like IPNetSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newIPNetSliceValue(value, p), name, shorthand, usage, validation...)
+func IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value []net.IPNet) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0]).(func(value interface{}) error)
+		CommandLine.VarP(newIPNetSliceValue(value, p), name, shorthand, usage, validationFunc)
+	}
+	CommandLine.VarP(newIPNetSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPNetSlice defines a []net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IPNet variable that stores the value of that flag.
-func (f *FlagSet) IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value interface{}) error) *[]net.IPNet {
+func (f *FlagSet) IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value []net.IPNet) error) *[]net.IPNet {
 	p := []net.IPNet{}
 	f.IPNetSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // IPNetSliceP is like IPNetSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value interface{}) error) *[]net.IPNet {
+func (f *FlagSet) IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value []net.IPNet) error) *[]net.IPNet {
 	p := []net.IPNet{}
 	f.IPNetSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -137,11 +153,11 @@ func (f *FlagSet) IPNetSliceP(name, shorthand string, value []net.IPNet, usage s
 
 // IPNetSlice defines a []net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of the flag.
-func IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value interface{}) error) *[]net.IPNet {
+func IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value []net.IPNet) error) *[]net.IPNet {
 	return CommandLine.IPNetSliceP(name, "", value, usage, validation...)
 }
 
 // IPNetSliceP is like IPNetSlice, but accepts a shorthand letter that can be used after a single dash.
-func IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value interface{}) error) *[]net.IPNet {
+func IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value []net.IPNet) error) *[]net.IPNet {
 	return CommandLine.IPNetSliceP(name, shorthand, value, usage, validation...)
 }

--- a/ipnet_slice.go
+++ b/ipnet_slice.go
@@ -100,48 +100,48 @@ func (f *FlagSet) GetIPNetSlice(name string) ([]net.IPNet, error) {
 
 // IPNetSliceVar defines a ipNetSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IPNet variable in which to store the value of the flag.
-func (f *FlagSet) IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string) {
-	f.VarP(newIPNetSliceValue(value, p), name, "", usage)
+func (f *FlagSet) IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value any) error) {
+	f.VarP(newIPNetSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IPNetSliceVarP is like IPNetSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string) {
-	f.VarP(newIPNetSliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value any) error) {
+	f.VarP(newIPNetSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPNetSliceVar defines a []net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to a []net.IPNet variable in which to store the value of the flag.
-func IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetSliceValue(value, p), name, "", usage)
+func IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPNetSliceValue(value, p), name, "", usage, validation...)
 }
 
 // IPNetSliceVarP is like IPNetSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetSliceValue(value, p), name, shorthand, usage)
+func IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newIPNetSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // IPNetSlice defines a []net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IPNet variable that stores the value of that flag.
-func (f *FlagSet) IPNetSlice(name string, value []net.IPNet, usage string) *[]net.IPNet {
+func (f *FlagSet) IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value any) error) *[]net.IPNet {
 	p := []net.IPNet{}
-	f.IPNetSliceVarP(&p, name, "", value, usage)
+	f.IPNetSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // IPNetSliceP is like IPNetSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) IPNetSliceP(name, shorthand string, value []net.IPNet, usage string) *[]net.IPNet {
+func (f *FlagSet) IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value any) error) *[]net.IPNet {
 	p := []net.IPNet{}
-	f.IPNetSliceVarP(&p, name, shorthand, value, usage)
+	f.IPNetSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // IPNetSlice defines a []net.IPNet flag with specified name, default value, and usage string.
 // The return value is the address of a []net.IP variable that stores the value of the flag.
-func IPNetSlice(name string, value []net.IPNet, usage string) *[]net.IPNet {
-	return CommandLine.IPNetSliceP(name, "", value, usage)
+func IPNetSlice(name string, value []net.IPNet, usage string, validation ...func(value any) error) *[]net.IPNet {
+	return CommandLine.IPNetSliceP(name, "", value, usage, validation...)
 }
 
 // IPNetSliceP is like IPNetSlice, but accepts a shorthand letter that can be used after a single dash.
-func IPNetSliceP(name, shorthand string, value []net.IPNet, usage string) *[]net.IPNet {
-	return CommandLine.IPNetSliceP(name, shorthand, value, usage)
+func IPNetSliceP(name, shorthand string, value []net.IPNet, usage string, validation ...func(value any) error) *[]net.IPNet {
+	return CommandLine.IPNetSliceP(name, shorthand, value, usage, validation...)
 }

--- a/string.go
+++ b/string.go
@@ -33,48 +33,48 @@ func (f *FlagSet) GetString(name string) (string, error) {
 
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
-func (f *FlagSet) StringVar(p *string, name string, value string, usage string) {
-	f.VarP(newStringValue(value, p), name, "", usage)
+func (f *FlagSet) StringVar(p *string, name string, value string, usage string, validation ...func(value any) error) {
+	f.VarP(newStringValue(value, p), name, "", usage, validation...)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string) {
-	f.VarP(newStringValue(value, p), name, shorthand, usage)
+func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value any) error) {
+	f.VarP(newStringValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
-func StringVar(p *string, name string, value string, usage string) {
-	CommandLine.VarP(newStringValue(value, p), name, "", usage)
+func StringVar(p *string, name string, value string, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringValue(value, p), name, "", usage, validation...)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
-func StringVarP(p *string, name, shorthand string, value string, usage string) {
-	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage)
+func StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage, validation...)
 }
 
 // String defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a string variable that stores the value of the flag.
-func (f *FlagSet) String(name string, value string, usage string) *string {
+func (f *FlagSet) String(name string, value string, usage string, validation ...func(value any) error) *string {
 	p := new(string)
-	f.StringVarP(p, name, "", value, usage)
+	f.StringVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // StringP is like String, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringP(name, shorthand string, value string, usage string) *string {
+func (f *FlagSet) StringP(name, shorthand string, value string, usage string, validation ...func(value any) error) *string {
 	p := new(string)
-	f.StringVarP(p, name, shorthand, value, usage)
+	f.StringVarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // String defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a string variable that stores the value of the flag.
-func String(name string, value string, usage string) *string {
-	return CommandLine.StringP(name, "", value, usage)
+func String(name string, value string, usage string, validation ...func(value any) error) *string {
+	return CommandLine.StringP(name, "", value, usage, validation...)
 }
 
 // StringP is like String, but accepts a shorthand letter that can be used after a single dash.
-func StringP(name, shorthand string, value string, usage string) *string {
-	return CommandLine.StringP(name, shorthand, value, usage)
+func StringP(name, shorthand string, value string, usage string, validation ...func(value any) error) *string {
+	return CommandLine.StringP(name, shorthand, value, usage, validation...)
 }

--- a/string.go
+++ b/string.go
@@ -33,36 +33,56 @@ func (f *FlagSet) GetString(name string) (string, error) {
 
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
-func (f *FlagSet) StringVar(p *string, name string, value string, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) StringVar(p *string, name string, value string, usage string, validation ...func(value string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newStringValue(value, p), name, "", usage)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newStringValue(value, p), name, shorthand, usage)
 }
 
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
-func StringVar(p *string, name string, value string, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringValue(value, p), name, "", usage, validation...)
+func StringVar(p *string, name string, value string, usage string, validation ...func(value string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringValue(value, p), name, "", usage)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
-func StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage, validation...)
+func StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage)
 }
 
 // String defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a string variable that stores the value of the flag.
-func (f *FlagSet) String(name string, value string, usage string, validation ...func(value interface{}) error) *string {
+func (f *FlagSet) String(name string, value string, usage string, validation ...func(value string) error) *string {
 	p := new(string)
 	f.StringVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // StringP is like String, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringP(name, shorthand string, value string, usage string, validation ...func(value interface{}) error) *string {
+func (f *FlagSet) StringP(name, shorthand string, value string, usage string, validation ...func(value string) error) *string {
 	p := new(string)
 	f.StringVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -70,11 +90,11 @@ func (f *FlagSet) StringP(name, shorthand string, value string, usage string, va
 
 // String defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a string variable that stores the value of the flag.
-func String(name string, value string, usage string, validation ...func(value interface{}) error) *string {
+func String(name string, value string, usage string, validation ...func(value string) error) *string {
 	return CommandLine.StringP(name, "", value, usage, validation...)
 }
 
 // StringP is like String, but accepts a shorthand letter that can be used after a single dash.
-func StringP(name, shorthand string, value string, usage string, validation ...func(value interface{}) error) *string {
+func StringP(name, shorthand string, value string, usage string, validation ...func(value string) error) *string {
 	return CommandLine.StringP(name, shorthand, value, usage, validation...)
 }

--- a/string.go
+++ b/string.go
@@ -33,36 +33,36 @@ func (f *FlagSet) GetString(name string) (string, error) {
 
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
-func (f *FlagSet) StringVar(p *string, name string, value string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringVar(p *string, name string, value string, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringValue(value, p), name, "", usage, validation...)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
-func StringVar(p *string, name string, value string, usage string, validation ...func(value any) error) {
+func StringVar(p *string, name string, value string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringValue(value, p), name, "", usage, validation...)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
-func StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value any) error) {
+func StringVarP(p *string, name, shorthand string, value string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage, validation...)
 }
 
 // String defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a string variable that stores the value of the flag.
-func (f *FlagSet) String(name string, value string, usage string, validation ...func(value any) error) *string {
+func (f *FlagSet) String(name string, value string, usage string, validation ...func(value interface{}) error) *string {
 	p := new(string)
 	f.StringVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // StringP is like String, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringP(name, shorthand string, value string, usage string, validation ...func(value any) error) *string {
+func (f *FlagSet) StringP(name, shorthand string, value string, usage string, validation ...func(value interface{}) error) *string {
 	p := new(string)
 	f.StringVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -70,11 +70,11 @@ func (f *FlagSet) StringP(name, shorthand string, value string, usage string, va
 
 // String defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a string variable that stores the value of the flag.
-func String(name string, value string, usage string, validation ...func(value any) error) *string {
+func String(name string, value string, usage string, validation ...func(value interface{}) error) *string {
 	return CommandLine.StringP(name, "", value, usage, validation...)
 }
 
 // StringP is like String, but accepts a shorthand letter that can be used after a single dash.
-func StringP(name, shorthand string, value string, usage string, validation ...func(value any) error) *string {
+func StringP(name, shorthand string, value string, usage string, validation ...func(value interface{}) error) *string {
 	return CommandLine.StringP(name, shorthand, value, usage, validation...)
 }

--- a/string_array.go
+++ b/string_array.go
@@ -75,38 +75,58 @@ func (f *FlagSet) GetStringArray(name string) ([]string, error) {
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringArrayValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value []string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringArrayValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newStringArrayValue(value, p), name, "", usage)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringArrayValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value []string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringArrayValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newStringArrayValue(value, p), name, shorthand, usage)
 }
 
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringArrayValue(value, p), name, "", usage, validation...)
+func StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value []string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringArrayValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringArrayValue(value, p), name, "", usage)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
-func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringArrayValue(value, p), name, shorthand, usage, validation...)
+func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value []string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringArrayValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringArrayValue(value, p), name, shorthand, usage)
 }
 
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func (f *FlagSet) StringArray(name string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
+func (f *FlagSet) StringArray(name string, value []string, usage string, validation ...func(value []string) error) *[]string {
 	p := []string{}
 	f.StringArrayVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringArrayP is like StringArray, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
+func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value []string) error) *[]string {
 	p := []string{}
 	f.StringArrayVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -115,11 +135,11 @@ func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage str
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func StringArray(name string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
+func StringArray(name string, value []string, usage string, validation ...func(value []string) error) *[]string {
 	return CommandLine.StringArrayP(name, "", value, usage, validation...)
 }
 
 // StringArrayP is like StringArray, but accepts a shorthand letter that can be used after a single dash.
-func StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
+func StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value []string) error) *[]string {
 	return CommandLine.StringArrayP(name, shorthand, value, usage, validation...)
 }

--- a/string_array.go
+++ b/string_array.go
@@ -75,38 +75,38 @@ func (f *FlagSet) GetStringArray(name string) ([]string, error) {
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringArrayValue(value, p), name, "", usage, validation...)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringArrayValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value any) error) {
+func StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringArrayValue(value, p), name, "", usage, validation...)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
-func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value any) error) {
+func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringArrayValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func (f *FlagSet) StringArray(name string, value []string, usage string, validation ...func(value any) error) *[]string {
+func (f *FlagSet) StringArray(name string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
 	p := []string{}
 	f.StringArrayVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringArrayP is like StringArray, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value any) error) *[]string {
+func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
 	p := []string{}
 	f.StringArrayVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -115,11 +115,11 @@ func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage str
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func StringArray(name string, value []string, usage string, validation ...func(value any) error) *[]string {
+func StringArray(name string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
 	return CommandLine.StringArrayP(name, "", value, usage, validation...)
 }
 
 // StringArrayP is like StringArray, but accepts a shorthand letter that can be used after a single dash.
-func StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value any) error) *[]string {
+func StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
 	return CommandLine.StringArrayP(name, shorthand, value, usage, validation...)
 }

--- a/string_array.go
+++ b/string_array.go
@@ -75,51 +75,51 @@ func (f *FlagSet) GetStringArray(name string) ([]string, error) {
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string) {
-	f.VarP(newStringArrayValue(value, p), name, "", usage)
+func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value any) error) {
+	f.VarP(newStringArrayValue(value, p), name, "", usage, validation...)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	f.VarP(newStringArrayValue(value, p), name, shorthand, usage)
+func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value any) error) {
+	f.VarP(newStringArrayValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func StringArrayVar(p *[]string, name string, value []string, usage string) {
-	CommandLine.VarP(newStringArrayValue(value, p), name, "", usage)
+func StringArrayVar(p *[]string, name string, value []string, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringArrayValue(value, p), name, "", usage, validation...)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
-func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	CommandLine.VarP(newStringArrayValue(value, p), name, shorthand, usage)
+func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringArrayValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func (f *FlagSet) StringArray(name string, value []string, usage string) *[]string {
+func (f *FlagSet) StringArray(name string, value []string, usage string, validation ...func(value any) error) *[]string {
 	p := []string{}
-	f.StringArrayVarP(&p, name, "", value, usage)
+	f.StringArrayVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringArrayP is like StringArray, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage string) *[]string {
+func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value any) error) *[]string {
 	p := []string{}
-	f.StringArrayVarP(&p, name, shorthand, value, usage)
+	f.StringArrayVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
-func StringArray(name string, value []string, usage string) *[]string {
-	return CommandLine.StringArrayP(name, "", value, usage)
+func StringArray(name string, value []string, usage string, validation ...func(value any) error) *[]string {
+	return CommandLine.StringArrayP(name, "", value, usage, validation...)
 }
 
 // StringArrayP is like StringArray, but accepts a shorthand letter that can be used after a single dash.
-func StringArrayP(name, shorthand string, value []string, usage string) *[]string {
-	return CommandLine.StringArrayP(name, shorthand, value, usage)
+func StringArrayP(name, shorthand string, value []string, usage string, validation ...func(value any) error) *[]string {
+	return CommandLine.StringArrayP(name, shorthand, value, usage, validation...)
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -98,51 +98,60 @@ func (f *FlagSet) GetStringSlice(name string) ([]string, error) {
 // The argument p points to a []string variable in which to store the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
 // For example:
-//   --ss="v1,v2" --ss="v3"
+//
+//	--ss="v1,v2" --ss="v3"
+//
 // will result in
-//   []string{"v1", "v2", "v3"}
-func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string) {
-	f.VarP(newStringSliceValue(value, p), name, "", usage)
+//
+//	[]string{"v1", "v2", "v3"}
+func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value any) error) {
+	f.VarP(newStringSliceValue(value, p), name, "", usage, validation...)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	f.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value any) error) {
+	f.VarP(newStringSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
 // For example:
-//   --ss="v1,v2" --ss="v3"
+//
+//	--ss="v1,v2" --ss="v3"
+//
 // will result in
-//   []string{"v1", "v2", "v3"}
-func StringSliceVar(p *[]string, name string, value []string, usage string) {
-	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage)
+//
+//	[]string{"v1", "v2", "v3"}
+func StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage, validation...)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringSlice defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
 // For example:
-//   --ss="v1,v2" --ss="v3"
+//
+//	--ss="v1,v2" --ss="v3"
+//
 // will result in
-//   []string{"v1", "v2", "v3"}
-func (f *FlagSet) StringSlice(name string, value []string, usage string) *[]string {
+//
+//	[]string{"v1", "v2", "v3"}
+func (f *FlagSet) StringSlice(name string, value []string, usage string, validation ...func(value any) error) *[]string {
 	p := []string{}
-	f.StringSliceVarP(&p, name, "", value, usage)
+	f.StringSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage string) *[]string {
+func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value any) error) *[]string {
 	p := []string{}
-	f.StringSliceVarP(&p, name, shorthand, value, usage)
+	f.StringSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
@@ -150,14 +159,17 @@ func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage str
 // The return value is the address of a []string variable that stores the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
 // For example:
-//   --ss="v1,v2" --ss="v3"
+//
+//	--ss="v1,v2" --ss="v3"
+//
 // will result in
-//   []string{"v1", "v2", "v3"}
-func StringSlice(name string, value []string, usage string) *[]string {
-	return CommandLine.StringSliceP(name, "", value, usage)
+//
+//	[]string{"v1", "v2", "v3"}
+func StringSlice(name string, value []string, usage string, validation ...func(value any) error) *[]string {
+	return CommandLine.StringSliceP(name, "", value, usage, validation...)
 }
 
 // StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
-func StringSliceP(name, shorthand string, value []string, usage string) *[]string {
-	return CommandLine.StringSliceP(name, shorthand, value, usage)
+func StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value any) error) *[]string {
+	return CommandLine.StringSliceP(name, shorthand, value, usage, validation...)
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -104,12 +104,12 @@ func (f *FlagSet) GetStringSlice(name string) ([]string, error) {
 // will result in
 //
 //	[]string{"v1", "v2", "v3"}
-func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringSliceValue(value, p), name, "", usage, validation...)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
@@ -123,12 +123,12 @@ func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []s
 // will result in
 //
 //	[]string{"v1", "v2", "v3"}
-func StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value any) error) {
+func StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage, validation...)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value any) error) {
+func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
@@ -142,14 +142,14 @@ func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage 
 // will result in
 //
 //	[]string{"v1", "v2", "v3"}
-func (f *FlagSet) StringSlice(name string, value []string, usage string, validation ...func(value any) error) *[]string {
+func (f *FlagSet) StringSlice(name string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
 	p := []string{}
 	f.StringSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value any) error) *[]string {
+func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
 	p := []string{}
 	f.StringSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -165,11 +165,11 @@ func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage str
 // will result in
 //
 //	[]string{"v1", "v2", "v3"}
-func StringSlice(name string, value []string, usage string, validation ...func(value any) error) *[]string {
+func StringSlice(name string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
 	return CommandLine.StringSliceP(name, "", value, usage, validation...)
 }
 
 // StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
-func StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value any) error) *[]string {
+func StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
 	return CommandLine.StringSliceP(name, shorthand, value, usage, validation...)
 }

--- a/string_slice.go
+++ b/string_slice.go
@@ -104,13 +104,23 @@ func (f *FlagSet) GetStringSlice(name string) ([]string, error) {
 // will result in
 //
 //	[]string{"v1", "v2", "v3"}
-func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringSliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value []string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newStringSliceValue(value, p), name, "", usage)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringSliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value []string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newStringSliceValue(value, p), name, shorthand, usage)
 }
 
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
@@ -123,13 +133,23 @@ func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []s
 // will result in
 //
 //	[]string{"v1", "v2", "v3"}
-func StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage, validation...)
+func StringSliceVar(p *[]string, name string, value []string, usage string, validation ...func(value []string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage, validation...)
+func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string, validation ...func(value []string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage)
 }
 
 // StringSlice defines a string flag with specified name, default value, and usage string.
@@ -142,14 +162,14 @@ func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage 
 // will result in
 //
 //	[]string{"v1", "v2", "v3"}
-func (f *FlagSet) StringSlice(name string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
+func (f *FlagSet) StringSlice(name string, value []string, usage string, validation ...func(value []string) error) *[]string {
 	p := []string{}
 	f.StringSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
+func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value []string) error) *[]string {
 	p := []string{}
 	f.StringSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -165,11 +185,11 @@ func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage str
 // will result in
 //
 //	[]string{"v1", "v2", "v3"}
-func StringSlice(name string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
+func StringSlice(name string, value []string, usage string, validation ...func(value []string) error) *[]string {
 	return CommandLine.StringSliceP(name, "", value, usage, validation...)
 }
 
 // StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
-func StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value interface{}) error) *[]string {
+func StringSliceP(name, shorthand string, value []string, usage string, validation ...func(value []string) error) *[]string {
 	return CommandLine.StringSliceP(name, shorthand, value, usage, validation...)
 }

--- a/string_to_int.go
+++ b/string_to_int.go
@@ -99,38 +99,38 @@ func (f *FlagSet) GetStringToInt(name string) (map[string]int, error) {
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringToIntValue(value, p), name, "", usage, validation...)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringToIntValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value any) error) {
+func StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringToIntValue(value, p), name, "", usage, validation...)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
-func StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value any) error) {
+func StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringToIntValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToInt defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToInt(name string, value map[string]int, usage string, validation ...func(value any) error) *map[string]int {
+func (f *FlagSet) StringToInt(name string, value map[string]int, usage string, validation ...func(value interface{}) error) *map[string]int {
 	p := map[string]int{}
 	f.StringToIntVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringToIntP is like StringToInt, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value any) error) *map[string]int {
+func (f *FlagSet) StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value interface{}) error) *map[string]int {
 	p := map[string]int{}
 	f.StringToIntVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -139,11 +139,11 @@ func (f *FlagSet) StringToIntP(name, shorthand string, value map[string]int, usa
 // StringToInt defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToInt(name string, value map[string]int, usage string, validation ...func(value any) error) *map[string]int {
+func StringToInt(name string, value map[string]int, usage string, validation ...func(value interface{}) error) *map[string]int {
 	return CommandLine.StringToIntP(name, "", value, usage, validation...)
 }
 
 // StringToIntP is like StringToInt, but accepts a shorthand letter that can be used after a single dash.
-func StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value any) error) *map[string]int {
+func StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value interface{}) error) *map[string]int {
 	return CommandLine.StringToIntP(name, shorthand, value, usage, validation...)
 }

--- a/string_to_int.go
+++ b/string_to_int.go
@@ -99,51 +99,51 @@ func (f *FlagSet) GetStringToInt(name string) (map[string]int, error) {
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToIntVar(p *map[string]int, name string, value map[string]int, usage string) {
-	f.VarP(newStringToIntValue(value, p), name, "", usage)
+func (f *FlagSet) StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value any) error) {
+	f.VarP(newStringToIntValue(value, p), name, "", usage, validation...)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string) {
-	f.VarP(newStringToIntValue(value, p), name, shorthand, usage)
+func (f *FlagSet) StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value any) error) {
+	f.VarP(newStringToIntValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToIntVar(p *map[string]int, name string, value map[string]int, usage string) {
-	CommandLine.VarP(newStringToIntValue(value, p), name, "", usage)
+func StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringToIntValue(value, p), name, "", usage, validation...)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
-func StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string) {
-	CommandLine.VarP(newStringToIntValue(value, p), name, shorthand, usage)
+func StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringToIntValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToInt defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToInt(name string, value map[string]int, usage string) *map[string]int {
+func (f *FlagSet) StringToInt(name string, value map[string]int, usage string, validation ...func(value any) error) *map[string]int {
 	p := map[string]int{}
-	f.StringToIntVarP(&p, name, "", value, usage)
+	f.StringToIntVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringToIntP is like StringToInt, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToIntP(name, shorthand string, value map[string]int, usage string) *map[string]int {
+func (f *FlagSet) StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value any) error) *map[string]int {
 	p := map[string]int{}
-	f.StringToIntVarP(&p, name, shorthand, value, usage)
+	f.StringToIntVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // StringToInt defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToInt(name string, value map[string]int, usage string) *map[string]int {
-	return CommandLine.StringToIntP(name, "", value, usage)
+func StringToInt(name string, value map[string]int, usage string, validation ...func(value any) error) *map[string]int {
+	return CommandLine.StringToIntP(name, "", value, usage, validation...)
 }
 
 // StringToIntP is like StringToInt, but accepts a shorthand letter that can be used after a single dash.
-func StringToIntP(name, shorthand string, value map[string]int, usage string) *map[string]int {
-	return CommandLine.StringToIntP(name, shorthand, value, usage)
+func StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value any) error) *map[string]int {
+	return CommandLine.StringToIntP(name, shorthand, value, usage, validation...)
 }

--- a/string_to_int.go
+++ b/string_to_int.go
@@ -99,38 +99,58 @@ func (f *FlagSet) GetStringToInt(name string) (map[string]int, error) {
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringToIntValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value map[string]int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringToIntValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newStringToIntValue(value, p), name, "", usage)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringToIntValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value map[string]int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringToIntValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newStringToIntValue(value, p), name, shorthand, usage)
 }
 
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringToIntValue(value, p), name, "", usage, validation...)
+func StringToIntVar(p *map[string]int, name string, value map[string]int, usage string, validation ...func(value map[string]int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringToIntValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringToIntValue(value, p), name, "", usage)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
-func StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringToIntValue(value, p), name, shorthand, usage, validation...)
+func StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string, validation ...func(value map[string]int) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringToIntValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringToIntValue(value, p), name, shorthand, usage)
 }
 
 // StringToInt defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToInt(name string, value map[string]int, usage string, validation ...func(value interface{}) error) *map[string]int {
+func (f *FlagSet) StringToInt(name string, value map[string]int, usage string, validation ...func(value map[string]int) error) *map[string]int {
 	p := map[string]int{}
 	f.StringToIntVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringToIntP is like StringToInt, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value interface{}) error) *map[string]int {
+func (f *FlagSet) StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value map[string]int) error) *map[string]int {
 	p := map[string]int{}
 	f.StringToIntVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -139,11 +159,11 @@ func (f *FlagSet) StringToIntP(name, shorthand string, value map[string]int, usa
 // StringToInt defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToInt(name string, value map[string]int, usage string, validation ...func(value interface{}) error) *map[string]int {
+func StringToInt(name string, value map[string]int, usage string, validation ...func(value map[string]int) error) *map[string]int {
 	return CommandLine.StringToIntP(name, "", value, usage, validation...)
 }
 
 // StringToIntP is like StringToInt, but accepts a shorthand letter that can be used after a single dash.
-func StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value interface{}) error) *map[string]int {
+func StringToIntP(name, shorthand string, value map[string]int, usage string, validation ...func(value map[string]int) error) *map[string]int {
 	return CommandLine.StringToIntP(name, shorthand, value, usage, validation...)
 }

--- a/string_to_int64.go
+++ b/string_to_int64.go
@@ -99,38 +99,58 @@ func (f *FlagSet) GetStringToInt64(name string) (map[string]int64, error) {
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringToInt64Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value map[string]int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringToInt64Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newStringToInt64Value(value, p), name, "", usage)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringToInt64Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value map[string]int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringToInt64Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
 }
 
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringToInt64Value(value, p), name, "", usage, validation...)
+func StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value map[string]int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringToInt64Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringToInt64Value(value, p), name, "", usage)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
-func StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringToInt64Value(value, p), name, shorthand, usage, validation...)
+func StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value map[string]int64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringToInt64Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
 }
 
 // StringToInt64 defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int64 variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToInt64(name string, value map[string]int64, usage string, validation ...func(value interface{}) error) *map[string]int64 {
+func (f *FlagSet) StringToInt64(name string, value map[string]int64, usage string, validation ...func(value map[string]int64) error) *map[string]int64 {
 	p := map[string]int64{}
 	f.StringToInt64VarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringToInt64P is like StringToInt64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value interface{}) error) *map[string]int64 {
+func (f *FlagSet) StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value map[string]int64) error) *map[string]int64 {
 	p := map[string]int64{}
 	f.StringToInt64VarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -139,11 +159,11 @@ func (f *FlagSet) StringToInt64P(name, shorthand string, value map[string]int64,
 // StringToInt64 defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int64 variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToInt64(name string, value map[string]int64, usage string, validation ...func(value interface{}) error) *map[string]int64 {
+func StringToInt64(name string, value map[string]int64, usage string, validation ...func(value map[string]int64) error) *map[string]int64 {
 	return CommandLine.StringToInt64P(name, "", value, usage, validation...)
 }
 
 // StringToInt64P is like StringToInt64, but accepts a shorthand letter that can be used after a single dash.
-func StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value interface{}) error) *map[string]int64 {
+func StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value map[string]int64) error) *map[string]int64 {
 	return CommandLine.StringToInt64P(name, shorthand, value, usage, validation...)
 }

--- a/string_to_int64.go
+++ b/string_to_int64.go
@@ -99,38 +99,38 @@ func (f *FlagSet) GetStringToInt64(name string) (map[string]int64, error) {
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringToInt64Value(value, p), name, "", usage, validation...)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringToInt64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value any) error) {
+func StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringToInt64Value(value, p), name, "", usage, validation...)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
-func StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value any) error) {
+func StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringToInt64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToInt64 defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int64 variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToInt64(name string, value map[string]int64, usage string, validation ...func(value any) error) *map[string]int64 {
+func (f *FlagSet) StringToInt64(name string, value map[string]int64, usage string, validation ...func(value interface{}) error) *map[string]int64 {
 	p := map[string]int64{}
 	f.StringToInt64VarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringToInt64P is like StringToInt64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value any) error) *map[string]int64 {
+func (f *FlagSet) StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value interface{}) error) *map[string]int64 {
 	p := map[string]int64{}
 	f.StringToInt64VarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -139,11 +139,11 @@ func (f *FlagSet) StringToInt64P(name, shorthand string, value map[string]int64,
 // StringToInt64 defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int64 variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToInt64(name string, value map[string]int64, usage string, validation ...func(value any) error) *map[string]int64 {
+func StringToInt64(name string, value map[string]int64, usage string, validation ...func(value interface{}) error) *map[string]int64 {
 	return CommandLine.StringToInt64P(name, "", value, usage, validation...)
 }
 
 // StringToInt64P is like StringToInt64, but accepts a shorthand letter that can be used after a single dash.
-func StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value any) error) *map[string]int64 {
+func StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value interface{}) error) *map[string]int64 {
 	return CommandLine.StringToInt64P(name, shorthand, value, usage, validation...)
 }

--- a/string_to_int64.go
+++ b/string_to_int64.go
@@ -99,51 +99,51 @@ func (f *FlagSet) GetStringToInt64(name string) (map[string]int64, error) {
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string) {
-	f.VarP(newStringToInt64Value(value, p), name, "", usage)
+func (f *FlagSet) StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value any) error) {
+	f.VarP(newStringToInt64Value(value, p), name, "", usage, validation...)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string) {
-	f.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
+func (f *FlagSet) StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value any) error) {
+	f.VarP(newStringToInt64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string) {
-	CommandLine.VarP(newStringToInt64Value(value, p), name, "", usage)
+func StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringToInt64Value(value, p), name, "", usage, validation...)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
-func StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string) {
-	CommandLine.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
+func StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringToInt64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToInt64 defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int64 variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToInt64(name string, value map[string]int64, usage string) *map[string]int64 {
+func (f *FlagSet) StringToInt64(name string, value map[string]int64, usage string, validation ...func(value any) error) *map[string]int64 {
 	p := map[string]int64{}
-	f.StringToInt64VarP(&p, name, "", value, usage)
+	f.StringToInt64VarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringToInt64P is like StringToInt64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToInt64P(name, shorthand string, value map[string]int64, usage string) *map[string]int64 {
+func (f *FlagSet) StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value any) error) *map[string]int64 {
 	p := map[string]int64{}
-	f.StringToInt64VarP(&p, name, shorthand, value, usage)
+	f.StringToInt64VarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // StringToInt64 defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]int64 variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToInt64(name string, value map[string]int64, usage string) *map[string]int64 {
-	return CommandLine.StringToInt64P(name, "", value, usage)
+func StringToInt64(name string, value map[string]int64, usage string, validation ...func(value any) error) *map[string]int64 {
+	return CommandLine.StringToInt64P(name, "", value, usage, validation...)
 }
 
 // StringToInt64P is like StringToInt64, but accepts a shorthand letter that can be used after a single dash.
-func StringToInt64P(name, shorthand string, value map[string]int64, usage string) *map[string]int64 {
-	return CommandLine.StringToInt64P(name, shorthand, value, usage)
+func StringToInt64P(name, shorthand string, value map[string]int64, usage string, validation ...func(value any) error) *map[string]int64 {
+	return CommandLine.StringToInt64P(name, shorthand, value, usage, validation...)
 }

--- a/string_to_string.go
+++ b/string_to_string.go
@@ -110,38 +110,38 @@ func (f *FlagSet) GetStringToString(name string) (map[string]string, error) {
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringToStringValue(value, p), name, "", usage, validation...)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value any) error) {
+func (f *FlagSet) StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newStringToStringValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value any) error) {
+func StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringToStringValue(value, p), name, "", usage, validation...)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
-func StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value any) error) {
+func StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newStringToStringValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToString defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToString(name string, value map[string]string, usage string, validation ...func(value any) error) *map[string]string {
+func (f *FlagSet) StringToString(name string, value map[string]string, usage string, validation ...func(value interface{}) error) *map[string]string {
 	p := map[string]string{}
 	f.StringToStringVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringToStringP is like StringToString, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value any) error) *map[string]string {
+func (f *FlagSet) StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value interface{}) error) *map[string]string {
 	p := map[string]string{}
 	f.StringToStringVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -150,11 +150,11 @@ func (f *FlagSet) StringToStringP(name, shorthand string, value map[string]strin
 // StringToString defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToString(name string, value map[string]string, usage string, validation ...func(value any) error) *map[string]string {
+func StringToString(name string, value map[string]string, usage string, validation ...func(value interface{}) error) *map[string]string {
 	return CommandLine.StringToStringP(name, "", value, usage, validation...)
 }
 
 // StringToStringP is like StringToString, but accepts a shorthand letter that can be used after a single dash.
-func StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value any) error) *map[string]string {
+func StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value interface{}) error) *map[string]string {
 	return CommandLine.StringToStringP(name, shorthand, value, usage, validation...)
 }

--- a/string_to_string.go
+++ b/string_to_string.go
@@ -110,38 +110,58 @@ func (f *FlagSet) GetStringToString(name string) (map[string]string, error) {
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringToStringValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value map[string]string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringToStringValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newStringToStringValue(value, p), name, "", usage)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newStringToStringValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value map[string]string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newStringToStringValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newStringToStringValue(value, p), name, shorthand, usage)
 }
 
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringToStringValue(value, p), name, "", usage, validation...)
+func StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value map[string]string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringToStringValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringToStringValue(value, p), name, "", usage)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
-func StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newStringToStringValue(value, p), name, shorthand, usage, validation...)
+func StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value map[string]string) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newStringToStringValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newStringToStringValue(value, p), name, shorthand, usage)
 }
 
 // StringToString defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToString(name string, value map[string]string, usage string, validation ...func(value interface{}) error) *map[string]string {
+func (f *FlagSet) StringToString(name string, value map[string]string, usage string, validation ...func(value map[string]string) error) *map[string]string {
 	p := map[string]string{}
 	f.StringToStringVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringToStringP is like StringToString, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value interface{}) error) *map[string]string {
+func (f *FlagSet) StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value map[string]string) error) *map[string]string {
 	p := map[string]string{}
 	f.StringToStringVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -150,11 +170,11 @@ func (f *FlagSet) StringToStringP(name, shorthand string, value map[string]strin
 // StringToString defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToString(name string, value map[string]string, usage string, validation ...func(value interface{}) error) *map[string]string {
+func StringToString(name string, value map[string]string, usage string, validation ...func(value map[string]string) error) *map[string]string {
 	return CommandLine.StringToStringP(name, "", value, usage, validation...)
 }
 
 // StringToStringP is like StringToString, but accepts a shorthand letter that can be used after a single dash.
-func StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value interface{}) error) *map[string]string {
+func StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value map[string]string) error) *map[string]string {
 	return CommandLine.StringToStringP(name, shorthand, value, usage, validation...)
 }

--- a/string_to_string.go
+++ b/string_to_string.go
@@ -110,51 +110,51 @@ func (f *FlagSet) GetStringToString(name string) (map[string]string, error) {
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToStringVar(p *map[string]string, name string, value map[string]string, usage string) {
-	f.VarP(newStringToStringValue(value, p), name, "", usage)
+func (f *FlagSet) StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value any) error) {
+	f.VarP(newStringToStringValue(value, p), name, "", usage, validation...)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string) {
-	f.VarP(newStringToStringValue(value, p), name, shorthand, usage)
+func (f *FlagSet) StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value any) error) {
+	f.VarP(newStringToStringValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToStringVar(p *map[string]string, name string, value map[string]string, usage string) {
-	CommandLine.VarP(newStringToStringValue(value, p), name, "", usage)
+func StringToStringVar(p *map[string]string, name string, value map[string]string, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringToStringValue(value, p), name, "", usage, validation...)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
-func StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string) {
-	CommandLine.VarP(newStringToStringValue(value, p), name, shorthand, usage)
+func StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newStringToStringValue(value, p), name, shorthand, usage, validation...)
 }
 
 // StringToString defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func (f *FlagSet) StringToString(name string, value map[string]string, usage string) *map[string]string {
+func (f *FlagSet) StringToString(name string, value map[string]string, usage string, validation ...func(value any) error) *map[string]string {
 	p := map[string]string{}
-	f.StringToStringVarP(&p, name, "", value, usage)
+	f.StringToStringVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // StringToStringP is like StringToString, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) StringToStringP(name, shorthand string, value map[string]string, usage string) *map[string]string {
+func (f *FlagSet) StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value any) error) *map[string]string {
 	p := map[string]string{}
-	f.StringToStringVarP(&p, name, shorthand, value, usage)
+	f.StringToStringVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // StringToString defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a map[string]string variable that stores the value of the flag.
 // The value of each argument will not try to be separated by comma
-func StringToString(name string, value map[string]string, usage string) *map[string]string {
-	return CommandLine.StringToStringP(name, "", value, usage)
+func StringToString(name string, value map[string]string, usage string, validation ...func(value any) error) *map[string]string {
+	return CommandLine.StringToStringP(name, "", value, usage, validation...)
 }
 
 // StringToStringP is like StringToString, but accepts a shorthand letter that can be used after a single dash.
-func StringToStringP(name, shorthand string, value map[string]string, usage string) *map[string]string {
-	return CommandLine.StringToStringP(name, shorthand, value, usage)
+func StringToStringP(name, shorthand string, value map[string]string, usage string, validation ...func(value any) error) *map[string]string {
+	return CommandLine.StringToStringP(name, shorthand, value, usage, validation...)
 }

--- a/uint.go
+++ b/uint.go
@@ -41,36 +41,56 @@ func (f *FlagSet) GetUint(name string) (uint, error) {
 
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
-func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUintValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string, validation ...func(value uint) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUintValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newUintValue(value, p), name, "", usage)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUintValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value uint) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUintValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newUintValue(value, p), name, shorthand, usage)
 }
 
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
-func UintVar(p *uint, name string, value uint, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUintValue(value, p), name, "", usage, validation...)
+func UintVar(p *uint, name string, value uint, usage string, validation ...func(value uint) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUintValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUintValue(value, p), name, "", usage)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
-func UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage, validation...)
+func UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value uint) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUintValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage)
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func (f *FlagSet) Uint(name string, value uint, usage string, validation ...func(value interface{}) error) *uint {
+func (f *FlagSet) Uint(name string, value uint, usage string, validation ...func(value uint) error) *uint {
 	p := new(uint)
 	f.UintVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintP(name, shorthand string, value uint, usage string, validation ...func(value interface{}) error) *uint {
+func (f *FlagSet) UintP(name, shorthand string, value uint, usage string, validation ...func(value uint) error) *uint {
 	p := new(uint)
 	f.UintVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +98,11 @@ func (f *FlagSet) UintP(name, shorthand string, value uint, usage string, valida
 
 // Uint defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func Uint(name string, value uint, usage string, validation ...func(value interface{}) error) *uint {
+func Uint(name string, value uint, usage string, validation ...func(value uint) error) *uint {
 	return CommandLine.UintP(name, "", value, usage, validation...)
 }
 
 // UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
-func UintP(name, shorthand string, value uint, usage string, validation ...func(value interface{}) error) *uint {
+func UintP(name, shorthand string, value uint, usage string, validation ...func(value uint) error) *uint {
 	return CommandLine.UintP(name, shorthand, value, usage, validation...)
 }

--- a/uint.go
+++ b/uint.go
@@ -41,36 +41,36 @@ func (f *FlagSet) GetUint(name string) (uint, error) {
 
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
-func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string, validation ...func(value any) error) {
+func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUintValue(value, p), name, "", usage, validation...)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value any) error) {
+func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUintValue(value, p), name, shorthand, usage, validation...)
 }
 
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
-func UintVar(p *uint, name string, value uint, usage string, validation ...func(value any) error) {
+func UintVar(p *uint, name string, value uint, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUintValue(value, p), name, "", usage, validation...)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
-func UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value any) error) {
+func UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func (f *FlagSet) Uint(name string, value uint, usage string, validation ...func(value any) error) *uint {
+func (f *FlagSet) Uint(name string, value uint, usage string, validation ...func(value interface{}) error) *uint {
 	p := new(uint)
 	f.UintVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintP(name, shorthand string, value uint, usage string, validation ...func(value any) error) *uint {
+func (f *FlagSet) UintP(name, shorthand string, value uint, usage string, validation ...func(value interface{}) error) *uint {
 	p := new(uint)
 	f.UintVarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +78,11 @@ func (f *FlagSet) UintP(name, shorthand string, value uint, usage string, valida
 
 // Uint defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func Uint(name string, value uint, usage string, validation ...func(value any) error) *uint {
+func Uint(name string, value uint, usage string, validation ...func(value interface{}) error) *uint {
 	return CommandLine.UintP(name, "", value, usage, validation...)
 }
 
 // UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
-func UintP(name, shorthand string, value uint, usage string, validation ...func(value any) error) *uint {
+func UintP(name, shorthand string, value uint, usage string, validation ...func(value interface{}) error) *uint {
 	return CommandLine.UintP(name, shorthand, value, usage, validation...)
 }

--- a/uint.go
+++ b/uint.go
@@ -41,48 +41,48 @@ func (f *FlagSet) GetUint(name string) (uint, error) {
 
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
-func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string) {
-	f.VarP(newUintValue(value, p), name, "", usage)
+func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string, validation ...func(value any) error) {
+	f.VarP(newUintValue(value, p), name, "", usage, validation...)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string) {
-	f.VarP(newUintValue(value, p), name, shorthand, usage)
+func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value any) error) {
+	f.VarP(newUintValue(value, p), name, shorthand, usage, validation...)
 }
 
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
-func UintVar(p *uint, name string, value uint, usage string) {
-	CommandLine.VarP(newUintValue(value, p), name, "", usage)
+func UintVar(p *uint, name string, value uint, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUintValue(value, p), name, "", usage, validation...)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
-func UintVarP(p *uint, name, shorthand string, value uint, usage string) {
-	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage)
+func UintVarP(p *uint, name, shorthand string, value uint, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func (f *FlagSet) Uint(name string, value uint, usage string) *uint {
+func (f *FlagSet) Uint(name string, value uint, usage string, validation ...func(value any) error) *uint {
 	p := new(uint)
-	f.UintVarP(p, name, "", value, usage)
+	f.UintVarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintP(name, shorthand string, value uint, usage string) *uint {
+func (f *FlagSet) UintP(name, shorthand string, value uint, usage string, validation ...func(value any) error) *uint {
 	p := new(uint)
-	f.UintVarP(p, name, shorthand, value, usage)
+	f.UintVarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func Uint(name string, value uint, usage string) *uint {
-	return CommandLine.UintP(name, "", value, usage)
+func Uint(name string, value uint, usage string, validation ...func(value any) error) *uint {
+	return CommandLine.UintP(name, "", value, usage, validation...)
 }
 
 // UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
-func UintP(name, shorthand string, value uint, usage string) *uint {
-	return CommandLine.UintP(name, shorthand, value, usage)
+func UintP(name, shorthand string, value uint, usage string, validation ...func(value any) error) *uint {
+	return CommandLine.UintP(name, shorthand, value, usage, validation...)
 }

--- a/uint16.go
+++ b/uint16.go
@@ -41,48 +41,48 @@ func (f *FlagSet) GetUint16(name string) (uint16, error) {
 
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
-func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string) {
-	f.VarP(newUint16Value(value, p), name, "", usage)
+func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value any) error) {
+	f.VarP(newUint16Value(value, p), name, "", usage, validation...)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
-	f.VarP(newUint16Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value any) error) {
+	f.VarP(newUint16Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
-func Uint16Var(p *uint16, name string, value uint16, usage string) {
-	CommandLine.VarP(newUint16Value(value, p), name, "", usage)
+func Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUint16Value(value, p), name, "", usage, validation...)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
-	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage)
+func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func (f *FlagSet) Uint16(name string, value uint16, usage string) *uint16 {
+func (f *FlagSet) Uint16(name string, value uint16, usage string, validation ...func(value any) error) *uint16 {
 	p := new(uint16)
-	f.Uint16VarP(p, name, "", value, usage)
+	f.Uint16VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string) *uint16 {
+func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value any) error) *uint16 {
 	p := new(uint16)
-	f.Uint16VarP(p, name, shorthand, value, usage)
+	f.Uint16VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func Uint16(name string, value uint16, usage string) *uint16 {
-	return CommandLine.Uint16P(name, "", value, usage)
+func Uint16(name string, value uint16, usage string, validation ...func(value any) error) *uint16 {
+	return CommandLine.Uint16P(name, "", value, usage, validation...)
 }
 
 // Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
-func Uint16P(name, shorthand string, value uint16, usage string) *uint16 {
-	return CommandLine.Uint16P(name, shorthand, value, usage)
+func Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value any) error) *uint16 {
+	return CommandLine.Uint16P(name, shorthand, value, usage, validation...)
 }

--- a/uint16.go
+++ b/uint16.go
@@ -41,36 +41,36 @@ func (f *FlagSet) GetUint16(name string) (uint16, error) {
 
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
-func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUint16Value(value, p), name, "", usage, validation...)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUint16Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
-func Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value any) error) {
+func Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUint16Value(value, p), name, "", usage, validation...)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value any) error) {
+func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func (f *FlagSet) Uint16(name string, value uint16, usage string, validation ...func(value any) error) *uint16 {
+func (f *FlagSet) Uint16(name string, value uint16, usage string, validation ...func(value interface{}) error) *uint16 {
 	p := new(uint16)
 	f.Uint16VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value any) error) *uint16 {
+func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value interface{}) error) *uint16 {
 	p := new(uint16)
 	f.Uint16VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +78,11 @@ func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string, va
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func Uint16(name string, value uint16, usage string, validation ...func(value any) error) *uint16 {
+func Uint16(name string, value uint16, usage string, validation ...func(value interface{}) error) *uint16 {
 	return CommandLine.Uint16P(name, "", value, usage, validation...)
 }
 
 // Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
-func Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value any) error) *uint16 {
+func Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value interface{}) error) *uint16 {
 	return CommandLine.Uint16P(name, shorthand, value, usage, validation...)
 }

--- a/uint16.go
+++ b/uint16.go
@@ -41,36 +41,56 @@ func (f *FlagSet) GetUint16(name string) (uint16, error) {
 
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
-func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUint16Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value uint16) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUint16Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newUint16Value(value, p), name, "", usage)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUint16Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value uint16) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUint16Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newUint16Value(value, p), name, shorthand, usage)
 }
 
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
-func Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUint16Value(value, p), name, "", usage, validation...)
+func Uint16Var(p *uint16, name string, value uint16, usage string, validation ...func(value uint16) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUint16Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUint16Value(value, p), name, "", usage)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage, validation...)
+func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string, validation ...func(value uint16) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage)
 }
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func (f *FlagSet) Uint16(name string, value uint16, usage string, validation ...func(value interface{}) error) *uint16 {
+func (f *FlagSet) Uint16(name string, value uint16, usage string, validation ...func(value uint16) error) *uint16 {
 	p := new(uint16)
 	f.Uint16VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value interface{}) error) *uint16 {
+func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value uint16) error) *uint16 {
 	p := new(uint16)
 	f.Uint16VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +98,11 @@ func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string, va
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
-func Uint16(name string, value uint16, usage string, validation ...func(value interface{}) error) *uint16 {
+func Uint16(name string, value uint16, usage string, validation ...func(value uint16) error) *uint16 {
 	return CommandLine.Uint16P(name, "", value, usage, validation...)
 }
 
 // Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
-func Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value interface{}) error) *uint16 {
+func Uint16P(name, shorthand string, value uint16, usage string, validation ...func(value uint16) error) *uint16 {
 	return CommandLine.Uint16P(name, shorthand, value, usage, validation...)
 }

--- a/uint32.go
+++ b/uint32.go
@@ -41,36 +41,56 @@ func (f *FlagSet) GetUint32(name string) (uint32, error) {
 
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32 variable in which to store the value of the flag.
-func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUint32Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value uint32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUint32Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newUint32Value(value, p), name, "", usage)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUint32Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value uint32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUint32Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newUint32Value(value, p), name, shorthand, usage)
 }
 
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32  variable in which to store the value of the flag.
-func Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUint32Value(value, p), name, "", usage, validation...)
+func Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value uint32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUint32Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUint32Value(value, p), name, "", usage)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage, validation...)
+func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value uint32) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage)
 }
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
 // The return value is the address of a uint32  variable that stores the value of the flag.
-func (f *FlagSet) Uint32(name string, value uint32, usage string, validation ...func(value interface{}) error) *uint32 {
+func (f *FlagSet) Uint32(name string, value uint32, usage string, validation ...func(value uint32) error) *uint32 {
 	p := new(uint32)
 	f.Uint32VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value interface{}) error) *uint32 {
+func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value uint32) error) *uint32 {
 	p := new(uint32)
 	f.Uint32VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +98,11 @@ func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string, va
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
 // The return value is the address of a uint32  variable that stores the value of the flag.
-func Uint32(name string, value uint32, usage string, validation ...func(value interface{}) error) *uint32 {
+func Uint32(name string, value uint32, usage string, validation ...func(value uint32) error) *uint32 {
 	return CommandLine.Uint32P(name, "", value, usage, validation...)
 }
 
 // Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
-func Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value interface{}) error) *uint32 {
+func Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value uint32) error) *uint32 {
 	return CommandLine.Uint32P(name, shorthand, value, usage, validation...)
 }

--- a/uint32.go
+++ b/uint32.go
@@ -41,36 +41,36 @@ func (f *FlagSet) GetUint32(name string) (uint32, error) {
 
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32 variable in which to store the value of the flag.
-func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUint32Value(value, p), name, "", usage, validation...)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUint32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32  variable in which to store the value of the flag.
-func Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value any) error) {
+func Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUint32Value(value, p), name, "", usage, validation...)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value any) error) {
+func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
 // The return value is the address of a uint32  variable that stores the value of the flag.
-func (f *FlagSet) Uint32(name string, value uint32, usage string, validation ...func(value any) error) *uint32 {
+func (f *FlagSet) Uint32(name string, value uint32, usage string, validation ...func(value interface{}) error) *uint32 {
 	p := new(uint32)
 	f.Uint32VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value any) error) *uint32 {
+func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value interface{}) error) *uint32 {
 	p := new(uint32)
 	f.Uint32VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +78,11 @@ func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string, va
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
 // The return value is the address of a uint32  variable that stores the value of the flag.
-func Uint32(name string, value uint32, usage string, validation ...func(value any) error) *uint32 {
+func Uint32(name string, value uint32, usage string, validation ...func(value interface{}) error) *uint32 {
 	return CommandLine.Uint32P(name, "", value, usage, validation...)
 }
 
 // Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
-func Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value any) error) *uint32 {
+func Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value interface{}) error) *uint32 {
 	return CommandLine.Uint32P(name, shorthand, value, usage, validation...)
 }

--- a/uint32.go
+++ b/uint32.go
@@ -41,48 +41,48 @@ func (f *FlagSet) GetUint32(name string) (uint32, error) {
 
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32 variable in which to store the value of the flag.
-func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string) {
-	f.VarP(newUint32Value(value, p), name, "", usage)
+func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value any) error) {
+	f.VarP(newUint32Value(value, p), name, "", usage, validation...)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
-	f.VarP(newUint32Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value any) error) {
+	f.VarP(newUint32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32  variable in which to store the value of the flag.
-func Uint32Var(p *uint32, name string, value uint32, usage string) {
-	CommandLine.VarP(newUint32Value(value, p), name, "", usage)
+func Uint32Var(p *uint32, name string, value uint32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUint32Value(value, p), name, "", usage, validation...)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
-	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage)
+func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
 // The return value is the address of a uint32  variable that stores the value of the flag.
-func (f *FlagSet) Uint32(name string, value uint32, usage string) *uint32 {
+func (f *FlagSet) Uint32(name string, value uint32, usage string, validation ...func(value any) error) *uint32 {
 	p := new(uint32)
-	f.Uint32VarP(p, name, "", value, usage)
+	f.Uint32VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string) *uint32 {
+func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value any) error) *uint32 {
 	p := new(uint32)
-	f.Uint32VarP(p, name, shorthand, value, usage)
+	f.Uint32VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
 // The return value is the address of a uint32  variable that stores the value of the flag.
-func Uint32(name string, value uint32, usage string) *uint32 {
-	return CommandLine.Uint32P(name, "", value, usage)
+func Uint32(name string, value uint32, usage string, validation ...func(value any) error) *uint32 {
+	return CommandLine.Uint32P(name, "", value, usage, validation...)
 }
 
 // Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
-func Uint32P(name, shorthand string, value uint32, usage string) *uint32 {
-	return CommandLine.Uint32P(name, shorthand, value, usage)
+func Uint32P(name, shorthand string, value uint32, usage string, validation ...func(value any) error) *uint32 {
+	return CommandLine.Uint32P(name, shorthand, value, usage, validation...)
 }

--- a/uint64.go
+++ b/uint64.go
@@ -41,36 +41,36 @@ func (f *FlagSet) GetUint64(name string) (uint64, error) {
 
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
-func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUint64Value(value, p), name, "", usage, validation...)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUint64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
-func Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value any) error) {
+func Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUint64Value(value, p), name, "", usage, validation...)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value any) error) {
+func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
 // The return value is the address of a uint64 variable that stores the value of the flag.
-func (f *FlagSet) Uint64(name string, value uint64, usage string, validation ...func(value any) error) *uint64 {
+func (f *FlagSet) Uint64(name string, value uint64, usage string, validation ...func(value interface{}) error) *uint64 {
 	p := new(uint64)
 	f.Uint64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value any) error) *uint64 {
+func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value interface{}) error) *uint64 {
 	p := new(uint64)
 	f.Uint64VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +78,11 @@ func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string, va
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
 // The return value is the address of a uint64 variable that stores the value of the flag.
-func Uint64(name string, value uint64, usage string, validation ...func(value any) error) *uint64 {
+func Uint64(name string, value uint64, usage string, validation ...func(value interface{}) error) *uint64 {
 	return CommandLine.Uint64P(name, "", value, usage, validation...)
 }
 
 // Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
-func Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value any) error) *uint64 {
+func Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value interface{}) error) *uint64 {
 	return CommandLine.Uint64P(name, shorthand, value, usage, validation...)
 }

--- a/uint64.go
+++ b/uint64.go
@@ -41,48 +41,48 @@ func (f *FlagSet) GetUint64(name string) (uint64, error) {
 
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
-func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string) {
-	f.VarP(newUint64Value(value, p), name, "", usage)
+func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value any) error) {
+	f.VarP(newUint64Value(value, p), name, "", usage, validation...)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
-	f.VarP(newUint64Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value any) error) {
+	f.VarP(newUint64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
-func Uint64Var(p *uint64, name string, value uint64, usage string) {
-	CommandLine.VarP(newUint64Value(value, p), name, "", usage)
+func Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUint64Value(value, p), name, "", usage, validation...)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
-	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage)
+func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
 // The return value is the address of a uint64 variable that stores the value of the flag.
-func (f *FlagSet) Uint64(name string, value uint64, usage string) *uint64 {
+func (f *FlagSet) Uint64(name string, value uint64, usage string, validation ...func(value any) error) *uint64 {
 	p := new(uint64)
-	f.Uint64VarP(p, name, "", value, usage)
+	f.Uint64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string) *uint64 {
+func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value any) error) *uint64 {
 	p := new(uint64)
-	f.Uint64VarP(p, name, shorthand, value, usage)
+	f.Uint64VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
 // The return value is the address of a uint64 variable that stores the value of the flag.
-func Uint64(name string, value uint64, usage string) *uint64 {
-	return CommandLine.Uint64P(name, "", value, usage)
+func Uint64(name string, value uint64, usage string, validation ...func(value any) error) *uint64 {
+	return CommandLine.Uint64P(name, "", value, usage, validation...)
 }
 
 // Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
-func Uint64P(name, shorthand string, value uint64, usage string) *uint64 {
-	return CommandLine.Uint64P(name, shorthand, value, usage)
+func Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value any) error) *uint64 {
+	return CommandLine.Uint64P(name, shorthand, value, usage, validation...)
 }

--- a/uint64.go
+++ b/uint64.go
@@ -41,36 +41,56 @@ func (f *FlagSet) GetUint64(name string) (uint64, error) {
 
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
-func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUint64Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value uint64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUint64Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newUint64Value(value, p), name, "", usage)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUint64Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value uint64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUint64Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newUint64Value(value, p), name, shorthand, usage)
 }
 
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
-func Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUint64Value(value, p), name, "", usage, validation...)
+func Uint64Var(p *uint64, name string, value uint64, usage string, validation ...func(value uint64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUint64Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUint64Value(value, p), name, "", usage)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage, validation...)
+func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string, validation ...func(value uint64) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage)
 }
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
 // The return value is the address of a uint64 variable that stores the value of the flag.
-func (f *FlagSet) Uint64(name string, value uint64, usage string, validation ...func(value interface{}) error) *uint64 {
+func (f *FlagSet) Uint64(name string, value uint64, usage string, validation ...func(value uint64) error) *uint64 {
 	p := new(uint64)
 	f.Uint64VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value interface{}) error) *uint64 {
+func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value uint64) error) *uint64 {
 	p := new(uint64)
 	f.Uint64VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +98,11 @@ func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string, va
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
 // The return value is the address of a uint64 variable that stores the value of the flag.
-func Uint64(name string, value uint64, usage string, validation ...func(value interface{}) error) *uint64 {
+func Uint64(name string, value uint64, usage string, validation ...func(value uint64) error) *uint64 {
 	return CommandLine.Uint64P(name, "", value, usage, validation...)
 }
 
 // Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
-func Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value interface{}) error) *uint64 {
+func Uint64P(name, shorthand string, value uint64, usage string, validation ...func(value uint64) error) *uint64 {
 	return CommandLine.Uint64P(name, shorthand, value, usage, validation...)
 }

--- a/uint8.go
+++ b/uint8.go
@@ -41,48 +41,48 @@ func (f *FlagSet) GetUint8(name string) (uint8, error) {
 
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
-func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string) {
-	f.VarP(newUint8Value(value, p), name, "", usage)
+func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value any) error) {
+	f.VarP(newUint8Value(value, p), name, "", usage, validation...)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
-	f.VarP(newUint8Value(value, p), name, shorthand, usage)
+func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value any) error) {
+	f.VarP(newUint8Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
-func Uint8Var(p *uint8, name string, value uint8, usage string) {
-	CommandLine.VarP(newUint8Value(value, p), name, "", usage)
+func Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUint8Value(value, p), name, "", usage, validation...)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
-	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage)
+func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
 // The return value is the address of a uint8 variable that stores the value of the flag.
-func (f *FlagSet) Uint8(name string, value uint8, usage string) *uint8 {
+func (f *FlagSet) Uint8(name string, value uint8, usage string, validation ...func(value any) error) *uint8 {
 	p := new(uint8)
-	f.Uint8VarP(p, name, "", value, usage)
+	f.Uint8VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string) *uint8 {
+func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value any) error) *uint8 {
 	p := new(uint8)
-	f.Uint8VarP(p, name, shorthand, value, usage)
+	f.Uint8VarP(p, name, shorthand, value, usage, validation...)
 	return p
 }
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
 // The return value is the address of a uint8 variable that stores the value of the flag.
-func Uint8(name string, value uint8, usage string) *uint8 {
-	return CommandLine.Uint8P(name, "", value, usage)
+func Uint8(name string, value uint8, usage string, validation ...func(value any) error) *uint8 {
+	return CommandLine.Uint8P(name, "", value, usage, validation...)
 }
 
 // Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
-func Uint8P(name, shorthand string, value uint8, usage string) *uint8 {
-	return CommandLine.Uint8P(name, shorthand, value, usage)
+func Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value any) error) *uint8 {
+	return CommandLine.Uint8P(name, shorthand, value, usage, validation...)
 }

--- a/uint8.go
+++ b/uint8.go
@@ -41,36 +41,56 @@ func (f *FlagSet) GetUint8(name string) (uint8, error) {
 
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
-func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUint8Value(value, p), name, "", usage, validation...)
+func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value uint8) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUint8Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newUint8Value(value, p), name, "", usage)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUint8Value(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value uint8) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUint8Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newUint8Value(value, p), name, shorthand, usage)
 }
 
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
-func Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUint8Value(value, p), name, "", usage, validation...)
+func Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value uint8) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUint8Value(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUint8Value(value, p), name, "", usage)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage, validation...)
+func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value uint8) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage)
 }
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
 // The return value is the address of a uint8 variable that stores the value of the flag.
-func (f *FlagSet) Uint8(name string, value uint8, usage string, validation ...func(value interface{}) error) *uint8 {
+func (f *FlagSet) Uint8(name string, value uint8, usage string, validation ...func(value uint8) error) *uint8 {
 	p := new(uint8)
 	f.Uint8VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value interface{}) error) *uint8 {
+func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value uint8) error) *uint8 {
 	p := new(uint8)
 	f.Uint8VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +98,11 @@ func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string, vali
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
 // The return value is the address of a uint8 variable that stores the value of the flag.
-func Uint8(name string, value uint8, usage string, validation ...func(value interface{}) error) *uint8 {
+func Uint8(name string, value uint8, usage string, validation ...func(value uint8) error) *uint8 {
 	return CommandLine.Uint8P(name, "", value, usage, validation...)
 }
 
 // Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
-func Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value interface{}) error) *uint8 {
+func Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value uint8) error) *uint8 {
 	return CommandLine.Uint8P(name, shorthand, value, usage, validation...)
 }

--- a/uint8.go
+++ b/uint8.go
@@ -41,36 +41,36 @@ func (f *FlagSet) GetUint8(name string) (uint8, error) {
 
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
-func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUint8Value(value, p), name, "", usage, validation...)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value any) error) {
+func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUint8Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
-func Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value any) error) {
+func Uint8Var(p *uint8, name string, value uint8, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUint8Value(value, p), name, "", usage, validation...)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
-func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value any) error) {
+func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage, validation...)
 }
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
 // The return value is the address of a uint8 variable that stores the value of the flag.
-func (f *FlagSet) Uint8(name string, value uint8, usage string, validation ...func(value any) error) *uint8 {
+func (f *FlagSet) Uint8(name string, value uint8, usage string, validation ...func(value interface{}) error) *uint8 {
 	p := new(uint8)
 	f.Uint8VarP(p, name, "", value, usage, validation...)
 	return p
 }
 
 // Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value any) error) *uint8 {
+func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value interface{}) error) *uint8 {
 	p := new(uint8)
 	f.Uint8VarP(p, name, shorthand, value, usage, validation...)
 	return p
@@ -78,11 +78,11 @@ func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string, vali
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
 // The return value is the address of a uint8 variable that stores the value of the flag.
-func Uint8(name string, value uint8, usage string, validation ...func(value any) error) *uint8 {
+func Uint8(name string, value uint8, usage string, validation ...func(value interface{}) error) *uint8 {
 	return CommandLine.Uint8P(name, "", value, usage, validation...)
 }
 
 // Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
-func Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value any) error) *uint8 {
+func Uint8P(name, shorthand string, value uint8, usage string, validation ...func(value interface{}) error) *uint8 {
 	return CommandLine.Uint8P(name, shorthand, value, usage, validation...)
 }

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -121,36 +121,56 @@ func (f *FlagSet) GetUintSlice(name string) ([]uint, error) {
 
 // UintSliceVar defines a uintSlice flag with specified name, default value, and usage string.
 // The argument p points to a []uint variable in which to store the value of the flag.
-func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUintSliceValue(value, p), name, "", usage, validation...)
+func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value []uint) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUintSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	f.VarP(newUintSliceValue(value, p), name, "", usage)
 }
 
 // UintSliceVarP is like UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value interface{}) error) {
-	f.VarP(newUintSliceValue(value, p), name, shorthand, usage, validation...)
+func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value []uint) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		f.VarP(newUintSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	f.VarP(newUintSliceValue(value, p), name, shorthand, usage)
 }
 
 // UintSliceVar defines a uint[] flag with specified name, default value, and usage string.
 // The argument p points to a uint[] variable in which to store the value of the flag.
-func UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, "", usage, validation...)
+func UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value []uint) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUintSliceValue(value, p), name, "", usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUintSliceValue(value, p), name, "", usage)
 }
 
 // UintSliceVarP is like the UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value interface{}) error) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage, validation...)
+func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value []uint) error) {
+	if len(validation) > 0 {
+		validationFunc := interface{}(validation[0])
+		CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage, validationFunc)
+		return
+	}
+	CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage)
 }
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.
 // The return value is the address of a []uint variable that stores the value of the flag.
-func (f *FlagSet) UintSlice(name string, value []uint, usage string, validation ...func(value interface{}) error) *[]uint {
+func (f *FlagSet) UintSlice(name string, value []uint, usage string, validation ...func(value []uint) error) *[]uint {
 	p := []uint{}
 	f.UintSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // UintSliceP is like UintSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value interface{}) error) *[]uint {
+func (f *FlagSet) UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value []uint) error) *[]uint {
 	p := []uint{}
 	f.UintSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -158,11 +178,11 @@ func (f *FlagSet) UintSliceP(name, shorthand string, value []uint, usage string,
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.
 // The return value is the address of a []uint variable that stores the value of the flag.
-func UintSlice(name string, value []uint, usage string, validation ...func(value interface{}) error) *[]uint {
+func UintSlice(name string, value []uint, usage string, validation ...func(value []uint) error) *[]uint {
 	return CommandLine.UintSliceP(name, "", value, usage, validation...)
 }
 
 // UintSliceP is like UintSlice, but accepts a shorthand letter that can be used after a single dash.
-func UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value interface{}) error) *[]uint {
+func UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value []uint) error) *[]uint {
 	return CommandLine.UintSliceP(name, shorthand, value, usage, validation...)
 }

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -121,36 +121,36 @@ func (f *FlagSet) GetUintSlice(name string) ([]uint, error) {
 
 // UintSliceVar defines a uintSlice flag with specified name, default value, and usage string.
 // The argument p points to a []uint variable in which to store the value of the flag.
-func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value any) error) {
+func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUintSliceValue(value, p), name, "", usage, validation...)
 }
 
 // UintSliceVarP is like UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value any) error) {
+func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value interface{}) error) {
 	f.VarP(newUintSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // UintSliceVar defines a uint[] flag with specified name, default value, and usage string.
 // The argument p points to a uint[] variable in which to store the value of the flag.
-func UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value any) error) {
+func UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUintSliceValue(value, p), name, "", usage, validation...)
 }
 
 // UintSliceVarP is like the UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value any) error) {
+func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value interface{}) error) {
 	CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.
 // The return value is the address of a []uint variable that stores the value of the flag.
-func (f *FlagSet) UintSlice(name string, value []uint, usage string, validation ...func(value any) error) *[]uint {
+func (f *FlagSet) UintSlice(name string, value []uint, usage string, validation ...func(value interface{}) error) *[]uint {
 	p := []uint{}
 	f.UintSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // UintSliceP is like UintSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value any) error) *[]uint {
+func (f *FlagSet) UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value interface{}) error) *[]uint {
 	p := []uint{}
 	f.UintSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
@@ -158,11 +158,11 @@ func (f *FlagSet) UintSliceP(name, shorthand string, value []uint, usage string,
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.
 // The return value is the address of a []uint variable that stores the value of the flag.
-func UintSlice(name string, value []uint, usage string, validation ...func(value any) error) *[]uint {
+func UintSlice(name string, value []uint, usage string, validation ...func(value interface{}) error) *[]uint {
 	return CommandLine.UintSliceP(name, "", value, usage, validation...)
 }
 
 // UintSliceP is like UintSlice, but accepts a shorthand letter that can be used after a single dash.
-func UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value any) error) *[]uint {
+func UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value interface{}) error) *[]uint {
 	return CommandLine.UintSliceP(name, shorthand, value, usage, validation...)
 }

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -121,48 +121,48 @@ func (f *FlagSet) GetUintSlice(name string) ([]uint, error) {
 
 // UintSliceVar defines a uintSlice flag with specified name, default value, and usage string.
 // The argument p points to a []uint variable in which to store the value of the flag.
-func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string) {
-	f.VarP(newUintSliceValue(value, p), name, "", usage)
+func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value any) error) {
+	f.VarP(newUintSliceValue(value, p), name, "", usage, validation...)
 }
 
 // UintSliceVarP is like UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string) {
-	f.VarP(newUintSliceValue(value, p), name, shorthand, usage)
+func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value any) error) {
+	f.VarP(newUintSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // UintSliceVar defines a uint[] flag with specified name, default value, and usage string.
 // The argument p points to a uint[] variable in which to store the value of the flag.
-func UintSliceVar(p *[]uint, name string, value []uint, usage string) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, "", usage)
+func UintSliceVar(p *[]uint, name string, value []uint, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUintSliceValue(value, p), name, "", usage, validation...)
 }
 
 // UintSliceVarP is like the UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
-func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage)
+func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string, validation ...func(value any) error) {
+	CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage, validation...)
 }
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.
 // The return value is the address of a []uint variable that stores the value of the flag.
-func (f *FlagSet) UintSlice(name string, value []uint, usage string) *[]uint {
+func (f *FlagSet) UintSlice(name string, value []uint, usage string, validation ...func(value any) error) *[]uint {
 	p := []uint{}
-	f.UintSliceVarP(&p, name, "", value, usage)
+	f.UintSliceVarP(&p, name, "", value, usage, validation...)
 	return &p
 }
 
 // UintSliceP is like UintSlice, but accepts a shorthand letter that can be used after a single dash.
-func (f *FlagSet) UintSliceP(name, shorthand string, value []uint, usage string) *[]uint {
+func (f *FlagSet) UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value any) error) *[]uint {
 	p := []uint{}
-	f.UintSliceVarP(&p, name, shorthand, value, usage)
+	f.UintSliceVarP(&p, name, shorthand, value, usage, validation...)
 	return &p
 }
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.
 // The return value is the address of a []uint variable that stores the value of the flag.
-func UintSlice(name string, value []uint, usage string) *[]uint {
-	return CommandLine.UintSliceP(name, "", value, usage)
+func UintSlice(name string, value []uint, usage string, validation ...func(value any) error) *[]uint {
+	return CommandLine.UintSliceP(name, "", value, usage, validation...)
 }
 
 // UintSliceP is like UintSlice, but accepts a shorthand letter that can be used after a single dash.
-func UintSliceP(name, shorthand string, value []uint, usage string) *[]uint {
-	return CommandLine.UintSliceP(name, shorthand, value, usage)
+func UintSliceP(name, shorthand string, value []uint, usage string, validation ...func(value any) error) *[]uint {
+	return CommandLine.UintSliceP(name, shorthand, value, usage, validation...)
 }


### PR DESCRIPTION
 fixes [https://github.com/spf13/pflag/issues/236](https://github.com/spf13/pflag/issues/236),
fixes[https://github.com/spf13/pflag/issues/293](https://github.com/spf13/pflag/issues/293),
 fixes [https://github.com/spf13/pflag/issues/299](https://github.com/spf13/pflag/issues/299)
Hi, After merging this pull request we can add custom validation for any type of flag.

It is optional and for this operation, you should define a function and pass it as the last parameter to the flag definition function.

```go
var flagvar int
func init() {
	validation := func(value int)error{
		if value <= 4 {
			return errors.New("int value should be greater than 4")
        }
    }
	
    flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname", validation)
````
In the above example if you pass an integer value greater than 4, it returned an error and the value of the flag doesn't set.
