### PR TITLE
Omit zero time.Time default from usage line

### DIFF
--- a/time.go
+++ b/time.go
@@ -48,7 +48,13 @@ func (d *timeValue) Type() string {
 	return "time"
 }
 
-func (d *timeValue) String() string { return d.Time.Format(time.RFC3339Nano) }
+func (d *timeValue) String() string {
+	if d.Time.IsZero() {
+		return ""
+	} else {
+		return d.Time.Format(time.RFC3339Nano)
+	}
+}
 
 // GetTime return the time value of a flag with the given name
 func (f *FlagSet) GetTime(name string) (time.Time, error) {


### PR DESCRIPTION
This was missed in #348, there previously was no way to omit the default value. Treating zero timestamp values as canary for absence of a default is in line with other flag types, e.g. zero ints.

Stand-alone test program:
```go
package main

import (
	"github.com/spf13/pflag"
	"time"
)

func main() {
	pflag.Time("time", time.Time{}, []string{time.RFC3339Nano, time.RFC3339}, "test")
	pflag.Parse()
	pflag.Usage()
}
```

Before this change:
```text
Usage of pflagtest:
      --time time   test (default 0001-01-01T00:00:00Z)
```

After:
```text
Usage of pflagtest:
      --time time   test
```