### PR TITLE
fix: treat first empty StringArray value as an empty array

### DIFF
--- a/string_array.go
+++ b/string_array.go
@@ -14,6 +14,11 @@ func newStringArrayValue(val []string, p *[]string) *stringArrayValue {
 }
 
 func (s *stringArrayValue) Set(val string) error {
+	if val == "" && !s.changed {
+		*s.value = []string{}
+		s.changed = true
+		return nil
+	}
 	if !s.changed {
 		*s.value = []string{val}
 		s.changed = true

--- a/string_array_test.go
+++ b/string_array_test.go
@@ -53,6 +53,44 @@ func TestEmptySAValue(t *testing.T) {
 	if len(getSA) != 0 {
 		t.Fatalf("got sa %v with len=%d but expected length=0", getSA, len(getSA))
 	}
+	if len(sa) != 0 {
+		t.Fatalf("got sa variable %v with len=%d but expected length=0", sa, len(sa))
+	}
+}
+
+func TestEmptySAQuotedValue(t *testing.T) {
+	var sa []string
+	f := setUpSAFlagSet(&sa)
+	err := f.Parse([]string{"--sa", ""})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	getSA, err := f.GetStringArray("sa")
+	if err != nil {
+		t.Fatal("got an error from GetStringArray():", err)
+	}
+	if len(getSA) != 0 {
+		t.Fatalf("got sa %v with len=%d but expected length=0", getSA, len(getSA))
+	}
+	if len(sa) != 0 {
+		t.Fatalf("got sa variable %v with len=%d but expected length=0", sa, len(sa))
+	}
+}
+
+func TestEmptySAAppendEmptyString(t *testing.T) {
+	var sa []string
+	f := setUpSAFlagSet(&sa)
+	err := f.Parse([]string{"--sa=one", "--sa="})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	if len(sa) != 2 {
+		t.Fatalf("got sa %v with len=%d but expected length=2", sa, len(sa))
+	}
+	if sa[0] != "one" || sa[1] != "" {
+		t.Fatalf("got sa %v but expected [one \"\"]", sa)
+	}
 }
 
 func TestSADefault(t *testing.T) {


### PR DESCRIPTION
## Summary

`StringArrayVar` stored the first `--array=""` / `--array ""` assignment as `[]string{""}`, so `len(array)` was 1 even though `GetStringArray()` appeared empty due to CSV round-tripping.

The first empty assignment now clears the array. Subsequent empty assignments still append an empty string element, preserving explicit multi-value usage like `--sa=one --sa=`.

Fixes #415

## Test plan

- [x] `go test ./...`
- [x] Added tests for `--sa=""`, `--sa ""`, and appended empty values