### PR TITLE
Add documentation for flags with custom variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,22 @@ It is possible to mark a flag as hidden, meaning it will still function as norma
 flags.MarkHidden("secretFlag")
 ```
 
+## Custom flag variable names
+It is possible to change the variable name used in command help output for non-boolean flags. By default, the variable name is an educated guess based on the flag type.
+
+**Example**
+```go
+flags.String("normalflag", "", "unchanged variable name")
+flags.String("fancyflag", "", "enter a `fancyvalue` for this flag")
+flags.PrintDefaults()
+```
+
+**Output**
+```
+  --fancyflag fancyvalue   enter a fancyvalue for this flag
+  --normalflag string      unchanged variable name
+```
+
 ## Disable sorting of flags
 `pflag` allows you to disable sorting of flags for help and usage message.
 


### PR DESCRIPTION
This PR adds documentation around the special back-tick syntax in flag usage to override the variable name displayed in the help output. This functionality is implemented in the `UnquoteUsage` function, and is referred to in `FlagSet.FlagUsagesWrapped` as the `varname`, so I used the term "flag variable name" here in the documentation.

I plan to open a separate PR over on `spf13/cobra.dev` to address the higher-level Cobra documentation, since that is more likely to be seen by downstream users, but it deserves to be included here as well.

This relates to spf13/cobra#2125, but I wouldn't consider that closed until this is added to the cobra documentation as well.