### PR TITLE
ip: stop GetIP erroring when the IP flag has a nil default

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -32,6 +32,14 @@ func (i *ipValue) Type() string {
 }
 
 func ipConv(sval string) (interface{}, error) {
+	// An unset IP flag with a nil default round-trips through String() as
+	// "<nil>", because that's what net.IP.String returns for a nil
+	// receiver. Treat that (and the empty string, to match how Set treats
+	// empty input) as "no IP" so GetIP doesn't error on
+	// IP("ip", nil, ...). See #351.
+	if sval == "" || sval == "<nil>" {
+		return net.IP(nil), nil
+	}
 	ip := net.ParseIP(sval)
 	if ip != nil {
 		return ip, nil

--- a/ip_test.go
+++ b/ip_test.go
@@ -61,3 +61,31 @@ func TestIP(t *testing.T) {
 		}
 	}
 }
+
+// TestIPNilDefault covers #351: declaring an IP flag with a nil default and
+// then reading it without setting it must return (nil, nil), not an error.
+// Before the ipConv guard, the unset flag's String() returned "<nil>" and
+// GetIP tried to parse it as an address.
+func TestIPNilDefault(t *testing.T) {
+	f := NewFlagSet("test", ContinueOnError)
+	f.IP("ip", nil, "")
+
+	ip, err := f.GetIP("ip")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != nil {
+		t.Errorf("expected nil IP, got %v", ip)
+	}
+
+	var bound net.IP
+	f2 := NewFlagSet("test2", ContinueOnError)
+	f2.IPVar(&bound, "ip", nil, "")
+	ip, err = f2.GetIP("ip")
+	if err != nil {
+		t.Fatalf("unexpected error (IPVar variant): %v", err)
+	}
+	if ip != nil {
+		t.Errorf("expected nil IP (IPVar variant), got %v", ip)
+	}
+}


### PR DESCRIPTION
Reporter's case from #351:

```go
fs.IP("ip", nil, "--ip")
ip, err := fs.GetIP("ip")
// err = invalid string being converted to IP address: <nil>
```

The flag's underlying value is a nil `net.IP`. When `GetIP` runs, `getFlagType` round-trips through `Value.String()`, and `net.IP(nil).String()` returns the literal `"<nil>"`. `ipConv` then hands that to `net.ParseIP`, which rejects it.

`Set("")` already short-circuits without storing anything, so an empty value is the existing "no IP" sentinel. Mirror that on the read side: when `ipConv` sees `""` or `"<nil>"`, return `(net.IP(nil), nil)` instead of erroring.

The fix is one branch in `ipConv`. `IPVar(&p, "ip", nil, ...)` works the same way.

Regression test covers both `IP` and `IPVar` with a nil default. Fails on master, passes here. `go test ./...` is clean.

Fixes #351.
