### PR TITLE
docs: fix SortFlags README example to use FlagSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,12 @@ flags.MarkHidden("secretFlag")
 
 **Example**:
 ```go
-flags.BoolP("verbose", "v", false, "verbose output")
-flags.String("coolflag", "yeaah", "it's really cool flag")
-flags.Int("usefulflag", 777, "sometimes it's very useful")
-flags.SortFlags = false
-flags.PrintDefaults()
+fs := pflag.NewFlagSet("example", pflag.ContinueOnError)
+fs.BoolP("verbose", "v", false, "verbose output")
+fs.String("coolflag", "yeaah", "it's really cool flag")
+fs.Int("usefulflag", 777, "sometimes it's very useful")
+fs.SortFlags = false
+fs.PrintDefaults()
 ```
 **Output**:
 ```


### PR DESCRIPTION
## Summary
- Update the "Disable sorting of flags" README example to use an explicit `FlagSet`
- `SortFlags` is a field on `FlagSet`, not a package-level identifier

Fixes #456

## Test plan
- [x] Documentation-only change
- [x] Example matches `flag_test.go` usage of `fs.SortFlags`