### PR TITLE
fix: update POSIX argument syntax link to working sourceware URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pflag is compatible with the [GNU extensions to the POSIX recommendations
 for command-line options][1]. For a more precise description, see the
 "Command-line flag syntax" section below.
 
-[1]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+[1]: https://sourceware.org/glibc/manual/latest/html_node/Argument-Syntax.html
 
 pflag is available under the same style of BSD license as the Go language,
 which can be found in the LICENSE file.


### PR DESCRIPTION
## Summary

Updates the README.md [1] reference link from the broken gnu.org redirect to the direct sourceware.org URL.

**Issue:** #463 - Link to POSIX recommendations in README is broken

**The Problem:**
- Current: 
- This redirects to  (without the path)

**The Fix:**
- Changed to: 
- Directly links to the correct page on sourceware.org

**Changed:** 1 line in README.md

Fixes #463