### PR TITLE
fix: allow nil default IP flags in GetIP

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -32,6 +32,9 @@ func (i *ipValue) Type() string {
 }
 
 func ipConv(sval string) (interface{}, error) {
+	if sval == "" || sval == "<nil>" {
+		return net.IP(nil), nil
+	}
 	ip := net.ParseIP(sval)
 	if ip != nil {
 		return ip, nil

--- a/ip_test.go
+++ b/ip_test.go
@@ -61,3 +61,20 @@ func TestIP(t *testing.T) {
 		}
 	}
 }
+
+func TestIPNilDefault(t *testing.T) {
+	var addr net.IP
+	f := NewFlagSet("test", ContinueOnError)
+	f.IPVar(&addr, "address", nil, "IP Address")
+
+	ip, err := f.GetIP("address")
+	if err != nil {
+		t.Fatalf("expected nil default IP to round-trip without error, got %v", err)
+	}
+	if ip != nil {
+		t.Fatalf("expected nil default IP, got %v", ip)
+	}
+	if addr != nil {
+		t.Fatalf("expected bound IP variable to stay nil, got %v", addr)
+	}
+}


### PR DESCRIPTION
## Summary
- treat the zero-value string form of a nil `net.IP` flag as a nil result in `GetIP()`
- keep `IPVar(..., nil, ...)` usable for optional IP flags without forcing callers through parse errors
- add regression coverage for nil default IP flags

## Motivation
When an `IP` flag is declared with a nil default value, the internal string form becomes `<nil>`. `GetIP()` currently passes that through `ipConv`, which tries to parse it as a literal IP string and returns an error. This makes optional IP flags awkward to model when callers want an actual nil default.

This change keeps the existing parsing behavior for user-provided values, but lets untouched nil defaults round-trip cleanly through `GetIP()`.

Closes #351