### PR TITLE
fix: allow hex input in UintSlice

### DIFF
--- a/uint_slice.go
+++ b/uint_slice.go
@@ -23,7 +23,7 @@ func (s *uintSliceValue) Set(val string) error {
 	ss := strings.Split(val, ",")
 	out := make([]uint, len(ss))
 	for i, d := range ss {
-		u, err := strconv.ParseUint(d, 10, 0)
+		u, err := strconv.ParseUint(d, 0, 0)
 		if err != nil {
 			return err
 		}
@@ -51,7 +51,7 @@ func (s *uintSliceValue) String() string {
 }
 
 func (s *uintSliceValue) fromString(val string) (uint, error) {
-	t, err := strconv.ParseUint(val, 10, 0)
+	t, err := strconv.ParseUint(val, 0, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -101,7 +101,7 @@ func uintSliceConv(val string) (interface{}, error) {
 	ss := strings.Split(val, ",")
 	out := make([]uint, len(ss))
 	for i, d := range ss {
-		u, err := strconv.ParseUint(d, 10, 0)
+		u, err := strconv.ParseUint(d, 0, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/uint_slice_test.go
+++ b/uint_slice_test.go
@@ -70,6 +70,40 @@ func TestUIS(t *testing.T) {
 	}
 }
 
+func TestUISHex(t *testing.T) {
+	var uis []uint
+	f := setUpUISFlagSet(&uis)
+
+	vals := []string{"0x1", "0x2", "0x10"}
+	arg := fmt.Sprintf("--uis=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range uis {
+		u, err := strconv.ParseUint(vals[i], 0, 0)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if uint(u) != v {
+			t.Fatalf("expected uis[%d] to be %s but got: %d", i, vals[i], v)
+		}
+	}
+	getUIS, err := f.GetUintSlice("uis")
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+	for i, v := range getUIS {
+		u, err := strconv.ParseUint(vals[i], 0, 0)
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if uint(u) != v {
+			t.Fatalf("expected uis[%d] to be %s but got: %d from GetUintSlice", i, vals[i], v)
+		}
+	}
+}
+
 func TestUISDefault(t *testing.T) {
 	var uis []uint
 	f := setUpUISFlagSetWithDefault(&uis)


### PR DESCRIPTION
## Summary
- make `UintSlice` parse values with base autodetection instead of decimal-only parsing
- keep `UintSlice` aligned with other integer slice flags that already accept `0x` input
- add regression coverage for hexadecimal `UintSlice` values

## Problem
Issue #229 reports that `UintSliceVar` rejects inputs like `0x86` even though other integer slice flags accept Go-style base prefixes. Today `UintSlice` uses `strconv.ParseUint(..., 10, 0)` in parsing, replacement, and getter conversion paths, so hexadecimal values fail unexpectedly.

## Fix
Switch the `UintSlice` parsing paths to `strconv.ParseUint(..., 0, 0)` so base prefixes are handled consistently across parse, replace, and `GetUintSlice()`.

Closes #229