### PR TITLE
fix: Don't print ErrHelp in ParseAll

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -1202,6 +1202,9 @@ func (f *FlagSet) ParseAll(arguments []string, fn func(flag *Flag, value string)
 		case ContinueOnError:
 			return err
 		case ExitOnError:
+			if err == ErrHelp {
+				os.Exit(0)
+			}
 			fmt.Fprintln(f.Output(), err)
 			os.Exit(2)
 		case PanicOnError:

--- a/flag.go
+++ b/flag.go
@@ -1173,7 +1173,7 @@ func (f *FlagSet) Parse(arguments []string) error {
 		case ContinueOnError:
 			return err
 		case ExitOnError:
-			if err == ErrHelp {
+			if errors.Is(err, ErrHelp) {
 				os.Exit(0)
 			}
 			fmt.Fprintln(f.Output(), err)
@@ -1202,7 +1202,7 @@ func (f *FlagSet) ParseAll(arguments []string, fn func(flag *Flag, value string)
 		case ContinueOnError:
 			return err
 		case ExitOnError:
-			if err == ErrHelp {
+			if errors.Is(err, ErrHelp) {
 				os.Exit(0)
 			}
 			fmt.Fprintln(f.Output(), err)


### PR DESCRIPTION
This is a fixup of #407 to ensure behavior of ExitOnError is consistent.
