### PR TITLE
fix: README.md indicating the use of godoc(deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,7 @@ func main() {
 ## More info
 
 You can see the full reference documentation of the pflag package
-[at godoc.org][3], or through go's standard documentation system by
-running `godoc -http=:6060` and browsing to
-[http://localhost:6060/pkg/github.com/spf13/pflag][2] after
-installation.
+at [pkg.go.dev][2], or through go's standard documentation system by
+cloning the repository and running `go doc -http` in it.
 
-[2]: http://localhost:6060/pkg/github.com/spf13/pflag
-[3]: http://godoc.org/github.com/spf13/pflag
+[2]: https://pkg.go.dev/github.com/spf13/pflag


### PR DESCRIPTION
Point to the use of go doc -http and pkg.go.dev instead.

From what I read the command godoc stop having a CLI in Go 1.12 https://go.dev/doc/go1.12#godoc

In Go 1.13 it was taken out from the default installation. https://go.dev/doc/go1.13#godoc

godoc.org was replaced by pkg.go.dev officially in 2021 according to https://github.com/golang/go/issues/43178#issuecomment-775313687