### PR TITLE
fix: treat empty string-array values as empty slices

### DIFF
--- a/string_array.go
+++ b/string_array.go
@@ -14,12 +14,17 @@ func newStringArrayValue(val []string, p *[]string) *stringArrayValue {
 }
 
 func (s *stringArrayValue) Set(val string) error {
-	if !s.changed {
-		*s.value = []string{val}
-		s.changed = true
-	} else {
-		*s.value = append(*s.value, val)
+	values := []string{}
+	if val != "" {
+		values = append(values, val)
 	}
+
+	if !s.changed {
+		*s.value = values
+	} else {
+		*s.value = append(*s.value, values...)
+	}
+	s.changed = true
 	return nil
 }
 

--- a/string_array_test.go
+++ b/string_array_test.go
@@ -45,8 +45,61 @@ func TestEmptySAValue(t *testing.T) {
 	if err != nil {
 		t.Fatal("expected no error; got", err)
 	}
+	if len(sa) != 0 {
+		t.Fatalf("got sa %v with len=%d but expected length=0", sa, len(sa))
+	}
+	if sa == nil {
+		t.Fatal("expected sa to be a non-nil empty slice")
+	}
 
 	getSA, err := f.GetStringArray("sa")
+	if err != nil {
+		t.Fatal("got an error from GetStringArray():", err)
+	}
+	if len(getSA) != 0 {
+		t.Fatalf("got sa %v with len=%d but expected length=0", getSA, len(getSA))
+	}
+}
+
+func TestEmptySASeparateValue(t *testing.T) {
+	var sa []string
+	f := setUpSAFlagSet(&sa)
+	err := f.Parse([]string{"--sa", ""})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	if len(sa) != 0 {
+		t.Fatalf("got sa %v with len=%d but expected length=0", sa, len(sa))
+	}
+	if sa == nil {
+		t.Fatal("expected sa to be a non-nil empty slice")
+	}
+
+	getSA, err := f.GetStringArray("sa")
+	if err != nil {
+		t.Fatal("got an error from GetStringArray():", err)
+	}
+	if len(getSA) != 0 {
+		t.Fatalf("got sa %v with len=%d but expected length=0", getSA, len(getSA))
+	}
+}
+
+func TestEmptySASeparateValueCommandLine(t *testing.T) {
+	ResetForTesting(func() {})
+
+	var sa []string
+	StringArrayVar(&sa, "sa", []string{}, "Command separated list!")
+	if err := CommandLine.Parse([]string{"--sa", ""}); err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	if len(sa) != 0 {
+		t.Fatalf("got sa %v with len=%d but expected length=0", sa, len(sa))
+	}
+	if sa == nil {
+		t.Fatal("expected sa to be a non-nil empty slice")
+	}
+
+	getSA, err := GetCommandLine().GetStringArray("sa")
 	if err != nil {
 		t.Fatal("got an error from GetStringArray():", err)
 	}


### PR DESCRIPTION
## Summary
- treat explicit empty `StringArray` values as an empty slice instead of a single empty-string element
- make the bound `[]string` agree with `GetStringArray()` and `String()` for `--flag=` and `--flag ""`
- add regression coverage for both `FlagSet.Parse` and `CommandLine.Parse`

## Testing
- go test ./... -run 'TestEmptySAValue|TestEmptySASeparateValue|TestEmptySASeparateValueCommandLine'
- go test ./...
- go vet ./...

Closes #415
