### PR TITLE
Show 'correct' explicit bool value syntax in help

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -723,9 +723,12 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 		}
 
 		varname, usage := UnquoteUsage(flag)
-		if varname != "" {
+		if flag.Value.Type() == "bool" {
+			line += "[=true|false]"
+		} else if varname != "" {
 			line += " " + varname
 		}
+
 		if flag.NoOptDefVal != "" {
 			switch flag.Value.Type() {
 			case "string":

--- a/flag_test.go
+++ b/flag_test.go
@@ -1271,28 +1271,28 @@ func TestHiddenFlagUsage(t *testing.T) {
 	}
 }
 
-const defaultOutput = `      --A                         for bootstrapping, allow 'any' type
-      --Alongflagname             disable bounds checking
-  -C, --CCC                       a boolean defaulting to true (default true)
-      --D path                    set relative path for local imports
-  -E, --EEE num[=1234]            a num with NoOptDefVal (default 4321)
-      --F number                  a non-zero number (default 2.7)
-      --G float                   a float that defaults to zero
-      --IP ip                     IP address with no default
-      --IPMask ipMask             Netmask address with no default
-      --IPNet ipNet               IP network with no default
-      --Ints ints                 int slice with zero default
-      --N int                     a non-zero int (default 27)
-      --ND1 string[="bar"]        a string with NoOptDefVal (default "foo")
-      --ND2 num[=4321]            a num with NoOptDefVal (default 1234)
-      --StringArray stringArray   string array with zero default
-      --StringSlice strings       string slice with zero default
-      --Z int                     an int that defaults to zero
-      --custom custom             custom Value implementation
-      --custom-with-val custom    custom value which has been set from command line while help is shown
-      --customP custom            a VarP with default (default 10)
-      --maxT timeout              set timeout for dial
-  -v, --verbose count             verbosity
+const defaultOutput = `      --A[=true|false]               for bootstrapping, allow 'any' type
+      --Alongflagname[=true|false]   disable bounds checking
+  -C, --CCC[=true|false]             a boolean defaulting to true (default true)
+      --D path                       set relative path for local imports
+  -E, --EEE num[=1234]               a num with NoOptDefVal (default 4321)
+      --F number                     a non-zero number (default 2.7)
+      --G float                      a float that defaults to zero
+      --IP ip                        IP address with no default
+      --IPMask ipMask                Netmask address with no default
+      --IPNet ipNet                  IP network with no default
+      --Ints ints                    int slice with zero default
+      --N int                        a non-zero int (default 27)
+      --ND1 string[="bar"]           a string with NoOptDefVal (default "foo")
+      --ND2 num[=4321]               a num with NoOptDefVal (default 1234)
+      --StringArray stringArray      string array with zero default
+      --StringSlice strings          string slice with zero default
+      --Z int                        an int that defaults to zero
+      --custom custom                custom Value implementation
+      --custom-with-val custom       custom value which has been set from command line while help is shown
+      --customP custom               a VarP with default (default 10)
+      --maxT timeout                 set timeout for dial
+  -v, --verbose count                verbosity
 `
 
 // Custom value that satisfies the Value interface.

--- a/printusage_test.go
+++ b/printusage_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 )
 
-const expectedOutput = `      --long-form    Some description
-      --long-form2   Some description
-                       with multiline
-  -s, --long-name    Some description
-  -t, --long-name2   Some description with
-                       multiline
+const expectedOutput = `      --long-form[=true|false]    Some description
+      --long-form2[=true|false]   Some description
+                                    with multiline
+  -s, --long-name[=true|false]    Some description
+  -t, --long-name2[=true|false]   Some description with
+                                    multiline
 `
 
 func setUpPFlagSet(buf io.Writer) *FlagSet {
@@ -47,11 +47,11 @@ func setUpPFlagSet2(buf io.Writer) *FlagSet {
 	return f
 }
 
-const expectedOutput2 = `      --long-form                    Some description
-      --long-form2                   Some description
+const expectedOutput2 = `      --long-form[=true|false]       Some description
+      --long-form2[=true|false]      Some description
                                        with multiline
-  -s, --long-name                    Some description
-  -t, --long-name2                   Some description with
+  -s, --long-name[=true|false]       Some description
+  -t, --long-name2[=true|false]      Some description with
                                        multiline
   -o, --other-very-long-arg string   Some very long description having
                                      break the limit (default
@@ -69,6 +69,6 @@ func TestPrintUsage_2(t *testing.T) {
 	f := setUpPFlagSet2(&buf)
 	res := f.FlagUsagesWrapped(80)
 	if res != expectedOutput2 {
-		t.Errorf("Expected \n%q \nActual \n%q", expectedOutput2, res)
+		t.Errorf("Expected \n%s \nActual \n%s", expectedOutput2, res)
 	}
 }


### PR DESCRIPTION
Here's [my suggestion](https://github.com/spf13/pflag/issues/410#issuecomment-2307928624) from #410 to (begin to) resolve it.