### PR TITLE
fix: update broken POSIX recommendations link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pflag is compatible with the [GNU extensions to the POSIX recommendations
 for command-line options][1]. For a more precise description, see the
 "Command-line flag syntax" section below.
 
-[1]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+[1]: https://sourceware.org/glibc/manual/latest/html_node/Argument-Syntax.html
 
 pflag is available under the same style of BSD license as the Go language,
 which can be found in the LICENSE file.


### PR DESCRIPTION
Fixes #463

The old link `http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html` now redirects to the glibc manual homepage (`https://sourceware.org/glibc/manual/`) instead of the specific Argument Syntax page.

Updated to the current URL: `https://sourceware.org/glibc/manual/latest/html_node/Argument-Syntax.html`