### PR TITLE
fix: Restore ParseErrorsWhitelist name for now

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -143,6 +143,10 @@ type ParseErrorsAllowlist struct {
 	UnknownFlags bool
 }
 
+// DEPRECATED: please use ParseErrorsAllowlist instead
+// This type will be removed in a future release
+type ParseErrorsWhitelist = ParseErrorsAllowlist
+
 // NormalizedName is a flag name that has been normalized according to rules
 // for the FlagSet (e.g. making '-' and '_' equivalent).
 type NormalizedName string
@@ -160,6 +164,10 @@ type FlagSet struct {
 
 	// ParseErrorsAllowlist is used to configure an allowlist of errors
 	ParseErrorsAllowlist ParseErrorsAllowlist
+
+	// DEPRECATED: please use ParseErrorsAllowlist instead
+	// This field will be removed in a future release
+	ParseErrorsWhitelist ParseErrorsAllowlist
 
 	name              string
 	parsed            bool
@@ -984,6 +992,8 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 		case name == "help":
 			f.usage()
 			return a, ErrHelp
+		case f.ParseErrorsWhitelist.UnknownFlags:
+			fallthrough
 		case f.ParseErrorsAllowlist.UnknownFlags:
 			// --unknown=unknownval arg ...
 			// we do not want to lose arg in this case
@@ -1042,6 +1052,8 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 			f.usage()
 			err = ErrHelp
 			return
+		case f.ParseErrorsWhitelist.UnknownFlags:
+			fallthrough
 		case f.ParseErrorsAllowlist.UnknownFlags:
 			// '-f=arg arg ...'
 			// we do not want to lose arg in this case

--- a/flag_test.go
+++ b/flag_test.go
@@ -447,11 +447,11 @@ func testParseAll(f *FlagSet, t *testing.T) {
 	}
 }
 
-func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
+func testParseWithUnknownFlags(f *FlagSet, t *testing.T, setUnknownFlags func(f *FlagSet)) {
 	if f.Parsed() {
 		t.Error("f.Parse() = true before Parse")
 	}
-	f.ParseErrorsAllowlist.UnknownFlags = true
+	setUnknownFlags(f)
 
 	f.BoolP("boola", "a", false, "bool value")
 	f.BoolP("boolb", "b", false, "bool2 value")
@@ -649,7 +649,12 @@ func TestParseAll(t *testing.T) {
 
 func TestIgnoreUnknownFlags(t *testing.T) {
 	ResetForTesting(func() { t.Error("bad parse") })
-	testParseWithUnknownFlags(GetCommandLine(), t)
+	testParseWithUnknownFlags(GetCommandLine(), t, func(f *FlagSet) { f.ParseErrorsAllowlist.UnknownFlags = true })
+}
+
+func TestIgnoreUnknownFlagsBackwardsCompat(t *testing.T) {
+	ResetForTesting(func() { t.Error("bad parse") })
+	testParseWithUnknownFlags(GetCommandLine(), t, func(f *FlagSet) { f.ParseErrorsWhitelist.UnknownFlags = true })
 }
 
 func TestFlagSetParse(t *testing.T) {


### PR DESCRIPTION
This will be removed in a future release, but is reintroduced here to not break backwards compatibility.

Fixes #445 
