### PR TITLE
fix: reject single-dash long flag spellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,12 @@ flags.MarkHidden("secretFlag")
 
 **Example**:
 ```go
-flags.BoolP("verbose", "v", false, "verbose output")
-flags.String("coolflag", "yeaah", "it's really cool flag")
-flags.Int("usefulflag", 777, "sometimes it's very useful")
-flags.SortFlags = false
-flags.PrintDefaults()
+flagset := pflag.NewFlagSet("example", pflag.ContinueOnError)
+flagset.BoolP("verbose", "v", false, "verbose output")
+flagset.String("coolflag", "yeaah", "it's really cool flag")
+flagset.Int("usefulflag", 777, "sometimes it's very useful")
+flagset.SortFlags = false
+flagset.PrintDefaults()
 ```
 **Output**:
 ```

--- a/errors.go
+++ b/errors.go
@@ -127,6 +127,22 @@ func (e *InvalidValueError) GetValue() string {
 	return e.value
 }
 
+// LongFlagSingleDashError is returned when a single-dash argument matches a
+// long flag name (e.g. "-name" instead of "--name").
+type LongFlagSingleDashError struct {
+	name string
+}
+
+// Error implements error.
+func (e *LongFlagSingleDashError) Error() string {
+	return fmt.Sprintf("bad flag syntax: -%s; did you mean --%s?", e.name, e.name)
+}
+
+// GetName returns the long flag name that was misspelled.
+func (e *LongFlagSingleDashError) GetName() string {
+	return e.name
+}
+
 // InvalidSyntaxError is the error returned when a bad flag name is passed on
 // the command line.
 type InvalidSyntaxError struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -37,6 +37,30 @@ func TestValueRequiredError(t *testing.T) {
 	}
 }
 
+func TestLongFlagSingleDashError(t *testing.T) {
+	err := &LongFlagSingleDashError{name: "name"}
+	if err.GetName() != "name" {
+		t.Errorf("expected name %q, got %q", "name", err.GetName())
+	}
+	if err.Error() != `bad flag syntax: -name; did you mean --name?` {
+		t.Errorf("unexpected error: %q", err.Error())
+	}
+}
+
+func TestParseLongFlagWithSingleDash(t *testing.T) {
+	f := NewFlagSet("test", ContinueOnError)
+	var name string
+	f.StringVarP(&name, "name", "n", "", "name")
+	err := f.Parse([]string{"-name", "wrong"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var longDash *LongFlagSingleDashError
+	if !errors.As(err, &longDash) {
+		t.Fatalf("expected LongFlagSingleDashError, got %T: %v", err, err)
+	}
+}
+
 func TestInvalidValueError(t *testing.T) {
 	expectedCause := errors.New("error")
 	err := &InvalidValueError{

--- a/flag.go
+++ b/flag.go
@@ -1096,6 +1096,10 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 		// '-f' (arg was optional)
 		value = flag.NoOptDefVal
 	} else if len(shorthands) > 1 {
+		if _, ok := f.formal[f.normalizeFlagName(shorthands)]; ok {
+			err = f.fail(&LongFlagSingleDashError{name: shorthands})
+			return
+		}
 		// '-farg'
 		value = shorthands[1:]
 		outShorts = ""

--- a/string_array.go
+++ b/string_array.go
@@ -14,6 +14,9 @@ func newStringArrayValue(val []string, p *[]string) *stringArrayValue {
 }
 
 func (s *stringArrayValue) Set(val string) error {
+	if val == "" {
+		return nil
+	}
 	if !s.changed {
 		*s.value = []string{val}
 		s.changed = true


### PR DESCRIPTION
## Summary

Fixes spf13/cobra#2358.

Arguments like `-name` that match a long flag name now return a helpful error instead of being parsed as shorthand `-n` with value `ame`.

## Test plan

- [x] `go test ./...`