### PR TITLE
fix: accept empty IntSlice values

### DIFF
--- a/int_slice.go
+++ b/int_slice.go
@@ -20,15 +20,17 @@ func newIntSliceValue(val []int, p *[]int) *intSliceValue {
 }
 
 func (s *intSliceValue) Set(val string) error {
-	ss := strings.Split(val, ",")
-	out := make([]int, len(ss))
-	for i, d := range ss {
-		var err error
-		out[i], err = strconv.Atoi(d)
-		if err != nil {
-			return err
+	out := make([]int, 0)
+	if val != "" {
+		ss := strings.Split(val, ",")
+		out = make([]int, len(ss))
+		for i, d := range ss {
+			var err error
+			out[i], err = strconv.Atoi(d)
+			if err != nil {
+				return err
+			}
 		}
-
 	}
 	if !s.changed {
 		*s.value = out

--- a/int_slice_test.go
+++ b/int_slice_test.go
@@ -23,6 +23,12 @@ func setUpISFlagSetWithDefault(isp *[]int) *FlagSet {
 	return f
 }
 
+func setUpISFlagSetWithNilDefault(isp *[]int) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.IntSliceVar(isp, "is", nil, "Command separated list!")
+	return f
+}
+
 func TestEmptyIS(t *testing.T) {
 	var is []int
 	f := setUpISFlagSet(&is)
@@ -74,6 +80,26 @@ func TestIS(t *testing.T) {
 	}
 }
 
+func TestEmptyISValue(t *testing.T) {
+	var is []int
+	f := setUpISFlagSetWithDefault(&is)
+	err := f.Parse([]string{"--is="})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	if is == nil {
+		t.Fatal("expected explicit empty value to produce a non-nil empty slice")
+	}
+
+	getIS, err := f.GetIntSlice("is")
+	if err != nil {
+		t.Fatal("got an error from GetIntSlice():", err)
+	}
+	if len(getIS) != 0 {
+		t.Fatalf("got is %v with len=%d but expected length=0", getIS, len(getIS))
+	}
+}
+
 func TestISDefault(t *testing.T) {
 	var is []int
 	f := setUpISFlagSetWithDefault(&is)
@@ -106,6 +132,19 @@ func TestISDefault(t *testing.T) {
 		if d != v {
 			t.Fatalf("expected is[%d] to be %d from GetIntSlice but got: %d", i, d, v)
 		}
+	}
+}
+
+func TestISNilDefault(t *testing.T) {
+	var is []int
+	f := setUpISFlagSetWithNilDefault(&is)
+
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil default to remain nil but got: %v", is)
 	}
 }
 


### PR DESCRIPTION
Closes #222

`IntSlice` currently treats `--data=` as `strconv.Atoi("")`, so callers cannot use an explicit empty value to clear a slice while still distinguishing it from an omitted flag.

This change makes `--data=` resolve to a non-nil empty slice, matching the existing `StringSlice` empty-value behavior. It also adds regression coverage for the explicit empty-value case and for preserving a nil default when the flag is omitted.

Validation:
- `go test ./...`
- `go test -race -v ./...`