### PR TITLE
fix: ignore empty StringArray values; clarify SortFlags docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,12 @@ flags.MarkHidden("secretFlag")
 
 **Example**:
 ```go
-flags.BoolP("verbose", "v", false, "verbose output")
-flags.String("coolflag", "yeaah", "it's really cool flag")
-flags.Int("usefulflag", 777, "sometimes it's very useful")
-flags.SortFlags = false
-flags.PrintDefaults()
+flagset := pflag.NewFlagSet("example", pflag.ContinueOnError)
+flagset.BoolP("verbose", "v", false, "verbose output")
+flagset.String("coolflag", "yeaah", "it's really cool flag")
+flagset.Int("usefulflag", 777, "sometimes it's very useful")
+flagset.SortFlags = false
+flagset.PrintDefaults()
 ```
 **Output**:
 ```

--- a/string_array.go
+++ b/string_array.go
@@ -14,6 +14,9 @@ func newStringArrayValue(val []string, p *[]string) *stringArrayValue {
 }
 
 func (s *stringArrayValue) Set(val string) error {
+	if val == "" {
+		return nil
+	}
 	if !s.changed {
 		*s.value = []string{val}
 		s.changed = true


### PR DESCRIPTION
## Summary

Fixes #415 and #456.

- Empty `--flag=""` no longer appends a single empty string to StringArray flags
- README shows `SortFlags` on a `FlagSet` instance

## Test plan

- [x] `go test ./...`