### PR TITLE
fix: reject single-dash long flag names

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -1128,6 +1128,10 @@ func (f *FlagSet) parseShortArg(s string, args []string, fn parseFunc) (a []stri
 	a = args
 	shorthands := s[1:]
 
+	if err = f.rejectSingleDashLongFlag(s); err != nil {
+		return a, err
+	}
+
 	// "shorthands" can be a series of shorthand letters of flags (e.g. "-vvv").
 	for len(shorthands) > 0 {
 		shorthands, a, err = f.parseSingleShortArg(shorthands, args, fn)
@@ -1137,6 +1141,33 @@ func (f *FlagSet) parseShortArg(s string, args []string, fn parseFunc) (a []stri
 	}
 
 	return
+}
+
+// rejectSingleDashLongFlag reports an error when a registered long flag name is
+// passed with a single dash (e.g. "-name" instead of "--name").
+func (f *FlagSet) rejectSingleDashLongFlag(s string) error {
+	if isGotestFlag(s) {
+		return nil
+	}
+
+	name := s[1:]
+	if len(name) <= 1 {
+		return nil
+	}
+
+	if flagName, _, ok := strings.Cut(name, "="); ok {
+		name = flagName
+	}
+
+	if isGotestShorthandFlag(name) {
+		return nil
+	}
+
+	if _, exists := f.formal[f.normalizeFlagName(name)]; exists {
+		return f.fail(&InvalidSyntaxError{specifiedFlag: s})
+	}
+
+	return nil
 }
 
 func (f *FlagSet) parseArgs(args []string, fn parseFunc) (err error) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -656,6 +656,39 @@ func TestShorthandLookup(t *testing.T) {
 	t.Errorf("f.ShorthandLookup(\"ab\") did not panic")
 }
 
+func TestSingleDashLongFlagName(t *testing.T) {
+	f := NewFlagSet("singleDashLong", ContinueOnError)
+	f.SetOutput(ioutil.Discard)
+
+	var name string
+	f.StringVarP(&name, "name", "n", "", "name of configuration")
+
+	err := f.Parse([]string{"-name", "wrong"})
+	expectedErr := "bad flag syntax: -name"
+	if err == nil {
+		t.Fatal("expected error for single-dash long flag name")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected error %q, got %q", expectedErr, err.Error())
+	}
+	if name != "" {
+		t.Errorf("expected empty value, got %q", name)
+	}
+
+	err = f.Parse([]string{"-n", "right"})
+	if err != nil {
+		t.Errorf("expected no error for shorthand flag, got %v", err)
+	}
+	if name != "right" {
+		t.Errorf("expected value %q, got %q", "right", name)
+	}
+
+	err = f.Parse([]string{"-name=wrong"})
+	if err == nil || err.Error() != "bad flag syntax: -name=wrong" {
+		t.Errorf("expected error %q for -name=wrong, got %v", "bad flag syntax: -name=wrong", err)
+	}
+}
+
 func TestParse(t *testing.T) {
 	ResetForTesting(func() { t.Error("bad parse") })
 	testParse(GetCommandLine(), t)


### PR DESCRIPTION
## Summary

Fixes spf13/cobra#2358

When a long flag is registered with a shorthand (e.g. `--name` / `-n`), passing the long name with a single dash such as `-name wrong` was silently parsed as shorthand `-n` with value `ame`.

This change rejects single-dash tokens that exactly match a registered long flag name and returns `InvalidSyntaxError` (`bad flag syntax: -name`), guiding callers to use `--name` instead.

Go test flags prefixed with `-test.` are still skipped, preserving existing `AddGoFlagSet` behavior.

## Test plan

- [x] `go test ./...`
- [x] Added `TestSingleDashLongFlagName` covering `-name`, `-n`, and `-name=`