### PR TITLE
Reset args on re-parse even if empty

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -1157,11 +1157,11 @@ func (f *FlagSet) Parse(arguments []string) error {
 	}
 	f.parsed = true
 
+	f.args = make([]string, 0, len(arguments))
+
 	if len(arguments) == 0 {
 		return nil
 	}
-
-	f.args = make([]string, 0, len(arguments))
 
 	set := func(flag *Flag, value string) error {
 		return f.Set(flag.Name, value)

--- a/flag_test.go
+++ b/flag_test.go
@@ -656,6 +656,46 @@ func TestFlagSetParse(t *testing.T) {
 	testParse(NewFlagSet("test", ContinueOnError), t)
 }
 
+func TestParseRepeated(t *testing.T) {
+	fs := NewFlagSet("test repeated", ContinueOnError)
+
+	t.Run("first parse", func(t *testing.T) {
+		err := fs.Parse([]string{"foo", "bar"})
+		if err != nil {
+			t.Fatal("expected no error, got ", err)
+		}
+
+		argsAfterFirst := fs.Args()
+		if !reflect.DeepEqual(argsAfterFirst, []string{"foo", "bar"}) {
+			t.Fatalf("expected args [foo bar], got %v", argsAfterFirst)
+		}
+	})
+
+	t.Run("re-parse with fewer args", func(t *testing.T) {
+		err := fs.Parse([]string{"baz"})
+		if err != nil {
+			t.Fatal("expected no error, got ", err)
+		}
+
+		argsAfterSecond := fs.Args()
+		if !reflect.DeepEqual(argsAfterSecond, []string{"baz"}) {
+			t.Fatalf("expected args [baz], got %v", argsAfterSecond)
+		}
+	})
+
+	t.Run("re-parse with no args", func(t *testing.T) {
+		err := fs.Parse([]string{})
+		if err != nil {
+			t.Fatal("expected no error, got ", err)
+		}
+
+		argsAfterThird := fs.Args()
+		if !reflect.DeepEqual(argsAfterThird, []string{}) {
+			t.Fatalf("expected args [], got %v", argsAfterThird)
+		}
+	})
+}
+
 func TestChangedHelper(t *testing.T) {
 	f := NewFlagSet("changedtest", ContinueOnError)
 	f.Bool("changed", false, "changed bool")


### PR DESCRIPTION
This ensures fs.Args() returns the expected thing after every parse.

Fixes #439.
