### PR TITLE
fix: allow empty StringToString values

### DIFF
--- a/string_to_string.go
+++ b/string_to_string.go
@@ -24,8 +24,9 @@ func newStringToStringValue(val map[string]string, p *map[string]string) *string
 // Set updates the flag value from the given string, adding additional mappings or updating existing ones.
 func (s *stringToStringValue) Set(val string) error {
 	var ss []string
-	n := strings.Count(val, "=")
-	switch n {
+	switch n := strings.Count(val, "="); {
+	case val == "":
+		ss = []string{}
 	case 0:
 		return fmt.Errorf("%s must be formatted as key=value", val)
 	case 1:
@@ -53,6 +54,9 @@ func (s *stringToStringValue) Set(val string) error {
 		for k := range *s.value {
 			delete(*s.value, k)
 		}
+	}
+	if *s.value == nil {
+		*s.value = map[string]string{}
 	}
 
 	for k, v := range out {

--- a/string_to_string_test.go
+++ b/string_to_string_test.go
@@ -398,3 +398,58 @@ func TestS2SCalledTwice(t *testing.T) {
 		}
 	}
 }
+
+func TestS2SEmptyValueClearsDefaults(t *testing.T) {
+	var s2s map[string]string
+	f := setUpS2SFlagSetWithDefault(&s2s)
+
+	if err := f.Parse([]string{"--s2s="}); err != nil {
+		t.Fatalf("expected no error; got %v", err)
+	}
+	if s2s == nil {
+		t.Fatal("expected empty map, got nil")
+	}
+	if len(s2s) != 0 {
+		t.Fatalf("expected empty map, got %v", s2s)
+	}
+
+	getS2S, err := f.GetStringToString("s2s")
+	if err != nil {
+		t.Fatalf("got an error from GetStringToString(): %v", err)
+	}
+	if getS2S == nil {
+		t.Fatal("expected empty map from GetStringToString, got nil")
+	}
+	if len(getS2S) != 0 {
+		t.Fatalf("expected empty map from GetStringToString, got %v", getS2S)
+	}
+}
+
+func TestS2SEmptyValueKeepsEmptyDefaultNonNil(t *testing.T) {
+	var s2s map[string]string
+	f := setUpS2SFlagSet(&s2s)
+
+	if err := f.Parse([]string{"--s2s="}); err != nil {
+		t.Fatalf("expected no error; got %v", err)
+	}
+	if s2s == nil {
+		t.Fatal("expected empty map, got nil")
+	}
+	if len(s2s) != 0 {
+		t.Fatalf("expected empty map, got %v", s2s)
+	}
+}
+
+func TestS2SEmptyValueCanBeFollowedByEntries(t *testing.T) {
+	var s2s map[string]string
+	f := setUpS2SFlagSetWithDefault(&s2s)
+
+	if err := f.Parse([]string{"--s2s=", "--s2s=a=1"}); err != nil {
+		t.Fatalf("expected no error; got %v", err)
+	}
+
+	expected := map[string]string{"a": "1"}
+	if !reflect.DeepEqual(s2s, expected) {
+		t.Fatalf("expected %v, got %v", expected, s2s)
+	}
+}


### PR DESCRIPTION
## Summary
- allow an explicit `--flag=` / `flag.Set("")` for `StringToString` to clear the map to an empty map instead of returning a formatting error
- preserve the existing default value when the flag is omitted
- keep the resulting value non-nil so an explicit empty override is distinguishable from an untouched default

## Why
Issue #312 asks for a way to override a non-empty default map with an explicit empty value.

This change follows the same semantics already accepted for typed slice flags in #222 / #485:
- omitted flag => keep the default value
- explicit empty value => non-nil empty collection

That makes `StringToString` behave like a real override channel instead of forcing callers to choose between "keep defaults" and "replace with at least one entry".

## Scope / compatibility
- this is intentionally limited to `StringToString`
- it does **not** change `StringArray` / `StringSlice` / other collection types here
- the previously rejected input was `--flag=` itself, so this uses syntax that currently errors rather than reinterpreting a previously valid non-empty value

## Tests
Added regression coverage for:
- clearing a non-empty default map with `--s2s=`
- keeping explicit empty results non-nil
- following an empty override with later map entries

Note: I did **not** run `go test` / `go build` locally for this branch.
