### PR TITLE
Fix defaultIsZeroValue check for generic Value types

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -551,7 +551,7 @@ func (f *Flag) defaultIsZeroValue() bool {
 	case *intSliceValue, *stringSliceValue, *stringArrayValue:
 		return f.DefValue == "[]"
 	default:
-		switch f.Value.String() {
+		switch f.DefValue {
 		case "false":
 			return true
 		case "<nil>":

--- a/flag_test.go
+++ b/flag_test.go
@@ -1183,6 +1183,7 @@ const defaultOutput = `      --A                         for bootstrapping, allo
       --StringSlice strings       string slice with zero default
       --Z int                     an int that defaults to zero
       --custom custom             custom Value implementation
+      --custom-with-val custom    custom value which has been set from command line while help is shown
       --customP custom            a VarP with default (default 10)
       --maxT timeout              set timeout for dial
   -v, --verbose count             verbosity
@@ -1233,6 +1234,14 @@ func TestPrintDefaults(t *testing.T) {
 
 	cv2 := customValue(10)
 	fs.VarP(&cv2, "customP", "", "a VarP with default")
+
+	// Simulate case where a value has been provided and the help screen is shown
+	var cv3 customValue
+	fs.Var(&cv3, "custom-with-val", "custom value which has been set from command line while help is shown")
+	err := fs.Parse([]string{"--custom-with-val", "3"})
+	if err != nil {
+		t.Error("Parsing flags failed:", err)
+	}
 
 	fs.PrintDefaults()
 	got := buf.String()

--- a/flag_test.go
+++ b/flag_test.go
@@ -1246,9 +1246,7 @@ func TestPrintDefaults(t *testing.T) {
 	fs.PrintDefaults()
 	got := buf.String()
 	if got != defaultOutput {
-		fmt.Println("\n" + got)
-		fmt.Printf("\n" + defaultOutput)
-		t.Errorf("got %q want %q\n", got, defaultOutput)
+		t.Errorf("\n--- Got:\n%s--- Wanted:\n%s\n", got, defaultOutput)
 	}
 }
 


### PR DESCRIPTION
The `defaultIsZeroValue` function does not check on the `DefValue` field, for generic `Value` types., but instead wrongly checks on the flag `Value` field.
This results in the help screen wrongly displays the default value for a custom Value option, even though the default value is a "zerovalue". 


# Reproduce

```sh
hellocmd --my-option "some-value" -h
```

Should not display the default value in the help screen, but does anyways without this patch. 


## Example code to reproduce
```go
package main
import (
	"fmt"
	"github.com/spf13/cobra"
	"os"
)

var myOption StringOption

func init() {
	Command.Flags().Var(&myOption, "my-option", "My custom option")
}

func main() {
	if err := Command.Execute(); err != nil {
		fmt.Println(err)
		os.Exit(1)
	}
}

var Command = &cobra.Command{
	Use:   "hellocmd",
	Short: "Hello ",
	Long:  "Hello long",
	Run: func(cmd *cobra.Command, args []string) {
	},
}

type StringOption struct {
	value string
}

func (s *StringOption) Type() string {
	return "string"
}

func (s *StringOption) String() string {
	return s.value
}

func (s *StringOption) Set(s2 string) error {
	s.value = s2
	return nil
}
```

# Similar / related PR
### https://github.com/spf13/pflag/pull/361
Is related, however solves this problem specifically for `isBoolFlag()=true` custom `Value` types. 
While this additionally solves for other custom `Value` types. 