### PR TITLE
feat: Use structs for errors returned by pflag.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -47,6 +47,19 @@ func (e *NotExistError) Error() string {
 	panic(fmt.Errorf("unknown flagNotExistErrorMessageType: %v", e.messageType))
 }
 
+// GetSpecifiedName returns the name of the flag (without dashes) as it
+// appeared in the parsed arguments.
+func (e *NotExistError) GetSpecifiedName() string {
+	return e.name
+}
+
+// GetSpecifiedShortnames returns the group of shorthand arguments
+// (without dashes) that the flag appeared within. If the flag was not in a
+// shorthand group, this will return an empty string.
+func (e *NotExistError) GetSpecifiedShortnames() string {
+	return e.specifiedShorthands
+}
+
 // ValueRequiredError is the error returned when a flag needs an argument but
 // no argument was provided.
 type ValueRequiredError struct {
@@ -63,6 +76,24 @@ func (e *ValueRequiredError) Error() string {
 	}
 
 	return fmt.Sprintf("flag needs an argument: --%s", e.specifiedName)
+}
+
+// GetFlag returns the flag for which the error occurred.
+func (e *ValueRequiredError) GetFlag() *Flag {
+	return e.flag
+}
+
+// GetSpecifiedName returns the name of the flag (without dashes) as it
+// appeared in the parsed arguments.
+func (e *ValueRequiredError) GetSpecifiedName() string {
+	return e.specifiedName
+}
+
+// GetSpecifiedShortnames returns the group of shorthand arguments
+// (without dashes) that the flag appeared within. If the flag was not in a
+// shorthand group, this will return an empty string.
+func (e *ValueRequiredError) GetSpecifiedShortnames() string {
+	return e.specifiedShorthands
 }
 
 // InvalidValueError is the error returned when an invalid value is used
@@ -85,6 +116,21 @@ func (e *InvalidValueError) Error() string {
 	return fmt.Sprintf("invalid argument %q for %q flag: %v", e.value, flagName, e.cause)
 }
 
