### PR TITLE
Export built-in impls of Value and corresponding new funcs

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -10,26 +10,26 @@ type boolFlag interface {
 }
 
 // -- bool Value
-type boolValue bool
+type BoolValue bool
 
-func newBoolValue(val bool, p *bool) *boolValue {
+func NewBoolValue(val bool, p *bool) *BoolValue {
 	*p = val
-	return (*boolValue)(p)
+	return (*BoolValue)(p)
 }
 
-func (b *boolValue) Set(s string) error {
+func (b *BoolValue) Set(s string) error {
 	v, err := strconv.ParseBool(s)
-	*b = boolValue(v)
+	*b = BoolValue(v)
 	return err
 }
 
-func (b *boolValue) Type() string {
+func (b *BoolValue) Type() string {
 	return "bool"
 }
 
-func (b *boolValue) String() string { return strconv.FormatBool(bool(*b)) }
+func (b *BoolValue) String() string { return strconv.FormatBool(bool(*b)) }
 
-func (b *boolValue) IsBoolFlag() bool { return true }
+func (b *BoolValue) IsBoolFlag() bool { return true }
 
 func boolConv(sval string) (interface{}, error) {
 	return strconv.ParseBool(sval)
@@ -52,7 +52,7 @@ func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage)
+	flag := f.VarPF(NewBoolValue(value, p), name, shorthand, usage)
 	flag.NoOptDefVal = "true"
 }
 
@@ -64,7 +64,7 @@ func BoolVar(p *bool, name string, value bool, usage string) {
 
 // BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
-	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage)
+	flag := CommandLine.VarPF(NewBoolValue(value, p), name, shorthand, usage)
 	flag.NoOptDefVal = "true"
 }
 

--- a/bool_slice.go
+++ b/bool_slice.go
@@ -7,13 +7,13 @@ import (
 )
 
 // -- boolSlice Value
-type boolSliceValue struct {
+type BoolSliceValue struct {
 	value   *[]bool
 	changed bool
 }
 
-func newBoolSliceValue(val []bool, p *[]bool) *boolSliceValue {
-	bsv := new(boolSliceValue)
+func NewBoolSliceValue(val []bool, p *[]bool) *BoolSliceValue {
+	bsv := new(BoolSliceValue)
 	bsv.value = p
 	*bsv.value = val
 	return bsv
@@ -21,7 +21,7 @@ func newBoolSliceValue(val []bool, p *[]bool) *boolSliceValue {
 
 // Set converts, and assigns, the comma-separated boolean argument string representation as the []bool value of this flag.
 // If Set is called on a flag that already has a []bool assigned, the newly converted values will be appended.
-func (s *boolSliceValue) Set(val string) error {
+func (s *BoolSliceValue) Set(val string) error {
 
 	// remove all quote characters
 	rmQuote := strings.NewReplacer(`"`, "", `'`, "", "`", "")
@@ -54,12 +54,12 @@ func (s *boolSliceValue) Set(val string) error {
 }
 
 // Type returns a string that uniquely represents this flag's type.
-func (s *boolSliceValue) Type() string {
+func (s *BoolSliceValue) Type() string {
 	return "boolSlice"
 }
 
 // String defines a "native" format for this boolean slice flag value.
-func (s *boolSliceValue) String() string {
+func (s *BoolSliceValue) String() string {
 
 	boolStrSlice := make([]string, len(*s.value))
 	for i, b := range *s.value {
@@ -71,15 +71,15 @@ func (s *boolSliceValue) String() string {
 	return "[" + out + "]"
 }
 
-func (s *boolSliceValue) fromString(val string) (bool, error) {
+func (s *BoolSliceValue) fromString(val string) (bool, error) {
 	return strconv.ParseBool(val)
 }
 
-func (s *boolSliceValue) toString(val bool) string {
+func (s *BoolSliceValue) toString(val bool) string {
 	return strconv.FormatBool(val)
 }
 
-func (s *boolSliceValue) Append(val string) error {
+func (s *BoolSliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func (s *boolSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *boolSliceValue) Replace(val []string) error {
+func (s *BoolSliceValue) Replace(val []string) error {
 	out := make([]bool, len(val))
 	for i, d := range val {
 		var err error
@@ -101,7 +101,7 @@ func (s *boolSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *boolSliceValue) GetSlice() []string {
+func (s *BoolSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)
@@ -139,23 +139,23 @@ func (f *FlagSet) GetBoolSlice(name string) ([]bool, error) {
 // BoolSliceVar defines a boolSlice flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
 func (f *FlagSet) BoolSliceVar(p *[]bool, name string, value []bool, usage string) {
-	f.VarP(newBoolSliceValue(value, p), name, "", usage)
+	f.VarP(NewBoolSliceValue(value, p), name, "", usage)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string) {
-	f.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewBoolSliceValue(value, p), name, shorthand, usage)
 }
 
 // BoolSliceVar defines a []bool flag with specified name, default value, and usage string.
 // The argument p points to a []bool variable in which to store the value of the flag.
 func BoolSliceVar(p *[]bool, name string, value []bool, usage string) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewBoolSliceValue(value, p), name, "", usage)
 }
 
 // BoolSliceVarP is like BoolSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func BoolSliceVarP(p *[]bool, name, shorthand string, value []bool, usage string) {
-	CommandLine.VarP(newBoolSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewBoolSliceValue(value, p), name, shorthand, usage)
 }
 
 // BoolSlice defines a []bool flag with specified name, default value, and usage string.

--- a/bytes.go
+++ b/bytes.go
@@ -8,15 +8,15 @@ import (
 )
 
 // BytesHex adapts []byte for use as a flag. Value of flag is HEX encoded
-type bytesHexValue []byte
+type BytesHexValue []byte
 
 // String implements pflag.Value.String.
-func (bytesHex bytesHexValue) String() string {
+func (bytesHex BytesHexValue) String() string {
 	return fmt.Sprintf("%X", []byte(bytesHex))
 }
 
 // Set implements pflag.Value.Set.
-func (bytesHex *bytesHexValue) Set(value string) error {
+func (bytesHex *BytesHexValue) Set(value string) error {
 	bin, err := hex.DecodeString(strings.TrimSpace(value))
 
 	if err != nil {
@@ -29,13 +29,13 @@ func (bytesHex *bytesHexValue) Set(value string) error {
 }
 
 // Type implements pflag.Value.Type.
-func (*bytesHexValue) Type() string {
+func (*BytesHexValue) Type() string {
 	return "bytesHex"
 }
 
-func newBytesHexValue(val []byte, p *[]byte) *bytesHexValue {
+func NewBytesHexValue(val []byte, p *[]byte) *BytesHexValue {
 	*p = val
-	return (*bytesHexValue)(p)
+	return (*BytesHexValue)(p)
 }
 
 func bytesHexConv(sval string) (interface{}, error) {
@@ -63,23 +63,23 @@ func (f *FlagSet) GetBytesHex(name string) ([]byte, error) {
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
 func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string) {
-	f.VarP(newBytesHexValue(value, p), name, "", usage)
+	f.VarP(NewBytesHexValue(value, p), name, "", usage)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	f.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+	f.VarP(NewBytesHexValue(value, p), name, shorthand, usage)
 }
 
 // BytesHexVar defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
 func BytesHexVar(p *[]byte, name string, value []byte, usage string) {
-	CommandLine.VarP(newBytesHexValue(value, p), name, "", usage)
+	CommandLine.VarP(NewBytesHexValue(value, p), name, "", usage)
 }
 
 // BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
 func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewBytesHexValue(value, p), name, shorthand, usage)
 }
 
 // BytesHex defines an []byte flag with specified name, default value, and usage string.
@@ -109,15 +109,15 @@ func BytesHexP(name, shorthand string, value []byte, usage string) *[]byte {
 }
 
 // BytesBase64 adapts []byte for use as a flag. Value of flag is Base64 encoded
-type bytesBase64Value []byte
+type BytesBase64Value []byte
 
 // String implements pflag.Value.String.
-func (bytesBase64 bytesBase64Value) String() string {
+func (bytesBase64 BytesBase64Value) String() string {
 	return base64.StdEncoding.EncodeToString([]byte(bytesBase64))
 }
 
 // Set implements pflag.Value.Set.
-func (bytesBase64 *bytesBase64Value) Set(value string) error {
+func (bytesBase64 *BytesBase64Value) Set(value string) error {
 	bin, err := base64.StdEncoding.DecodeString(strings.TrimSpace(value))
 
 	if err != nil {
@@ -130,13 +130,13 @@ func (bytesBase64 *bytesBase64Value) Set(value string) error {
 }
 
 // Type implements pflag.Value.Type.
-func (*bytesBase64Value) Type() string {
+func (*BytesBase64Value) Type() string {
 	return "bytesBase64"
 }
 
-func newBytesBase64Value(val []byte, p *[]byte) *bytesBase64Value {
+func NewBytesBase64Value(val []byte, p *[]byte) *BytesBase64Value {
 	*p = val
-	return (*bytesBase64Value)(p)
+	return (*BytesBase64Value)(p)
 }
 
 func bytesBase64ValueConv(sval string) (interface{}, error) {
@@ -163,23 +163,23 @@ func (f *FlagSet) GetBytesBase64(name string) ([]byte, error) {
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
 func (f *FlagSet) BytesBase64Var(p *[]byte, name string, value []byte, usage string) {
-	f.VarP(newBytesBase64Value(value, p), name, "", usage)
+	f.VarP(NewBytesBase64Value(value, p), name, "", usage)
 }
 
 // BytesBase64VarP is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	f.VarP(newBytesBase64Value(value, p), name, shorthand, usage)
+	f.VarP(NewBytesBase64Value(value, p), name, shorthand, usage)
 }
 
 // BytesBase64Var defines an []byte flag with specified name, default value, and usage string.
 // The argument p points to an []byte variable in which to store the value of the flag.
 func BytesBase64Var(p *[]byte, name string, value []byte, usage string) {
-	CommandLine.VarP(newBytesBase64Value(value, p), name, "", usage)
+	CommandLine.VarP(NewBytesBase64Value(value, p), name, "", usage)
 }
 
 // BytesBase64VarP is like BytesBase64Var, but accepts a shorthand letter that can be used after a single dash.
 func BytesBase64VarP(p *[]byte, name, shorthand string, value []byte, usage string) {
-	CommandLine.VarP(newBytesBase64Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewBytesBase64Value(value, p), name, shorthand, usage)
 }
 
 // BytesBase64 defines an []byte flag with specified name, default value, and usage string.

--- a/count.go
+++ b/count.go
@@ -3,29 +3,29 @@ package pflag
 import "strconv"
 
 // -- count Value
-type countValue int
+type CountValue int
 
-func newCountValue(val int, p *int) *countValue {
+func NewCountValue(val int, p *int) *CountValue {
 	*p = val
-	return (*countValue)(p)
+	return (*CountValue)(p)
 }
 
-func (i *countValue) Set(s string) error {
+func (i *CountValue) Set(s string) error {
 	// "+1" means that no specific value was passed, so increment
 	if s == "+1" {
-		*i = countValue(*i + 1)
+		*i = CountValue(*i + 1)
 		return nil
 	}
 	v, err := strconv.ParseInt(s, 0, 0)
-	*i = countValue(v)
+	*i = CountValue(v)
 	return err
 }
 
-func (i *countValue) Type() string {
+func (i *CountValue) Type() string {
 	return "count"
 }
 
-func (i *countValue) String() string { return strconv.Itoa(int(*i)) }
+func (i *CountValue) String() string { return strconv.Itoa(int(*i)) }
 
 func countConv(sval string) (interface{}, error) {
 	i, err := strconv.Atoi(sval)
@@ -53,7 +53,7 @@ func (f *FlagSet) CountVar(p *int, name string, usage string) {
 
 // CountVarP is like CountVar only take a shorthand for the flag name.
 func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string) {
-	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage)
+	flag := f.VarPF(NewCountValue(0, p), name, shorthand, usage)
 	flag.NoOptDefVal = "+1"
 }
 

--- a/duration.go
+++ b/duration.go
@@ -5,24 +5,24 @@ import (
 )
 
 // -- time.Duration Value
-type durationValue time.Duration
+type DurationValue time.Duration
 
-func newDurationValue(val time.Duration, p *time.Duration) *durationValue {
+func NewDurationValue(val time.Duration, p *time.Duration) *DurationValue {
 	*p = val
-	return (*durationValue)(p)
+	return (*DurationValue)(p)
 }
 
-func (d *durationValue) Set(s string) error {
+func (d *DurationValue) Set(s string) error {
 	v, err := time.ParseDuration(s)
-	*d = durationValue(v)
+	*d = DurationValue(v)
 	return err
 }
 
-func (d *durationValue) Type() string {
+func (d *DurationValue) Type() string {
 	return "duration"
 }
 
-func (d *durationValue) String() string { return (*time.Duration)(d).String() }
+func (d *DurationValue) String() string { return (*time.Duration)(d).String() }
 
 func durationConv(sval string) (interface{}, error) {
 	return time.ParseDuration(sval)
@@ -40,23 +40,23 @@ func (f *FlagSet) GetDuration(name string) (time.Duration, error) {
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
 func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
-	f.VarP(newDurationValue(value, p), name, "", usage)
+	f.VarP(NewDurationValue(value, p), name, "", usage)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
-	f.VarP(newDurationValue(value, p), name, shorthand, usage)
+	f.VarP(NewDurationValue(value, p), name, shorthand, usage)
 }
 
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
 func DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
-	CommandLine.VarP(newDurationValue(value, p), name, "", usage)
+	CommandLine.VarP(NewDurationValue(value, p), name, "", usage)
 }
 
 // DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
 func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
-	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewDurationValue(value, p), name, shorthand, usage)
 }
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.

--- a/duration_slice.go
+++ b/duration_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- durationSlice Value
-type durationSliceValue struct {
+type DurationSliceValue struct {
 	value   *[]time.Duration
 	changed bool
 }
 
-func newDurationSliceValue(val []time.Duration, p *[]time.Duration) *durationSliceValue {
-	dsv := new(durationSliceValue)
+func NewDurationSliceValue(val []time.Duration, p *[]time.Duration) *DurationSliceValue {
+	dsv := new(DurationSliceValue)
 	dsv.value = p
 	*dsv.value = val
 	return dsv
 }
 
-func (s *durationSliceValue) Set(val string) error {
+func (s *DurationSliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]time.Duration, len(ss))
 	for i, d := range ss {
@@ -39,11 +39,11 @@ func (s *durationSliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *durationSliceValue) Type() string {
+func (s *DurationSliceValue) Type() string {
 	return "durationSlice"
 }
 
-func (s *durationSliceValue) String() string {
+func (s *DurationSliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%s", d)
@@ -51,15 +51,15 @@ func (s *durationSliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *durationSliceValue) fromString(val string) (time.Duration, error) {
+func (s *DurationSliceValue) fromString(val string) (time.Duration, error) {
 	return time.ParseDuration(val)
 }
 
-func (s *durationSliceValue) toString(val time.Duration) string {
+func (s *DurationSliceValue) toString(val time.Duration) string {
 	return fmt.Sprintf("%s", val)
 }
 
-func (s *durationSliceValue) Append(val string) error {
+func (s *DurationSliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (s *durationSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *durationSliceValue) Replace(val []string) error {
+func (s *DurationSliceValue) Replace(val []string) error {
 	out := make([]time.Duration, len(val))
 	for i, d := range val {
 		var err error
@@ -81,7 +81,7 @@ func (s *durationSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *durationSliceValue) GetSlice() []string {
+func (s *DurationSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)
@@ -120,23 +120,23 @@ func (f *FlagSet) GetDurationSlice(name string) ([]time.Duration, error) {
 // DurationSliceVar defines a durationSlice flag with specified name, default value, and usage string.
 // The argument p points to a []time.Duration variable in which to store the value of the flag.
 func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
-	f.VarP(newDurationSliceValue(value, p), name, "", usage)
+	f.VarP(NewDurationSliceValue(value, p), name, "", usage)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
-	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewDurationSliceValue(value, p), name, shorthand, usage)
 }
 
 // DurationSliceVar defines a duration[] flag with specified name, default value, and usage string.
 // The argument p points to a duration[] variable in which to store the value of the flag.
 func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
-	CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewDurationSliceValue(value, p), name, "", usage)
 }
 
 // DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
-	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewDurationSliceValue(value, p), name, shorthand, usage)
 }
 
 // DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.

--- a/flag.go
+++ b/flag.go
@@ -550,16 +550,16 @@ func (f *Flag) defaultIsZeroValue() bool {
 	switch f.Value.(type) {
 	case boolFlag:
 		return f.DefValue == "false"
-	case *durationValue:
+	case *DurationValue:
 		// Beginning in Go 1.7, duration zero values are "0s"
 		return f.DefValue == "0" || f.DefValue == "0s"
-	case *intValue, *int8Value, *int32Value, *int64Value, *uintValue, *uint8Value, *uint16Value, *uint32Value, *uint64Value, *countValue, *float32Value, *float64Value:
+	case *IntValue, *Int8Value, *Int32Value, *Int64Value, *UintValue, *Uint8Value, *Uint16Value, *Uint32Value, *Uint64Value, *CountValue, *Float32Value, *Float64Value:
 		return f.DefValue == "0"
-	case *stringValue:
+	case *StringValue:
 		return f.DefValue == ""
-	case *ipValue, *ipMaskValue, *ipNetValue:
+	case *IPValue, *IPMaskValue, *IPNetValue:
 		return f.DefValue == "<nil>"
-	case *intSliceValue, *stringSliceValue, *stringArrayValue:
+	case *IntSliceValue, *StringSliceValue, *StringArrayValue:
 		return f.DefValue == "[]"
 	default:
 		switch f.DefValue {

--- a/float32.go
+++ b/float32.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- float32 Value
-type float32Value float32
+type Float32Value float32
 
-func newFloat32Value(val float32, p *float32) *float32Value {
+func NewFloat32Value(val float32, p *float32) *Float32Value {
 	*p = val
-	return (*float32Value)(p)
+	return (*Float32Value)(p)
 }
 
-func (f *float32Value) Set(s string) error {
+func (f *Float32Value) Set(s string) error {
 	v, err := strconv.ParseFloat(s, 32)
-	*f = float32Value(v)
+	*f = Float32Value(v)
 	return err
 }
 
-func (f *float32Value) Type() string {
+func (f *Float32Value) Type() string {
 	return "float32"
 }
 
-func (f *float32Value) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 32) }
+func (f *Float32Value) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 32) }
 
 func float32Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseFloat(sval, 32)
@@ -42,23 +42,23 @@ func (f *FlagSet) GetFloat32(name string) (float32, error) {
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
 func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string) {
-	f.VarP(newFloat32Value(value, p), name, "", usage)
+	f.VarP(NewFloat32Value(value, p), name, "", usage)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
-	f.VarP(newFloat32Value(value, p), name, shorthand, usage)
+	f.VarP(NewFloat32Value(value, p), name, shorthand, usage)
 }
 
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
 func Float32Var(p *float32, name string, value float32, usage string) {
-	CommandLine.VarP(newFloat32Value(value, p), name, "", usage)
+	CommandLine.VarP(NewFloat32Value(value, p), name, "", usage)
 }
 
 // Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
 func Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
-	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewFloat32Value(value, p), name, shorthand, usage)
 }
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.

--- a/float32_slice.go
+++ b/float32_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- float32Slice Value
-type float32SliceValue struct {
+type Float32SliceValue struct {
 	value   *[]float32
 	changed bool
 }
 
-func newFloat32SliceValue(val []float32, p *[]float32) *float32SliceValue {
-	isv := new(float32SliceValue)
+func NewFloat32SliceValue(val []float32, p *[]float32) *Float32SliceValue {
+	isv := new(Float32SliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *float32SliceValue) Set(val string) error {
+func (s *Float32SliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]float32, len(ss))
 	for i, d := range ss {
@@ -41,11 +41,11 @@ func (s *float32SliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *float32SliceValue) Type() string {
+func (s *Float32SliceValue) Type() string {
 	return "float32Slice"
 }
 
-func (s *float32SliceValue) String() string {
+func (s *Float32SliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%f", d)
@@ -53,7 +53,7 @@ func (s *float32SliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *float32SliceValue) fromString(val string) (float32, error) {
+func (s *Float32SliceValue) fromString(val string) (float32, error) {
 	t64, err := strconv.ParseFloat(val, 32)
 	if err != nil {
 		return 0, err
@@ -61,11 +61,11 @@ func (s *float32SliceValue) fromString(val string) (float32, error) {
 	return float32(t64), nil
 }
 
-func (s *float32SliceValue) toString(val float32) string {
+func (s *Float32SliceValue) toString(val float32) string {
 	return fmt.Sprintf("%f", val)
 }
 
-func (s *float32SliceValue) Append(val string) error {
+func (s *Float32SliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (s *float32SliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *float32SliceValue) Replace(val []string) error {
+func (s *Float32SliceValue) Replace(val []string) error {
 	out := make([]float32, len(val))
 	for i, d := range val {
 		var err error
@@ -87,7 +87,7 @@ func (s *float32SliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *float32SliceValue) GetSlice() []string {
+func (s *Float32SliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)
@@ -128,23 +128,23 @@ func (f *FlagSet) GetFloat32Slice(name string) ([]float32, error) {
 // Float32SliceVar defines a float32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float32 variable in which to store the value of the flag.
 func (f *FlagSet) Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
-	f.VarP(newFloat32SliceValue(value, p), name, "", usage)
+	f.VarP(NewFloat32SliceValue(value, p), name, "", usage)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string) {
-	f.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewFloat32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float32SliceVar defines a float32[] flag with specified name, default value, and usage string.
 // The argument p points to a float32[] variable in which to store the value of the flag.
 func Float32SliceVar(p *[]float32, name string, value []float32, usage string) {
-	CommandLine.VarP(newFloat32SliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewFloat32SliceValue(value, p), name, "", usage)
 }
 
 // Float32SliceVarP is like Float32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Float32SliceVarP(p *[]float32, name, shorthand string, value []float32, usage string) {
-	CommandLine.VarP(newFloat32SliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewFloat32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float32Slice defines a []float32 flag with specified name, default value, and usage string.

--- a/float64.go
+++ b/float64.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- float64 Value
-type float64Value float64
+type Float64Value float64
 
-func newFloat64Value(val float64, p *float64) *float64Value {
+func NewFloat64Value(val float64, p *float64) *Float64Value {
 	*p = val
-	return (*float64Value)(p)
+	return (*Float64Value)(p)
 }
 
-func (f *float64Value) Set(s string) error {
+func (f *Float64Value) Set(s string) error {
 	v, err := strconv.ParseFloat(s, 64)
-	*f = float64Value(v)
+	*f = Float64Value(v)
 	return err
 }
 
-func (f *float64Value) Type() string {
+func (f *Float64Value) Type() string {
 	return "float64"
 }
 
-func (f *float64Value) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 64) }
+func (f *Float64Value) String() string { return strconv.FormatFloat(float64(*f), 'g', -1, 64) }
 
 func float64Conv(sval string) (interface{}, error) {
 	return strconv.ParseFloat(sval, 64)
@@ -38,23 +38,23 @@ func (f *FlagSet) GetFloat64(name string) (float64, error) {
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
 func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string) {
-	f.VarP(newFloat64Value(value, p), name, "", usage)
+	f.VarP(NewFloat64Value(value, p), name, "", usage)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
-	f.VarP(newFloat64Value(value, p), name, shorthand, usage)
+	f.VarP(NewFloat64Value(value, p), name, shorthand, usage)
 }
 
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
 func Float64Var(p *float64, name string, value float64, usage string) {
-	CommandLine.VarP(newFloat64Value(value, p), name, "", usage)
+	CommandLine.VarP(NewFloat64Value(value, p), name, "", usage)
 }
 
 // Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
 func Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
-	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewFloat64Value(value, p), name, shorthand, usage)
 }
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.

--- a/float64_slice.go
+++ b/float64_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- float64Slice Value
-type float64SliceValue struct {
+type Float64SliceValue struct {
 	value   *[]float64
 	changed bool
 }
 
-func newFloat64SliceValue(val []float64, p *[]float64) *float64SliceValue {
-	isv := new(float64SliceValue)
+func NewFloat64SliceValue(val []float64, p *[]float64) *Float64SliceValue {
+	isv := new(Float64SliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *float64SliceValue) Set(val string) error {
+func (s *Float64SliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]float64, len(ss))
 	for i, d := range ss {
@@ -39,11 +39,11 @@ func (s *float64SliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *float64SliceValue) Type() string {
+func (s *Float64SliceValue) Type() string {
 	return "float64Slice"
 }
 
-func (s *float64SliceValue) String() string {
+func (s *Float64SliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%f", d)
@@ -51,15 +51,15 @@ func (s *float64SliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *float64SliceValue) fromString(val string) (float64, error) {
+func (s *Float64SliceValue) fromString(val string) (float64, error) {
 	return strconv.ParseFloat(val, 64)
 }
 
-func (s *float64SliceValue) toString(val float64) string {
+func (s *Float64SliceValue) toString(val float64) string {
 	return fmt.Sprintf("%f", val)
 }
 
-func (s *float64SliceValue) Append(val string) error {
+func (s *Float64SliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (s *float64SliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *float64SliceValue) Replace(val []string) error {
+func (s *Float64SliceValue) Replace(val []string) error {
 	out := make([]float64, len(val))
 	for i, d := range val {
 		var err error
@@ -81,7 +81,7 @@ func (s *float64SliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *float64SliceValue) GetSlice() []string {
+func (s *Float64SliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)
@@ -120,23 +120,23 @@ func (f *FlagSet) GetFloat64Slice(name string) ([]float64, error) {
 // Float64SliceVar defines a float64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []float64 variable in which to store the value of the flag.
 func (f *FlagSet) Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
-	f.VarP(newFloat64SliceValue(value, p), name, "", usage)
+	f.VarP(NewFloat64SliceValue(value, p), name, "", usage)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string) {
-	f.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewFloat64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float64SliceVar defines a float64[] flag with specified name, default value, and usage string.
 // The argument p points to a float64[] variable in which to store the value of the flag.
 func Float64SliceVar(p *[]float64, name string, value []float64, usage string) {
-	CommandLine.VarP(newFloat64SliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewFloat64SliceValue(value, p), name, "", usage)
 }
 
 // Float64SliceVarP is like Float64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Float64SliceVarP(p *[]float64, name, shorthand string, value []float64, usage string) {
-	CommandLine.VarP(newFloat64SliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewFloat64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Float64Slice defines a []float64 flag with specified name, default value, and usage string.

--- a/int.go
+++ b/int.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- int Value
-type intValue int
+type IntValue int
 
-func newIntValue(val int, p *int) *intValue {
+func NewIntValue(val int, p *int) *IntValue {
 	*p = val
-	return (*intValue)(p)
+	return (*IntValue)(p)
 }
 
-func (i *intValue) Set(s string) error {
+func (i *IntValue) Set(s string) error {
 	v, err := strconv.ParseInt(s, 0, 64)
-	*i = intValue(v)
+	*i = IntValue(v)
 	return err
 }
 
-func (i *intValue) Type() string {
+func (i *IntValue) Type() string {
 	return "int"
 }
 
-func (i *intValue) String() string { return strconv.Itoa(int(*i)) }
+func (i *IntValue) String() string { return strconv.Itoa(int(*i)) }
 
 func intConv(sval string) (interface{}, error) {
 	return strconv.Atoi(sval)
@@ -38,23 +38,23 @@ func (f *FlagSet) GetInt(name string) (int, error) {
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 func (f *FlagSet) IntVar(p *int, name string, value int, usage string) {
-	f.VarP(newIntValue(value, p), name, "", usage)
+	f.VarP(NewIntValue(value, p), name, "", usage)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string) {
-	f.VarP(newIntValue(value, p), name, shorthand, usage)
+	f.VarP(NewIntValue(value, p), name, shorthand, usage)
 }
 
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 func IntVar(p *int, name string, value int, usage string) {
-	CommandLine.VarP(newIntValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIntValue(value, p), name, "", usage)
 }
 
 // IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
 func IntVarP(p *int, name, shorthand string, value int, usage string) {
-	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIntValue(value, p), name, shorthand, usage)
 }
 
 // Int defines an int flag with specified name, default value, and usage string.

--- a/int16.go
+++ b/int16.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- int16 Value
-type int16Value int16
+type Int16Value int16
 
-func newInt16Value(val int16, p *int16) *int16Value {
+func NewInt16Value(val int16, p *int16) *Int16Value {
 	*p = val
-	return (*int16Value)(p)
+	return (*Int16Value)(p)
 }
 
-func (i *int16Value) Set(s string) error {
+func (i *Int16Value) Set(s string) error {
 	v, err := strconv.ParseInt(s, 0, 16)
-	*i = int16Value(v)
+	*i = Int16Value(v)
 	return err
 }
 
-func (i *int16Value) Type() string {
+func (i *Int16Value) Type() string {
 	return "int16"
 }
 
-func (i *int16Value) String() string { return strconv.FormatInt(int64(*i), 10) }
+func (i *Int16Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int16Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseInt(sval, 0, 16)
@@ -42,23 +42,23 @@ func (f *FlagSet) GetInt16(name string) (int16, error) {
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
 func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string) {
-	f.VarP(newInt16Value(value, p), name, "", usage)
+	f.VarP(NewInt16Value(value, p), name, "", usage)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage string) {
-	f.VarP(newInt16Value(value, p), name, shorthand, usage)
+	f.VarP(NewInt16Value(value, p), name, shorthand, usage)
 }
 
 // Int16Var defines an int16 flag with specified name, default value, and usage string.
 // The argument p points to an int16 variable in which to store the value of the flag.
 func Int16Var(p *int16, name string, value int16, usage string) {
-	CommandLine.VarP(newInt16Value(value, p), name, "", usage)
+	CommandLine.VarP(NewInt16Value(value, p), name, "", usage)
 }
 
 // Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
 func Int16VarP(p *int16, name, shorthand string, value int16, usage string) {
-	CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt16Value(value, p), name, shorthand, usage)
 }
 
 // Int16 defines an int16 flag with specified name, default value, and usage string.

--- a/int32.go
+++ b/int32.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- int32 Value
-type int32Value int32
+type Int32Value int32
 
-func newInt32Value(val int32, p *int32) *int32Value {
+func NewInt32Value(val int32, p *int32) *Int32Value {
 	*p = val
-	return (*int32Value)(p)
+	return (*Int32Value)(p)
 }
 
-func (i *int32Value) Set(s string) error {
+func (i *Int32Value) Set(s string) error {
 	v, err := strconv.ParseInt(s, 0, 32)
-	*i = int32Value(v)
+	*i = Int32Value(v)
 	return err
 }
 
-func (i *int32Value) Type() string {
+func (i *Int32Value) Type() string {
 	return "int32"
 }
 
-func (i *int32Value) String() string { return strconv.FormatInt(int64(*i), 10) }
+func (i *Int32Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int32Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseInt(sval, 0, 32)
@@ -42,23 +42,23 @@ func (f *FlagSet) GetInt32(name string) (int32, error) {
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
 func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string) {
-	f.VarP(newInt32Value(value, p), name, "", usage)
+	f.VarP(NewInt32Value(value, p), name, "", usage)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
-	f.VarP(newInt32Value(value, p), name, shorthand, usage)
+	f.VarP(NewInt32Value(value, p), name, shorthand, usage)
 }
 
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
 func Int32Var(p *int32, name string, value int32, usage string) {
-	CommandLine.VarP(newInt32Value(value, p), name, "", usage)
+	CommandLine.VarP(NewInt32Value(value, p), name, "", usage)
 }
 
 // Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
 func Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
-	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt32Value(value, p), name, shorthand, usage)
 }
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.

--- a/int32_slice.go
+++ b/int32_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- int32Slice Value
-type int32SliceValue struct {
+type Int32SliceValue struct {
 	value   *[]int32
 	changed bool
 }
 
-func newInt32SliceValue(val []int32, p *[]int32) *int32SliceValue {
-	isv := new(int32SliceValue)
+func NewInt32SliceValue(val []int32, p *[]int32) *Int32SliceValue {
+	isv := new(Int32SliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *int32SliceValue) Set(val string) error {
+func (s *Int32SliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]int32, len(ss))
 	for i, d := range ss {
@@ -41,11 +41,11 @@ func (s *int32SliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *int32SliceValue) Type() string {
+func (s *Int32SliceValue) Type() string {
 	return "int32Slice"
 }
 
-func (s *int32SliceValue) String() string {
+func (s *Int32SliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%d", d)
@@ -53,7 +53,7 @@ func (s *int32SliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *int32SliceValue) fromString(val string) (int32, error) {
+func (s *Int32SliceValue) fromString(val string) (int32, error) {
 	t64, err := strconv.ParseInt(val, 0, 32)
 	if err != nil {
 		return 0, err
@@ -61,11 +61,11 @@ func (s *int32SliceValue) fromString(val string) (int32, error) {
 	return int32(t64), nil
 }
 
-func (s *int32SliceValue) toString(val int32) string {
+func (s *Int32SliceValue) toString(val int32) string {
 	return fmt.Sprintf("%d", val)
 }
 
-func (s *int32SliceValue) Append(val string) error {
+func (s *Int32SliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func (s *int32SliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *int32SliceValue) Replace(val []string) error {
+func (s *Int32SliceValue) Replace(val []string) error {
 	out := make([]int32, len(val))
 	for i, d := range val {
 		var err error
@@ -87,7 +87,7 @@ func (s *int32SliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *int32SliceValue) GetSlice() []string {
+func (s *Int32SliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)
@@ -128,23 +128,23 @@ func (f *FlagSet) GetInt32Slice(name string) ([]int32, error) {
 // Int32SliceVar defines a int32Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int32 variable in which to store the value of the flag.
 func (f *FlagSet) Int32SliceVar(p *[]int32, name string, value []int32, usage string) {
-	f.VarP(newInt32SliceValue(value, p), name, "", usage)
+	f.VarP(NewInt32SliceValue(value, p), name, "", usage)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string) {
-	f.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewInt32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int32SliceVar defines a int32[] flag with specified name, default value, and usage string.
 // The argument p points to a int32[] variable in which to store the value of the flag.
 func Int32SliceVar(p *[]int32, name string, value []int32, usage string) {
-	CommandLine.VarP(newInt32SliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewInt32SliceValue(value, p), name, "", usage)
 }
 
 // Int32SliceVarP is like Int32SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Int32SliceVarP(p *[]int32, name, shorthand string, value []int32, usage string) {
-	CommandLine.VarP(newInt32SliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt32SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int32Slice defines a []int32 flag with specified name, default value, and usage string.

--- a/int64.go
+++ b/int64.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- int64 Value
-type int64Value int64
+type Int64Value int64
 
-func newInt64Value(val int64, p *int64) *int64Value {
+func NewInt64Value(val int64, p *int64) *Int64Value {
 	*p = val
-	return (*int64Value)(p)
+	return (*Int64Value)(p)
 }
 
-func (i *int64Value) Set(s string) error {
+func (i *Int64Value) Set(s string) error {
 	v, err := strconv.ParseInt(s, 0, 64)
-	*i = int64Value(v)
+	*i = Int64Value(v)
 	return err
 }
 
-func (i *int64Value) Type() string {
+func (i *Int64Value) Type() string {
 	return "int64"
 }
 
-func (i *int64Value) String() string { return strconv.FormatInt(int64(*i), 10) }
+func (i *Int64Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int64Conv(sval string) (interface{}, error) {
 	return strconv.ParseInt(sval, 0, 64)
@@ -38,23 +38,23 @@ func (f *FlagSet) GetInt64(name string) (int64, error) {
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
 func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string) {
-	f.VarP(newInt64Value(value, p), name, "", usage)
+	f.VarP(NewInt64Value(value, p), name, "", usage)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
-	f.VarP(newInt64Value(value, p), name, shorthand, usage)
+	f.VarP(NewInt64Value(value, p), name, shorthand, usage)
 }
 
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
 func Int64Var(p *int64, name string, value int64, usage string) {
-	CommandLine.VarP(newInt64Value(value, p), name, "", usage)
+	CommandLine.VarP(NewInt64Value(value, p), name, "", usage)
 }
 
 // Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
 func Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
-	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt64Value(value, p), name, shorthand, usage)
 }
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.

--- a/int64_slice.go
+++ b/int64_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- int64Slice Value
-type int64SliceValue struct {
+type Int64SliceValue struct {
 	value   *[]int64
 	changed bool
 }
 
-func newInt64SliceValue(val []int64, p *[]int64) *int64SliceValue {
-	isv := new(int64SliceValue)
+func NewInt64SliceValue(val []int64, p *[]int64) *Int64SliceValue {
+	isv := new(Int64SliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *int64SliceValue) Set(val string) error {
+func (s *Int64SliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]int64, len(ss))
 	for i, d := range ss {
@@ -39,11 +39,11 @@ func (s *int64SliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *int64SliceValue) Type() string {
+func (s *Int64SliceValue) Type() string {
 	return "int64Slice"
 }
 
-func (s *int64SliceValue) String() string {
+func (s *Int64SliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%d", d)
@@ -51,15 +51,15 @@ func (s *int64SliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *int64SliceValue) fromString(val string) (int64, error) {
+func (s *Int64SliceValue) fromString(val string) (int64, error) {
 	return strconv.ParseInt(val, 0, 64)
 }
 
-func (s *int64SliceValue) toString(val int64) string {
+func (s *Int64SliceValue) toString(val int64) string {
 	return fmt.Sprintf("%d", val)
 }
 
-func (s *int64SliceValue) Append(val string) error {
+func (s *Int64SliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (s *int64SliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *int64SliceValue) Replace(val []string) error {
+func (s *Int64SliceValue) Replace(val []string) error {
 	out := make([]int64, len(val))
 	for i, d := range val {
 		var err error
@@ -81,7 +81,7 @@ func (s *int64SliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *int64SliceValue) GetSlice() []string {
+func (s *Int64SliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)
@@ -120,23 +120,23 @@ func (f *FlagSet) GetInt64Slice(name string) ([]int64, error) {
 // Int64SliceVar defines a int64Slice flag with specified name, default value, and usage string.
 // The argument p points to a []int64 variable in which to store the value of the flag.
 func (f *FlagSet) Int64SliceVar(p *[]int64, name string, value []int64, usage string) {
-	f.VarP(newInt64SliceValue(value, p), name, "", usage)
+	f.VarP(NewInt64SliceValue(value, p), name, "", usage)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string) {
-	f.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewInt64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int64SliceVar defines a int64[] flag with specified name, default value, and usage string.
 // The argument p points to a int64[] variable in which to store the value of the flag.
 func Int64SliceVar(p *[]int64, name string, value []int64, usage string) {
-	CommandLine.VarP(newInt64SliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewInt64SliceValue(value, p), name, "", usage)
 }
 
 // Int64SliceVarP is like Int64SliceVar, but accepts a shorthand letter that can be used after a single dash.
 func Int64SliceVarP(p *[]int64, name, shorthand string, value []int64, usage string) {
-	CommandLine.VarP(newInt64SliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt64SliceValue(value, p), name, shorthand, usage)
 }
 
 // Int64Slice defines a []int64 flag with specified name, default value, and usage string.

--- a/int8.go
+++ b/int8.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- int8 Value
-type int8Value int8
+type Int8Value int8
 
-func newInt8Value(val int8, p *int8) *int8Value {
+func NewInt8Value(val int8, p *int8) *Int8Value {
 	*p = val
-	return (*int8Value)(p)
+	return (*Int8Value)(p)
 }
 
-func (i *int8Value) Set(s string) error {
+func (i *Int8Value) Set(s string) error {
 	v, err := strconv.ParseInt(s, 0, 8)
-	*i = int8Value(v)
+	*i = Int8Value(v)
 	return err
 }
 
-func (i *int8Value) Type() string {
+func (i *Int8Value) Type() string {
 	return "int8"
 }
 
-func (i *int8Value) String() string { return strconv.FormatInt(int64(*i), 10) }
+func (i *Int8Value) String() string { return strconv.FormatInt(int64(*i), 10) }
 
 func int8Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseInt(sval, 0, 8)
@@ -42,23 +42,23 @@ func (f *FlagSet) GetInt8(name string) (int8, error) {
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
 func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string) {
-	f.VarP(newInt8Value(value, p), name, "", usage)
+	f.VarP(NewInt8Value(value, p), name, "", usage)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
-	f.VarP(newInt8Value(value, p), name, shorthand, usage)
+	f.VarP(NewInt8Value(value, p), name, shorthand, usage)
 }
 
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
 func Int8Var(p *int8, name string, value int8, usage string) {
-	CommandLine.VarP(newInt8Value(value, p), name, "", usage)
+	CommandLine.VarP(NewInt8Value(value, p), name, "", usage)
 }
 
 // Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
 func Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
-	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewInt8Value(value, p), name, shorthand, usage)
 }
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.

--- a/int_slice.go
+++ b/int_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- intSlice Value
-type intSliceValue struct {
+type IntSliceValue struct {
 	value   *[]int
 	changed bool
 }
 
-func newIntSliceValue(val []int, p *[]int) *intSliceValue {
-	isv := new(intSliceValue)
+func NewIntSliceValue(val []int, p *[]int) *IntSliceValue {
+	isv := new(IntSliceValue)
 	isv.value = p
 	*isv.value = val
 	return isv
 }
 
-func (s *intSliceValue) Set(val string) error {
+func (s *IntSliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]int, len(ss))
 	for i, d := range ss {
@@ -39,11 +39,11 @@ func (s *intSliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *intSliceValue) Type() string {
+func (s *IntSliceValue) Type() string {
 	return "intSlice"
 }
 
-func (s *intSliceValue) String() string {
+func (s *IntSliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%d", d)
@@ -51,7 +51,7 @@ func (s *intSliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *intSliceValue) Append(val string) error {
+func (s *IntSliceValue) Append(val string) error {
 	i, err := strconv.Atoi(val)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func (s *intSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *intSliceValue) Replace(val []string) error {
+func (s *IntSliceValue) Replace(val []string) error {
 	out := make([]int, len(val))
 	for i, d := range val {
 		var err error
@@ -73,7 +73,7 @@ func (s *intSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *intSliceValue) GetSlice() []string {
+func (s *IntSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = strconv.Itoa(d)
@@ -112,23 +112,23 @@ func (f *FlagSet) GetIntSlice(name string) ([]int, error) {
 // IntSliceVar defines a intSlice flag with specified name, default value, and usage string.
 // The argument p points to a []int variable in which to store the value of the flag.
 func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string) {
-	f.VarP(newIntSliceValue(value, p), name, "", usage)
+	f.VarP(NewIntSliceValue(value, p), name, "", usage)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string) {
-	f.VarP(newIntSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewIntSliceValue(value, p), name, shorthand, usage)
 }
 
 // IntSliceVar defines a int[] flag with specified name, default value, and usage string.
 // The argument p points to a int[] variable in which to store the value of the flag.
 func IntSliceVar(p *[]int, name string, value []int, usage string) {
-	CommandLine.VarP(newIntSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIntSliceValue(value, p), name, "", usage)
 }
 
 // IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string) {
-	CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIntSliceValue(value, p), name, shorthand, usage)
 }
 
 // IntSlice defines a []int flag with specified name, default value, and usage string.

--- a/ip.go
+++ b/ip.go
@@ -7,15 +7,15 @@ import (
 )
 
 // -- net.IP value
-type ipValue net.IP
+type IPValue net.IP
 
-func newIPValue(val net.IP, p *net.IP) *ipValue {
+func NewIPValue(val net.IP, p *net.IP) *IPValue {
 	*p = val
-	return (*ipValue)(p)
+	return (*IPValue)(p)
 }
 
-func (i *ipValue) String() string { return net.IP(*i).String() }
-func (i *ipValue) Set(s string) error {
+func (i *IPValue) String() string { return net.IP(*i).String() }
+func (i *IPValue) Set(s string) error {
 	if s == "" {
 		return nil
 	}
@@ -23,11 +23,11 @@ func (i *ipValue) Set(s string) error {
 	if ip == nil {
 		return fmt.Errorf("failed to parse IP: %q", s)
 	}
-	*i = ipValue(ip)
+	*i = IPValue(ip)
 	return nil
 }
 
-func (i *ipValue) Type() string {
+func (i *IPValue) Type() string {
 	return "ip"
 }
 
@@ -51,23 +51,23 @@ func (f *FlagSet) GetIP(name string) (net.IP, error) {
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
 func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string) {
-	f.VarP(newIPValue(value, p), name, "", usage)
+	f.VarP(NewIPValue(value, p), name, "", usage)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
-	f.VarP(newIPValue(value, p), name, shorthand, usage)
+	f.VarP(NewIPValue(value, p), name, shorthand, usage)
 }
 
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
 func IPVar(p *net.IP, name string, value net.IP, usage string) {
-	CommandLine.VarP(newIPValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIPValue(value, p), name, "", usage)
 }
 
 // IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
 func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
-	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIPValue(value, p), name, shorthand, usage)
 }
 
 // IP defines an net.IP flag with specified name, default value, and usage string.

--- a/ip_slice.go
+++ b/ip_slice.go
@@ -8,13 +8,13 @@ import (
 )
 
 // -- ipSlice Value
-type ipSliceValue struct {
+type IPSliceValue struct {
 	value   *[]net.IP
 	changed bool
 }
 
-func newIPSliceValue(val []net.IP, p *[]net.IP) *ipSliceValue {
-	ipsv := new(ipSliceValue)
+func NewIPSliceValue(val []net.IP, p *[]net.IP) *IPSliceValue {
+	ipsv := new(IPSliceValue)
 	ipsv.value = p
 	*ipsv.value = val
 	return ipsv
@@ -22,7 +22,7 @@ func newIPSliceValue(val []net.IP, p *[]net.IP) *ipSliceValue {
 
 // Set converts, and assigns, the comma-separated IP argument string representation as the []net.IP value of this flag.
 // If Set is called on a flag that already has a []net.IP assigned, the newly converted values will be appended.
-func (s *ipSliceValue) Set(val string) error {
+func (s *IPSliceValue) Set(val string) error {
 
 	// remove all quote characters
 	rmQuote := strings.NewReplacer(`"`, "", `'`, "", "`", "")
@@ -55,12 +55,12 @@ func (s *ipSliceValue) Set(val string) error {
 }
 
 // Type returns a string that uniquely represents this flag's type.
-func (s *ipSliceValue) Type() string {
+func (s *IPSliceValue) Type() string {
 	return "ipSlice"
 }
 
 // String defines a "native" format for this net.IP slice flag value.
-func (s *ipSliceValue) String() string {
+func (s *IPSliceValue) String() string {
 
 	ipStrSlice := make([]string, len(*s.value))
 	for i, ip := range *s.value {
@@ -72,15 +72,15 @@ func (s *ipSliceValue) String() string {
 	return "[" + out + "]"
 }
 
-func (s *ipSliceValue) fromString(val string) (net.IP, error) {
+func (s *IPSliceValue) fromString(val string) (net.IP, error) {
 	return net.ParseIP(strings.TrimSpace(val)), nil
 }
 
-func (s *ipSliceValue) toString(val net.IP) string {
+func (s *IPSliceValue) toString(val net.IP) string {
 	return val.String()
 }
 
-func (s *ipSliceValue) Append(val string) error {
+func (s *IPSliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ func (s *ipSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *ipSliceValue) Replace(val []string) error {
+func (s *IPSliceValue) Replace(val []string) error {
 	out := make([]net.IP, len(val))
 	for i, d := range val {
 		var err error
@@ -102,7 +102,7 @@ func (s *ipSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *ipSliceValue) GetSlice() []string {
+func (s *IPSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)
@@ -140,23 +140,23 @@ func (f *FlagSet) GetIPSlice(name string) ([]net.IP, error) {
 // IPSliceVar defines a ipSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
 func (f *FlagSet) IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string) {
-	f.VarP(newIPSliceValue(value, p), name, "", usage)
+	f.VarP(NewIPSliceValue(value, p), name, "", usage)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string) {
-	f.VarP(newIPSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewIPSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPSliceVar defines a []net.IP flag with specified name, default value, and usage string.
 // The argument p points to a []net.IP variable in which to store the value of the flag.
 func IPSliceVar(p *[]net.IP, name string, value []net.IP, usage string) {
-	CommandLine.VarP(newIPSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIPSliceValue(value, p), name, "", usage)
 }
 
 // IPSliceVarP is like IPSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func IPSliceVarP(p *[]net.IP, name, shorthand string, value []net.IP, usage string) {
-	CommandLine.VarP(newIPSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIPSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPSlice defines a []net.IP flag with specified name, default value, and usage string.

--- a/ipmask.go
+++ b/ipmask.go
@@ -7,24 +7,24 @@ import (
 )
 
 // -- net.IPMask value
-type ipMaskValue net.IPMask
+type IPMaskValue net.IPMask
 
-func newIPMaskValue(val net.IPMask, p *net.IPMask) *ipMaskValue {
+func NewIPMaskValue(val net.IPMask, p *net.IPMask) *IPMaskValue {
 	*p = val
-	return (*ipMaskValue)(p)
+	return (*IPMaskValue)(p)
 }
 
-func (i *ipMaskValue) String() string { return net.IPMask(*i).String() }
-func (i *ipMaskValue) Set(s string) error {
+func (i *IPMaskValue) String() string { return net.IPMask(*i).String() }
+func (i *IPMaskValue) Set(s string) error {
 	ip := ParseIPv4Mask(s)
 	if ip == nil {
 		return fmt.Errorf("failed to parse IP mask: %q", s)
 	}
-	*i = ipMaskValue(ip)
+	*i = IPMaskValue(ip)
 	return nil
 }
 
-func (i *ipMaskValue) Type() string {
+func (i *IPMaskValue) Type() string {
 	return "ipMask"
 }
 
@@ -76,23 +76,23 @@ func (f *FlagSet) GetIPv4Mask(name string) (net.IPMask, error) {
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
 func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
-	f.VarP(newIPMaskValue(value, p), name, "", usage)
+	f.VarP(NewIPMaskValue(value, p), name, "", usage)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
-	f.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+	f.VarP(NewIPMaskValue(value, p), name, shorthand, usage)
 }
 
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
 func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
-	CommandLine.VarP(newIPMaskValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIPMaskValue(value, p), name, "", usage)
 }
 
 // IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
 func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
-	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIPMaskValue(value, p), name, shorthand, usage)
 }
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.

--- a/ipnet.go
+++ b/ipnet.go
@@ -7,29 +7,29 @@ import (
 )
 
 // IPNet adapts net.IPNet for use as a flag.
-type ipNetValue net.IPNet
+type IPNetValue net.IPNet
 
-func (ipnet ipNetValue) String() string {
+func (ipnet IPNetValue) String() string {
 	n := net.IPNet(ipnet)
 	return n.String()
 }
 
-func (ipnet *ipNetValue) Set(value string) error {
+func (ipnet *IPNetValue) Set(value string) error {
 	_, n, err := net.ParseCIDR(strings.TrimSpace(value))
 	if err != nil {
 		return err
 	}
-	*ipnet = ipNetValue(*n)
+	*ipnet = IPNetValue(*n)
 	return nil
 }
 
-func (*ipNetValue) Type() string {
+func (*IPNetValue) Type() string {
 	return "ipNet"
 }
 
-func newIPNetValue(val net.IPNet, p *net.IPNet) *ipNetValue {
+func NewIPNetValue(val net.IPNet, p *net.IPNet) *IPNetValue {
 	*p = val
-	return (*ipNetValue)(p)
+	return (*IPNetValue)(p)
 }
 
 func ipNetConv(sval string) (interface{}, error) {
@@ -52,23 +52,23 @@ func (f *FlagSet) GetIPNet(name string) (net.IPNet, error) {
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
 func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
-	f.VarP(newIPNetValue(value, p), name, "", usage)
+	f.VarP(NewIPNetValue(value, p), name, "", usage)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
-	f.VarP(newIPNetValue(value, p), name, shorthand, usage)
+	f.VarP(NewIPNetValue(value, p), name, shorthand, usage)
 }
 
 // IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to an net.IPNet variable in which to store the value of the flag.
 func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIPNetValue(value, p), name, "", usage)
 }
 
 // IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
 func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIPNetValue(value, p), name, shorthand, usage)
 }
 
 // IPNet defines an net.IPNet flag with specified name, default value, and usage string.

--- a/ipnet_slice.go
+++ b/ipnet_slice.go
@@ -8,13 +8,13 @@ import (
 )
 
 // -- ipNetSlice Value
-type ipNetSliceValue struct {
+type IPNetSliceValue struct {
 	value   *[]net.IPNet
 	changed bool
 }
 
-func newIPNetSliceValue(val []net.IPNet, p *[]net.IPNet) *ipNetSliceValue {
-	ipnsv := new(ipNetSliceValue)
+func NewIPNetSliceValue(val []net.IPNet, p *[]net.IPNet) *IPNetSliceValue {
+	ipnsv := new(IPNetSliceValue)
 	ipnsv.value = p
 	*ipnsv.value = val
 	return ipnsv
@@ -22,7 +22,7 @@ func newIPNetSliceValue(val []net.IPNet, p *[]net.IPNet) *ipNetSliceValue {
 
 // Set converts, and assigns, the comma-separated IPNet argument string representation as the []net.IPNet value of this flag.
 // If Set is called on a flag that already has a []net.IPNet assigned, the newly converted values will be appended.
-func (s *ipNetSliceValue) Set(val string) error {
+func (s *IPNetSliceValue) Set(val string) error {
 
 	// remove all quote characters
 	rmQuote := strings.NewReplacer(`"`, "", `'`, "", "`", "")
@@ -55,12 +55,12 @@ func (s *ipNetSliceValue) Set(val string) error {
 }
 
 // Type returns a string that uniquely represents this flag's type.
-func (s *ipNetSliceValue) Type() string {
+func (s *IPNetSliceValue) Type() string {
 	return "ipNetSlice"
 }
 
 // String defines a "native" format for this net.IPNet slice flag value.
-func (s *ipNetSliceValue) String() string {
+func (s *IPNetSliceValue) String() string {
 
 	ipNetStrSlice := make([]string, len(*s.value))
 	for i, n := range *s.value {
@@ -101,23 +101,23 @@ func (f *FlagSet) GetIPNetSlice(name string) ([]net.IPNet, error) {
 // IPNetSliceVar defines a ipNetSlice flag with specified name, default value, and usage string.
 // The argument p points to a []net.IPNet variable in which to store the value of the flag.
 func (f *FlagSet) IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string) {
-	f.VarP(newIPNetSliceValue(value, p), name, "", usage)
+	f.VarP(NewIPNetSliceValue(value, p), name, "", usage)
 }
 
 // IPNetSliceVarP is like IPNetSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string) {
-	f.VarP(newIPNetSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewIPNetSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPNetSliceVar defines a []net.IPNet flag with specified name, default value, and usage string.
 // The argument p points to a []net.IPNet variable in which to store the value of the flag.
 func IPNetSliceVar(p *[]net.IPNet, name string, value []net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewIPNetSliceValue(value, p), name, "", usage)
 }
 
 // IPNetSliceVarP is like IPNetSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func IPNetSliceVarP(p *[]net.IPNet, name, shorthand string, value []net.IPNet, usage string) {
-	CommandLine.VarP(newIPNetSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewIPNetSliceValue(value, p), name, shorthand, usage)
 }
 
 // IPNetSlice defines a []net.IPNet flag with specified name, default value, and usage string.

--- a/string.go
+++ b/string.go
@@ -1,22 +1,22 @@
 package pflag
 
 // -- string Value
-type stringValue string
+type StringValue string
 
-func newStringValue(val string, p *string) *stringValue {
+func NewStringValue(val string, p *string) *StringValue {
 	*p = val
-	return (*stringValue)(p)
+	return (*StringValue)(p)
 }
 
-func (s *stringValue) Set(val string) error {
-	*s = stringValue(val)
+func (s *StringValue) Set(val string) error {
+	*s = StringValue(val)
 	return nil
 }
-func (s *stringValue) Type() string {
+func (s *StringValue) Type() string {
 	return "string"
 }
 
-func (s *stringValue) String() string { return string(*s) }
+func (s *StringValue) String() string { return string(*s) }
 
 func stringConv(sval string) (interface{}, error) {
 	return sval, nil
@@ -34,23 +34,23 @@ func (f *FlagSet) GetString(name string) (string, error) {
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
 func (f *FlagSet) StringVar(p *string, name string, value string, usage string) {
-	f.VarP(newStringValue(value, p), name, "", usage)
+	f.VarP(NewStringValue(value, p), name, "", usage)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string) {
-	f.VarP(newStringValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringValue(value, p), name, shorthand, usage)
 }
 
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
 func StringVar(p *string, name string, value string, usage string) {
-	CommandLine.VarP(newStringValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringValue(value, p), name, "", usage)
 }
 
 // StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
 func StringVarP(p *string, name, shorthand string, value string, usage string) {
-	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringValue(value, p), name, shorthand, usage)
 }
 
 // String defines a string flag with specified name, default value, and usage string.

--- a/string_array.go
+++ b/string_array.go
@@ -1,19 +1,19 @@
 package pflag
 
 // -- stringArray Value
-type stringArrayValue struct {
+type StringArrayValue struct {
 	value   *[]string
 	changed bool
 }
 
-func newStringArrayValue(val []string, p *[]string) *stringArrayValue {
-	ssv := new(stringArrayValue)
+func NewStringArrayValue(val []string, p *[]string) *StringArrayValue {
+	ssv := new(StringArrayValue)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
 }
 
-func (s *stringArrayValue) Set(val string) error {
+func (s *StringArrayValue) Set(val string) error {
 	if !s.changed {
 		*s.value = []string{val}
 		s.changed = true
@@ -23,12 +23,12 @@ func (s *stringArrayValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringArrayValue) Append(val string) error {
+func (s *StringArrayValue) Append(val string) error {
 	*s.value = append(*s.value, val)
 	return nil
 }
 
-func (s *stringArrayValue) Replace(val []string) error {
+func (s *StringArrayValue) Replace(val []string) error {
 	out := make([]string, len(val))
 	for i, d := range val {
 		out[i] = d
@@ -37,7 +37,7 @@ func (s *stringArrayValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *stringArrayValue) GetSlice() []string {
+func (s *StringArrayValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = d
@@ -45,11 +45,11 @@ func (s *stringArrayValue) GetSlice() []string {
 	return out
 }
 
-func (s *stringArrayValue) Type() string {
+func (s *StringArrayValue) Type() string {
 	return "stringArray"
 }
 
-func (s *stringArrayValue) String() string {
+func (s *StringArrayValue) String() string {
 	str, _ := writeAsCSV(*s.value)
 	return "[" + str + "]"
 }
@@ -76,24 +76,24 @@ func (f *FlagSet) GetStringArray(name string) ([]string, error) {
 // The argument p points to a []string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string) {
-	f.VarP(newStringArrayValue(value, p), name, "", usage)
+	f.VarP(NewStringArrayValue(value, p), name, "", usage)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	f.VarP(newStringArrayValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringArrayValue(value, p), name, shorthand, usage)
 }
 
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func StringArrayVar(p *[]string, name string, value []string, usage string) {
-	CommandLine.VarP(newStringArrayValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringArrayValue(value, p), name, "", usage)
 }
 
 // StringArrayVarP is like StringArrayVar, but accepts a shorthand letter that can be used after a single dash.
 func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	CommandLine.VarP(newStringArrayValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringArrayValue(value, p), name, shorthand, usage)
 }
 
 // StringArray defines a string flag with specified name, default value, and usage string.

--- a/string_slice.go
+++ b/string_slice.go
@@ -7,13 +7,13 @@ import (
 )
 
 // -- stringSlice Value
-type stringSliceValue struct {
+type StringSliceValue struct {
 	value   *[]string
 	changed bool
 }
 
-func newStringSliceValue(val []string, p *[]string) *stringSliceValue {
-	ssv := new(stringSliceValue)
+func NewStringSliceValue(val []string, p *[]string) *StringSliceValue {
+	ssv := new(StringSliceValue)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
@@ -39,7 +39,7 @@ func writeAsCSV(vals []string) (string, error) {
 	return strings.TrimSuffix(b.String(), "\n"), nil
 }
 
-func (s *stringSliceValue) Set(val string) error {
+func (s *StringSliceValue) Set(val string) error {
 	v, err := readAsCSV(val)
 	if err != nil {
 		return err
@@ -53,26 +53,26 @@ func (s *stringSliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringSliceValue) Type() string {
+func (s *StringSliceValue) Type() string {
 	return "stringSlice"
 }
 
-func (s *stringSliceValue) String() string {
+func (s *StringSliceValue) String() string {
 	str, _ := writeAsCSV(*s.value)
 	return "[" + str + "]"
 }
 
-func (s *stringSliceValue) Append(val string) error {
+func (s *StringSliceValue) Append(val string) error {
 	*s.value = append(*s.value, val)
 	return nil
 }
 
-func (s *stringSliceValue) Replace(val []string) error {
+func (s *StringSliceValue) Replace(val []string) error {
 	*s.value = val
 	return nil
 }
 
-func (s *stringSliceValue) GetSlice() []string {
+func (s *StringSliceValue) GetSlice() []string {
 	return *s.value
 }
 
@@ -98,41 +98,50 @@ func (f *FlagSet) GetStringSlice(name string) ([]string, error) {
 // The argument p points to a []string variable in which to store the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
 // For example:
-//   --ss="v1,v2" --ss="v3"
+//
+//	--ss="v1,v2" --ss="v3"
+//
 // will result in
-//   []string{"v1", "v2", "v3"}
+//
+//	[]string{"v1", "v2", "v3"}
 func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string) {
-	f.VarP(newStringSliceValue(value, p), name, "", usage)
+	f.VarP(NewStringSliceValue(value, p), name, "", usage)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	f.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringSliceValue(value, p), name, shorthand, usage)
 }
 
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
 // For example:
-//   --ss="v1,v2" --ss="v3"
+//
+//	--ss="v1,v2" --ss="v3"
+//
 // will result in
-//   []string{"v1", "v2", "v3"}
+//
+//	[]string{"v1", "v2", "v3"}
 func StringSliceVar(p *[]string, name string, value []string, usage string) {
-	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringSliceValue(value, p), name, "", usage)
 }
 
 // StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
-	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringSliceValue(value, p), name, shorthand, usage)
 }
 
 // StringSlice defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
 // For example:
-//   --ss="v1,v2" --ss="v3"
+//
+//	--ss="v1,v2" --ss="v3"
+//
 // will result in
-//   []string{"v1", "v2", "v3"}
+//
+//	[]string{"v1", "v2", "v3"}
 func (f *FlagSet) StringSlice(name string, value []string, usage string) *[]string {
 	p := []string{}
 	f.StringSliceVarP(&p, name, "", value, usage)
@@ -150,9 +159,12 @@ func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage str
 // The return value is the address of a []string variable that stores the value of the flag.
 // Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
 // For example:
-//   --ss="v1,v2" --ss="v3"
+//
+//	--ss="v1,v2" --ss="v3"
+//
 // will result in
-//   []string{"v1", "v2", "v3"}
+//
+//	[]string{"v1", "v2", "v3"}
 func StringSlice(name string, value []string, usage string) *[]string {
 	return CommandLine.StringSliceP(name, "", value, usage)
 }

--- a/string_to_int.go
+++ b/string_to_int.go
@@ -8,20 +8,20 @@ import (
 )
 
 // -- stringToInt Value
-type stringToIntValue struct {
+type StringToIntValue struct {
 	value   *map[string]int
 	changed bool
 }
 
-func newStringToIntValue(val map[string]int, p *map[string]int) *stringToIntValue {
-	ssv := new(stringToIntValue)
+func NewStringToIntValue(val map[string]int, p *map[string]int) *StringToIntValue {
+	ssv := new(StringToIntValue)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
 }
 
 // Format: a=1,b=2
-func (s *stringToIntValue) Set(val string) error {
+func (s *StringToIntValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make(map[string]int, len(ss))
 	for _, pair := range ss {
@@ -46,11 +46,11 @@ func (s *stringToIntValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringToIntValue) Type() string {
+func (s *StringToIntValue) Type() string {
 	return "stringToInt"
 }
 
-func (s *stringToIntValue) String() string {
+func (s *StringToIntValue) String() string {
 	var buf bytes.Buffer
 	i := 0
 	for k, v := range *s.value {
@@ -100,24 +100,24 @@ func (f *FlagSet) GetStringToInt(name string) (map[string]int, error) {
 // The argument p points to a map[string]int variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
 func (f *FlagSet) StringToIntVar(p *map[string]int, name string, value map[string]int, usage string) {
-	f.VarP(newStringToIntValue(value, p), name, "", usage)
+	f.VarP(NewStringToIntValue(value, p), name, "", usage)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string) {
-	f.VarP(newStringToIntValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringToIntValue(value, p), name, shorthand, usage)
 }
 
 // StringToIntVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]int variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
 func StringToIntVar(p *map[string]int, name string, value map[string]int, usage string) {
-	CommandLine.VarP(newStringToIntValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringToIntValue(value, p), name, "", usage)
 }
 
 // StringToIntVarP is like StringToIntVar, but accepts a shorthand letter that can be used after a single dash.
 func StringToIntVarP(p *map[string]int, name, shorthand string, value map[string]int, usage string) {
-	CommandLine.VarP(newStringToIntValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringToIntValue(value, p), name, shorthand, usage)
 }
 
 // StringToInt defines a string flag with specified name, default value, and usage string.

--- a/string_to_int64.go
+++ b/string_to_int64.go
@@ -8,20 +8,20 @@ import (
 )
 
 // -- stringToInt64 Value
-type stringToInt64Value struct {
+type StringToInt64Value struct {
 	value   *map[string]int64
 	changed bool
 }
 
-func newStringToInt64Value(val map[string]int64, p *map[string]int64) *stringToInt64Value {
-	ssv := new(stringToInt64Value)
+func NewStringToInt64Value(val map[string]int64, p *map[string]int64) *StringToInt64Value {
+	ssv := new(StringToInt64Value)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
 }
 
 // Format: a=1,b=2
-func (s *stringToInt64Value) Set(val string) error {
+func (s *StringToInt64Value) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make(map[string]int64, len(ss))
 	for _, pair := range ss {
@@ -46,11 +46,11 @@ func (s *stringToInt64Value) Set(val string) error {
 	return nil
 }
 
-func (s *stringToInt64Value) Type() string {
+func (s *StringToInt64Value) Type() string {
 	return "stringToInt64"
 }
 
-func (s *stringToInt64Value) String() string {
+func (s *StringToInt64Value) String() string {
 	var buf bytes.Buffer
 	i := 0
 	for k, v := range *s.value {
@@ -100,24 +100,24 @@ func (f *FlagSet) GetStringToInt64(name string) (map[string]int64, error) {
 // The argument p point64s to a map[string]int64 variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
 func (f *FlagSet) StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string) {
-	f.VarP(newStringToInt64Value(value, p), name, "", usage)
+	f.VarP(NewStringToInt64Value(value, p), name, "", usage)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string) {
-	f.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
+	f.VarP(NewStringToInt64Value(value, p), name, shorthand, usage)
 }
 
 // StringToInt64Var defines a string flag with specified name, default value, and usage string.
 // The argument p point64s to a map[string]int64 variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
 func StringToInt64Var(p *map[string]int64, name string, value map[string]int64, usage string) {
-	CommandLine.VarP(newStringToInt64Value(value, p), name, "", usage)
+	CommandLine.VarP(NewStringToInt64Value(value, p), name, "", usage)
 }
 
 // StringToInt64VarP is like StringToInt64Var, but accepts a shorthand letter that can be used after a single dash.
 func StringToInt64VarP(p *map[string]int64, name, shorthand string, value map[string]int64, usage string) {
-	CommandLine.VarP(newStringToInt64Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringToInt64Value(value, p), name, shorthand, usage)
 }
 
 // StringToInt64 defines a string flag with specified name, default value, and usage string.

--- a/string_to_string.go
+++ b/string_to_string.go
@@ -8,20 +8,20 @@ import (
 )
 
 // -- stringToString Value
-type stringToStringValue struct {
+type StringToStringValue struct {
 	value   *map[string]string
 	changed bool
 }
 
-func newStringToStringValue(val map[string]string, p *map[string]string) *stringToStringValue {
-	ssv := new(stringToStringValue)
+func NewStringToStringValue(val map[string]string, p *map[string]string) *StringToStringValue {
+	ssv := new(StringToStringValue)
 	ssv.value = p
 	*ssv.value = val
 	return ssv
 }
 
 // Format: a=1,b=2
-func (s *stringToStringValue) Set(val string) error {
+func (s *StringToStringValue) Set(val string) error {
 	var ss []string
 	n := strings.Count(val, "=")
 	switch n {
@@ -57,11 +57,11 @@ func (s *stringToStringValue) Set(val string) error {
 	return nil
 }
 
-func (s *stringToStringValue) Type() string {
+func (s *StringToStringValue) Type() string {
 	return "stringToString"
 }
 
-func (s *stringToStringValue) String() string {
+func (s *StringToStringValue) String() string {
 	records := make([]string, 0, len(*s.value)>>1)
 	for k, v := range *s.value {
 		records = append(records, k+"="+v)
@@ -111,24 +111,24 @@ func (f *FlagSet) GetStringToString(name string) (map[string]string, error) {
 // The argument p points to a map[string]string variable in which to store the values of the multiple flags.
 // The value of each argument will not try to be separated by comma
 func (f *FlagSet) StringToStringVar(p *map[string]string, name string, value map[string]string, usage string) {
-	f.VarP(newStringToStringValue(value, p), name, "", usage)
+	f.VarP(NewStringToStringValue(value, p), name, "", usage)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string) {
-	f.VarP(newStringToStringValue(value, p), name, shorthand, usage)
+	f.VarP(NewStringToStringValue(value, p), name, shorthand, usage)
 }
 
 // StringToStringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a map[string]string variable in which to store the value of the flag.
 // The value of each argument will not try to be separated by comma
 func StringToStringVar(p *map[string]string, name string, value map[string]string, usage string) {
-	CommandLine.VarP(newStringToStringValue(value, p), name, "", usage)
+	CommandLine.VarP(NewStringToStringValue(value, p), name, "", usage)
 }
 
 // StringToStringVarP is like StringToStringVar, but accepts a shorthand letter that can be used after a single dash.
 func StringToStringVarP(p *map[string]string, name, shorthand string, value map[string]string, usage string) {
-	CommandLine.VarP(newStringToStringValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewStringToStringValue(value, p), name, shorthand, usage)
 }
 
 // StringToString defines a string flag with specified name, default value, and usage string.

--- a/text.go
+++ b/text.go
@@ -7,9 +7,9 @@ import (
 )
 
 // following is copied from go 1.23.4 flag.go
-type textValue struct{ p encoding.TextUnmarshaler }
+type TextValue struct{ p encoding.TextUnmarshaler }
 
-func newTextValue(val encoding.TextMarshaler, p encoding.TextUnmarshaler) textValue {
+func NewTextValue(val encoding.TextMarshaler, p encoding.TextUnmarshaler) TextValue {
 	ptrVal := reflect.ValueOf(p)
 	if ptrVal.Kind() != reflect.Ptr {
 		panic("variable value type must be a pointer")
@@ -22,18 +22,18 @@ func newTextValue(val encoding.TextMarshaler, p encoding.TextUnmarshaler) textVa
 		panic(fmt.Sprintf("default type does not match variable type: %v != %v", defVal.Type(), ptrVal.Type().Elem()))
 	}
 	ptrVal.Elem().Set(defVal)
-	return textValue{p}
+	return TextValue{p}
 }
 
-func (v textValue) Set(s string) error {
+func (v TextValue) Set(s string) error {
 	return v.p.UnmarshalText([]byte(s))
 }
 
-func (v textValue) Get() interface{} {
+func (v TextValue) Get() interface{} {
 	return v.p
 }
 
-func (v textValue) String() string {
+func (v TextValue) String() string {
 	if m, ok := v.p.(encoding.TextMarshaler); ok {
 		if b, err := m.MarshalText(); err == nil {
 			return string(b)
@@ -44,7 +44,7 @@ func (v textValue) String() string {
 
 //end of copy
 
-func (v textValue) Type() string {
+func (v TextValue) Type() string {
 	return reflect.ValueOf(v.p).Type().Name()
 }
 
@@ -62,20 +62,20 @@ func (f *FlagSet) GetText(name string, out encoding.TextUnmarshaler) error {
 
 // TextVar defines a flag with a specified name, default value, and usage string. The argument p must be a pointer to a variable that will hold the value of the flag, and p must implement encoding.TextUnmarshaler. If the flag is used, the flag value will be passed to p's UnmarshalText method. The type of the default value must be the same as the type of p.
 func (f *FlagSet) TextVar(p encoding.TextUnmarshaler, name string, value encoding.TextMarshaler, usage string) {
-	f.VarP(newTextValue(value, p), name, "", usage)
+	f.VarP(NewTextValue(value, p), name, "", usage)
 }
 
 // TextVarP is like TextVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) TextVarP(p encoding.TextUnmarshaler, name, shorthand string, value encoding.TextMarshaler, usage string) {
-	f.VarP(newTextValue(value, p), name, shorthand, usage)
+	f.VarP(NewTextValue(value, p), name, shorthand, usage)
 }
 
 // TextVar defines a flag with a specified name, default value, and usage string. The argument p must be a pointer to a variable that will hold the value of the flag, and p must implement encoding.TextUnmarshaler. If the flag is used, the flag value will be passed to p's UnmarshalText method. The type of the default value must be the same as the type of p.
 func TextVar(p encoding.TextUnmarshaler, name string, value encoding.TextMarshaler, usage string) {
-	CommandLine.VarP(newTextValue(value, p), name, "", usage)
+	CommandLine.VarP(NewTextValue(value, p), name, "", usage)
 }
 
 // TextVarP is like TextVar, but accepts a shorthand letter that can be used after a single dash.
 func TextVarP(p encoding.TextUnmarshaler, name, shorthand string, value encoding.TextMarshaler, usage string) {
-	CommandLine.VarP(newTextValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewTextValue(value, p), name, shorthand, usage)
 }

--- a/uint.go
+++ b/uint.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- uint Value
-type uintValue uint
+type UintValue uint
 
-func newUintValue(val uint, p *uint) *uintValue {
+func NewUintValue(val uint, p *uint) *UintValue {
 	*p = val
-	return (*uintValue)(p)
+	return (*UintValue)(p)
 }
 
-func (i *uintValue) Set(s string) error {
+func (i *UintValue) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 64)
-	*i = uintValue(v)
+	*i = UintValue(v)
 	return err
 }
 
-func (i *uintValue) Type() string {
+func (i *UintValue) Type() string {
 	return "uint"
 }
 
-func (i *uintValue) String() string { return strconv.FormatUint(uint64(*i), 10) }
+func (i *UintValue) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uintConv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 0)
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint(name string) (uint, error) {
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
 func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string) {
-	f.VarP(newUintValue(value, p), name, "", usage)
+	f.VarP(NewUintValue(value, p), name, "", usage)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string) {
-	f.VarP(newUintValue(value, p), name, shorthand, usage)
+	f.VarP(NewUintValue(value, p), name, shorthand, usage)
 }
 
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
 func UintVar(p *uint, name string, value uint, usage string) {
-	CommandLine.VarP(newUintValue(value, p), name, "", usage)
+	CommandLine.VarP(NewUintValue(value, p), name, "", usage)
 }
 
 // UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
 func UintVarP(p *uint, name, shorthand string, value uint, usage string) {
-	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUintValue(value, p), name, shorthand, usage)
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.

--- a/uint16.go
+++ b/uint16.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- uint16 value
-type uint16Value uint16
+type Uint16Value uint16
 
-func newUint16Value(val uint16, p *uint16) *uint16Value {
+func NewUint16Value(val uint16, p *uint16) *Uint16Value {
 	*p = val
-	return (*uint16Value)(p)
+	return (*Uint16Value)(p)
 }
 
-func (i *uint16Value) Set(s string) error {
+func (i *Uint16Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 16)
-	*i = uint16Value(v)
+	*i = Uint16Value(v)
 	return err
 }
 
-func (i *uint16Value) Type() string {
+func (i *Uint16Value) Type() string {
 	return "uint16"
 }
 
-func (i *uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
+func (i *Uint16Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint16Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 16)
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint16(name string) (uint16, error) {
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint variable in which to store the value of the flag.
 func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string) {
-	f.VarP(newUint16Value(value, p), name, "", usage)
+	f.VarP(NewUint16Value(value, p), name, "", usage)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
-	f.VarP(newUint16Value(value, p), name, shorthand, usage)
+	f.VarP(NewUint16Value(value, p), name, shorthand, usage)
 }
 
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
 func Uint16Var(p *uint16, name string, value uint16, usage string) {
-	CommandLine.VarP(newUint16Value(value, p), name, "", usage)
+	CommandLine.VarP(NewUint16Value(value, p), name, "", usage)
 }
 
 // Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
-	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUint16Value(value, p), name, shorthand, usage)
 }
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.

--- a/uint32.go
+++ b/uint32.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- uint32 value
-type uint32Value uint32
+type Uint32Value uint32
 
-func newUint32Value(val uint32, p *uint32) *uint32Value {
+func NewUint32Value(val uint32, p *uint32) *Uint32Value {
 	*p = val
-	return (*uint32Value)(p)
+	return (*Uint32Value)(p)
 }
 
-func (i *uint32Value) Set(s string) error {
+func (i *Uint32Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 32)
-	*i = uint32Value(v)
+	*i = Uint32Value(v)
 	return err
 }
 
-func (i *uint32Value) Type() string {
+func (i *Uint32Value) Type() string {
 	return "uint32"
 }
 
-func (i *uint32Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
+func (i *Uint32Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint32Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 32)
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint32(name string) (uint32, error) {
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32 variable in which to store the value of the flag.
 func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string) {
-	f.VarP(newUint32Value(value, p), name, "", usage)
+	f.VarP(NewUint32Value(value, p), name, "", usage)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
-	f.VarP(newUint32Value(value, p), name, shorthand, usage)
+	f.VarP(NewUint32Value(value, p), name, shorthand, usage)
 }
 
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32  variable in which to store the value of the flag.
 func Uint32Var(p *uint32, name string, value uint32, usage string) {
-	CommandLine.VarP(newUint32Value(value, p), name, "", usage)
+	CommandLine.VarP(NewUint32Value(value, p), name, "", usage)
 }
 
 // Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
-	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUint32Value(value, p), name, shorthand, usage)
 }
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.

--- a/uint64.go
+++ b/uint64.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- uint64 Value
-type uint64Value uint64
+type Uint64Value uint64
 
-func newUint64Value(val uint64, p *uint64) *uint64Value {
+func NewUint64Value(val uint64, p *uint64) *Uint64Value {
 	*p = val
-	return (*uint64Value)(p)
+	return (*Uint64Value)(p)
 }
 
-func (i *uint64Value) Set(s string) error {
+func (i *Uint64Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 64)
-	*i = uint64Value(v)
+	*i = Uint64Value(v)
 	return err
 }
 
-func (i *uint64Value) Type() string {
+func (i *Uint64Value) Type() string {
 	return "uint64"
 }
 
-func (i *uint64Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
+func (i *Uint64Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint64Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 64)
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint64(name string) (uint64, error) {
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
 func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string) {
-	f.VarP(newUint64Value(value, p), name, "", usage)
+	f.VarP(NewUint64Value(value, p), name, "", usage)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
-	f.VarP(newUint64Value(value, p), name, shorthand, usage)
+	f.VarP(NewUint64Value(value, p), name, shorthand, usage)
 }
 
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
 func Uint64Var(p *uint64, name string, value uint64, usage string) {
-	CommandLine.VarP(newUint64Value(value, p), name, "", usage)
+	CommandLine.VarP(NewUint64Value(value, p), name, "", usage)
 }
 
 // Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
-	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUint64Value(value, p), name, shorthand, usage)
 }
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.

--- a/uint8.go
+++ b/uint8.go
@@ -3,24 +3,24 @@ package pflag
 import "strconv"
 
 // -- uint8 Value
-type uint8Value uint8
+type Uint8Value uint8
 
-func newUint8Value(val uint8, p *uint8) *uint8Value {
+func NewUint8Value(val uint8, p *uint8) *Uint8Value {
 	*p = val
-	return (*uint8Value)(p)
+	return (*Uint8Value)(p)
 }
 
-func (i *uint8Value) Set(s string) error {
+func (i *Uint8Value) Set(s string) error {
 	v, err := strconv.ParseUint(s, 0, 8)
-	*i = uint8Value(v)
+	*i = Uint8Value(v)
 	return err
 }
 
-func (i *uint8Value) Type() string {
+func (i *Uint8Value) Type() string {
 	return "uint8"
 }
 
-func (i *uint8Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
+func (i *Uint8Value) String() string { return strconv.FormatUint(uint64(*i), 10) }
 
 func uint8Conv(sval string) (interface{}, error) {
 	v, err := strconv.ParseUint(sval, 0, 8)
@@ -42,23 +42,23 @@ func (f *FlagSet) GetUint8(name string) (uint8, error) {
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
 func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string) {
-	f.VarP(newUint8Value(value, p), name, "", usage)
+	f.VarP(NewUint8Value(value, p), name, "", usage)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
-	f.VarP(newUint8Value(value, p), name, shorthand, usage)
+	f.VarP(NewUint8Value(value, p), name, shorthand, usage)
 }
 
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
 func Uint8Var(p *uint8, name string, value uint8, usage string) {
-	CommandLine.VarP(newUint8Value(value, p), name, "", usage)
+	CommandLine.VarP(NewUint8Value(value, p), name, "", usage)
 }
 
 // Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
-	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUint8Value(value, p), name, shorthand, usage)
 }
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.

--- a/uint_slice.go
+++ b/uint_slice.go
@@ -7,19 +7,19 @@ import (
 )
 
 // -- uintSlice Value
-type uintSliceValue struct {
+type UintSliceValue struct {
 	value   *[]uint
 	changed bool
 }
 
-func newUintSliceValue(val []uint, p *[]uint) *uintSliceValue {
-	uisv := new(uintSliceValue)
+func NewUintSliceValue(val []uint, p *[]uint) *UintSliceValue {
+	uisv := new(UintSliceValue)
 	uisv.value = p
 	*uisv.value = val
 	return uisv
 }
 
-func (s *uintSliceValue) Set(val string) error {
+func (s *UintSliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]uint, len(ss))
 	for i, d := range ss {
@@ -38,11 +38,11 @@ func (s *uintSliceValue) Set(val string) error {
 	return nil
 }
 
-func (s *uintSliceValue) Type() string {
+func (s *UintSliceValue) Type() string {
 	return "uintSlice"
 }
 
-func (s *uintSliceValue) String() string {
+func (s *UintSliceValue) String() string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = fmt.Sprintf("%d", d)
@@ -50,7 +50,7 @@ func (s *uintSliceValue) String() string {
 	return "[" + strings.Join(out, ",") + "]"
 }
 
-func (s *uintSliceValue) fromString(val string) (uint, error) {
+func (s *UintSliceValue) fromString(val string) (uint, error) {
 	t, err := strconv.ParseUint(val, 10, 0)
 	if err != nil {
 		return 0, err
@@ -58,11 +58,11 @@ func (s *uintSliceValue) fromString(val string) (uint, error) {
 	return uint(t), nil
 }
 
-func (s *uintSliceValue) toString(val uint) string {
+func (s *UintSliceValue) toString(val uint) string {
 	return fmt.Sprintf("%d", val)
 }
 
-func (s *uintSliceValue) Append(val string) error {
+func (s *UintSliceValue) Append(val string) error {
 	i, err := s.fromString(val)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func (s *uintSliceValue) Append(val string) error {
 	return nil
 }
 
-func (s *uintSliceValue) Replace(val []string) error {
+func (s *UintSliceValue) Replace(val []string) error {
 	out := make([]uint, len(val))
 	for i, d := range val {
 		var err error
@@ -84,7 +84,7 @@ func (s *uintSliceValue) Replace(val []string) error {
 	return nil
 }
 
-func (s *uintSliceValue) GetSlice() []string {
+func (s *UintSliceValue) GetSlice() []string {
 	out := make([]string, len(*s.value))
 	for i, d := range *s.value {
 		out[i] = s.toString(d)
@@ -122,23 +122,23 @@ func (f *FlagSet) GetUintSlice(name string) ([]uint, error) {
 // UintSliceVar defines a uintSlice flag with specified name, default value, and usage string.
 // The argument p points to a []uint variable in which to store the value of the flag.
 func (f *FlagSet) UintSliceVar(p *[]uint, name string, value []uint, usage string) {
-	f.VarP(newUintSliceValue(value, p), name, "", usage)
+	f.VarP(NewUintSliceValue(value, p), name, "", usage)
 }
 
 // UintSliceVarP is like UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string) {
-	f.VarP(newUintSliceValue(value, p), name, shorthand, usage)
+	f.VarP(NewUintSliceValue(value, p), name, shorthand, usage)
 }
 
 // UintSliceVar defines a uint[] flag with specified name, default value, and usage string.
 // The argument p points to a uint[] variable in which to store the value of the flag.
 func UintSliceVar(p *[]uint, name string, value []uint, usage string) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, "", usage)
+	CommandLine.VarP(NewUintSliceValue(value, p), name, "", usage)
 }
 
 // UintSliceVarP is like the UintSliceVar, but accepts a shorthand letter that can be used after a single dash.
 func UintSliceVarP(p *[]uint, name, shorthand string, value []uint, usage string) {
-	CommandLine.VarP(newUintSliceValue(value, p), name, shorthand, usage)
+	CommandLine.VarP(NewUintSliceValue(value, p), name, shorthand, usage)
 }
 
 // UintSlice defines a []uint flag with specified name, default value, and usage string.


### PR DESCRIPTION
This encourages reuse, making it possible for user to for example dynamically create a []*Flag and add them using (*Flagset) AddFlag.

Closes https://github.com/spf13/pflag/issues/334