### PR TITLE
Make Value a drop-in replacement for flag.Value

### DIFF
--- a/text.go
+++ b/text.go
@@ -54,8 +54,8 @@ func (f *FlagSet) GetText(name string, out encoding.TextUnmarshaler) error {
 	if flag == nil {
 		return fmt.Errorf("flag accessed but not defined: %s", name)
 	}
-	if flag.Value.Type() != reflect.TypeOf(out).Name() {
-		return fmt.Errorf("trying to get %s value of flag of type %s", reflect.TypeOf(out).Name(), flag.Value.Type())
+	if tvalue, ok := flag.Value.(TypedValue); ok && tvalue.Type() != reflect.TypeOf(out).Name() {
+		return fmt.Errorf("trying to get %s value of flag of type %s", reflect.TypeOf(out).Name(), tvalue.Type())
 	}
 	return out.UnmarshalText([]byte(flag.Value.String()))
 }

--- a/time.go
+++ b/time.go
@@ -58,8 +58,8 @@ func (f *FlagSet) GetTime(name string) (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	if flag.Value.Type() != "time" {
-		err := fmt.Errorf("trying to get %s value of flag of type %s", "time", flag.Value.Type())
+	if tvalue, ok := flag.Value.(TypedValue); ok && tvalue.Type() != "time" {
+		err := fmt.Errorf("trying to get %s value of flag of type %s", "time", tvalue.Type())
 		return time.Time{}, err
 	}
 


### PR DESCRIPTION
Fixes #228.

This should allow users to provide their own types implementing `flag.Value` also to `pflag`, as `pflag.Value` is now equivalent to the standard-library variant.

The `Type()` method is moved to a wrapper interface `TypedValue` and code relying on it must first test that the provided value implements this interface; this has been done in all code in `pflag` and tests are still passing, so I'm fairly confident that the changes are correct even if I haven't actually tried them out on a use case with a user-defined `Value` implementation (without `Type()`).