+// Unwrap implements errors.Unwrap.
+func (e *InvalidValueError) Unwrap() error {
+	return e.cause
+}
+
+// GetFlag returns the flag for which the error occurred.
+func (e *InvalidValueError) GetFlag() *Flag {
+	return e.flag
+}
+
+// GetValue returns the invalid value that was provided.
+func (e *InvalidValueError) GetValue() string {
+	return e.value
+}
+
 // InvalidSyntaxError is the error returned when a bad flag name is passed on
 // the command line.
 type InvalidSyntaxError struct {
@@ -94,4 +140,10 @@ type InvalidSyntaxError struct {
 // Error implements error.
 func (e *InvalidSyntaxError) Error() string {
 	return fmt.Sprintf("bad flag syntax: %s", e.specifiedFlag)
+}
+
+// GetSpecifiedName returns the exact flag (with dashes) as it
+// appeared in the parsed arguments.
+func (e *InvalidSyntaxError) GetSpecifiedFlag() string {
+	return e.specifiedFlag
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,97 @@
+package pflag
+
+import "fmt"
+
+// notExistErrorMessageType specifies which flavor of "flag does not exist"
+// is printed by NotExistError. This allows the related errors to be grouped
+// under a single NotExistError struct without making a breaking change to
+// the error message text.
+type notExistErrorMessageType int
+
+const (
+	flagNotExistMessage notExistErrorMessageType = iota
+	flagNotDefinedMessage
+	flagNoSuchFlagMessage
+	flagUnknownFlagMessage
+	flagUnknownShorthandFlagMessage
+)
+
+// NotExistError is the error returned when trying to access a flag that
+// does not exist in the FlagSet.
+type NotExistError struct {
+	name                string
+	specifiedShorthands string
+	messageType         notExistErrorMessageType
+}
+
+// Error implements error.
+func (e *NotExistError) Error() string {
+	switch e.messageType {
+	case flagNotExistMessage:
+		return fmt.Sprintf("flag %q does not exist", e.name)
+
+	case flagNotDefinedMessage:
+		return fmt.Sprintf("flag accessed but not defined: %s", e.name)
+
+	case flagNoSuchFlagMessage:
+		return fmt.Sprintf("no such flag -%v", e.name)
+
+	case flagUnknownFlagMessage:
+		return fmt.Sprintf("unknown flag: --%s", e.name)
+
+	case flagUnknownShorthandFlagMessage:
+		c := rune(e.name[0])
+		return fmt.Sprintf("unknown shorthand flag: %q in -%s", c, e.specifiedShorthands)
+	}
+
+	panic(fmt.Errorf("unknown flagNotExistErrorMessageType: %v", e.messageType))
+}
+
+// ValueRequiredError is the error returned when a flag needs an argument but
+// no argument was provided.
+type ValueRequiredError struct {
+	flag                *Flag
+	specifiedName       string
+	specifiedShorthands string
+}
+
+// Error implements error.
+func (e *ValueRequiredError) Error() string {
+	if len(e.specifiedShorthands) > 0 {
+		c := rune(e.specifiedName[0])
+		return fmt.Sprintf("flag needs an argument: %q in -%s", c, e.specifiedShorthands)
+	}
+
+	return fmt.Sprintf("flag needs an argument: --%s", e.specifiedName)
+}
+
+// InvalidValueError is the error returned when an invalid value is used
+// for a flag.
+type InvalidValueError struct {
+	flag  *Flag
+	value string
+	cause error
+}
+
+// Error implements error.
+func (e *InvalidValueError) Error() string {
+	flag := e.flag
+	var flagName string
+	if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
+		flagName = fmt.Sprintf("-%s, --%s", flag.Shorthand, flag.Name)
+	} else {
+		flagName = fmt.Sprintf("--%s", flag.Name)
+	}
+	return fmt.Sprintf("invalid argument %q for %q flag: %v", e.value, flagName, e.cause)
+}
+
+// InvalidSyntaxError is the error returned when a bad flag name is passed on
+// the command line.
+type InvalidSyntaxError struct {
+	specifiedFlag string
+}
+
+// Error implements error.
+func (e *InvalidSyntaxError) Error() string {
+	return fmt.Sprintf("bad flag syntax: %s", e.specifiedFlag)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,67 @@
+package pflag
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNotExistError(t *testing.T) {
+	err := &NotExistError{
+		name:                "foo",
+		specifiedShorthands: "bar",
+	}
+
+	if err.GetSpecifiedName() != "foo" {
+		t.Errorf("Expected GetSpecifiedName to return %q, got %q", "foo", err.GetSpecifiedName())
+	}
+	if err.GetSpecifiedShortnames() != "bar" {
+		t.Errorf("Expected GetSpecifiedShortnames to return %q, got %q", "bar", err.GetSpecifiedShortnames())
+	}
+}
+
+func TestValueRequiredError(t *testing.T) {
+	err := &ValueRequiredError{
+		flag:                &Flag{},
+		specifiedName:       "foo",
+		specifiedShorthands: "bar",
+	}
+
+	if err.GetFlag() == nil {
+		t.Error("Expected GetSpecifiedName to return its flag field, but got nil")
+	}
+	if err.GetSpecifiedName() != "foo" {
+		t.Errorf("Expected GetSpecifiedName to return %q, got %q", "foo", err.GetSpecifiedName())
+	}
+	if err.GetSpecifiedShortnames() != "bar" {
+		t.Errorf("Expected GetSpecifiedShortnames to return %q, got %q", "bar", err.GetSpecifiedShortnames())
+	}
+}
+
+func TestInvalidValueError(t *testing.T) {
+	expectedCause := errors.New("error")
+	err := &InvalidValueError{
+		flag:  &Flag{},
+		value: "foo",
+		cause: expectedCause,
+	}
+
+	if err.GetFlag() == nil {
+		t.Error("Expected GetSpecifiedName to return its flag field, but got nil")
+	}
+	if err.GetValue() != "foo" {
+		t.Errorf("Expected GetValue to return %q, got %q", "foo", err.GetValue())
+	}
+	if err.Unwrap() != expectedCause {
+		t.Errorf("Expected Unwrwap to return %q, got %q", expectedCause, err.Unwrap())
+	}
+}
+
+func TestInvalidSyntaxError(t *testing.T) {
+	err := &InvalidSyntaxError{
+		specifiedFlag: "--=",
+	}
+
+	if err.GetSpecifiedFlag() != "--=" {
+		t.Errorf("Expected GetSpecifiedFlag to return %q, got %q", "--=", err.GetSpecifiedFlag())
+	}
+}

--- a/flag_test.go
+++ b/flag_test.go
@@ -103,8 +103,13 @@ func TestEverything(t *testing.T) {
 func TestUsage(t *testing.T) {
 	called := false
 	ResetForTesting(func() { called = true })
-	if GetCommandLine().Parse([]string{"--x"}) == nil {
+	err := GetCommandLine().Parse([]string{"--x"})
+	expectedErr := "unknown flag: --x"
+	if err == nil {
 		t.Error("parse did not fail for unknown flag")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
 	}
 	if called {
 		t.Error("did call Usage while using ContinueOnError")
@@ -131,8 +136,13 @@ func TestAddFlagSet(t *testing.T) {
 func TestAnnotation(t *testing.T) {
 	f := NewFlagSet("shorthand", ContinueOnError)
 
-	if err := f.SetAnnotation("missing-flag", "key", nil); err == nil {
+	err := f.SetAnnotation("missing-flag", "key", nil)
+	expectedErr := "no such flag -missing-flag"
+	if err == nil {
 		t.Errorf("Expected error setting annotation on non-existent flag")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
 	}
 
 	f.StringP("stringa", "a", "", "string value")
@@ -349,6 +359,33 @@ func testParse(f *FlagSet, t *testing.T) {
 	} else if f.Args()[0] != extra {
 		t.Errorf("expected argument %q got %q", extra, f.Args()[0])
 	}
+	// Test unknown
+	err := f.Parse([]string{"--unknown"})
+	expectedErr := "unknown flag: --unknown"
+	if err == nil {
+		t.Error("parse did not fail for unknown flag")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+	// Test invalid
+	err = f.Parse([]string{"--bool=abcdefg"})
+	expectedErr = `invalid argument "abcdefg" for "--bool" flag: strconv.ParseBool: parsing "abcdefg": invalid syntax`
+	if err == nil {
+		t.Error("parse did not fail for invalid argument")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+	// Test required
+	err = f.Parse([]string{"--int"})
+	expectedErr = `flag needs an argument: --int`
+	if err == nil {
+		t.Error("parse did not fail for missing argument")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
 }
 
 func testParseAll(f *FlagSet, t *testing.T) {
@@ -537,6 +574,24 @@ func TestShorthand(t *testing.T) {
 	}
 	if f.ArgsLenAtDash() != 1 {
 		t.Errorf("expected argsLenAtDash %d got %d", f.ArgsLenAtDash(), 1)
+	}
+	// Test unknown
+	err := f.Parse([]string{"-ukn"})
+	expectedErr := "unknown shorthand flag: 'u' in -ukn"
+	if err == nil {
+		t.Error("parse did not fail for unknown shorthand flag")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+	// Test required
+	err = f.Parse([]string{"-as"})
+	expectedErr = `flag needs an argument: 's' in -s`
+	if err == nil {
+		t.Error("parse did not fail for missing argument")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
 	}
 }
 


### PR DESCRIPTION
This pull request is the pflag complement to https://github.com/spf13/cobra/pull/2266, converting a bunch of `fmt.Errorf` errors into structs implementing the `error` interface.

The goal of this pull request is to make it easier for callers of the `Parse` function to determine why flag parsing failed without having to resort to regex matching or parsing the returned error message. This pull request goes a bit further than using the `%w` error-wrapping format verb, opting to use structs as a way to both determine the type of returned error and get specific details about it (e.g. the relevant `*pflag.Flag`).


Giving callers this info enables them to do new things such as:
- Printing localized error messages.
- Changing how the errors are displayed (e.g. pretty printing, colors).

The error structs added are:
- `NotExistError`
- `ValueRequiredError`
- `InvalidValueError`
- `InvalidSyntaxError`

Tests have been added as well, and I made sure to maintain compatibility with versions of pflag prior to this pull request by using the exact same error messages.