### PR TITLE
fix: stop GetIP erroring when the IP flag has a nil default

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -32,6 +32,9 @@ func (i *ipValue) Type() string {
 }
 
 func ipConv(sval string) (interface{}, error) {
+	if sval == "" || sval == "<nil>" {
+		return net.IP(nil), nil
+	}
 	ip := net.ParseIP(sval)
 	if ip != nil {
 		return ip, nil

--- a/ip_nil_default_test.go
+++ b/ip_nil_default_test.go
@@ -1,0 +1,35 @@
+package pflag
+
+import (
+	"net"
+	"testing"
+)
+
+func TestGetIPNilDefault(t *testing.T) {
+	t.Run("IP", func(t *testing.T) {
+		f := NewFlagSet("test", ContinueOnError)
+		f.IP("ip", nil, "IP address")
+
+		ip, err := f.GetIP("ip")
+		if err != nil {
+			t.Fatalf("GetIP returned error: %v", err)
+		}
+		if ip != nil {
+			t.Fatalf("expected nil IP, got %v", ip)
+		}
+	})
+
+	t.Run("IPVar", func(t *testing.T) {
+		f := NewFlagSet("test", ContinueOnError)
+		var ip net.IP
+		f.IPVar(&ip, "ip", nil, "IP address")
+
+		got, err := f.GetIP("ip")
+		if err != nil {
+			t.Fatalf("GetIP returned error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("expected nil IP, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #478
Fixes #351

When an `IP` flag defaults to `nil`, `GetIP` round-trips through `Value.String()` and receives `"<nil>"`, which `ipConv` rejected. `Set("")` already treats empty input as "no IP"; this mirrors that on the read side by returning `(net.IP(nil), nil)` for `""` and `"<nil>"`.

## Test plan

- [x] Added `TestGetIPNilDefault` covering `IP` and `IPVar` with a nil default
- [x] `go test ./...`

Made with [Cursor](https://cursor.com)