### PR TITLE
docs: clarify SortFlags example with complete runnable program

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,13 +250,35 @@ flags.MarkHidden("secretFlag")
 ## Disable sorting of flags
 `pflag` allows you to disable sorting of flags for help and usage message.
 
+`SortFlags` is a field on `FlagSet`, not a package-level variable. To disable
+sorting on the default `CommandLine` flag set, use `pflag.CommandLine.SortFlags`.
+
 **Example**:
 ```go
-flags.BoolP("verbose", "v", false, "verbose output")
-flags.String("coolflag", "yeaah", "it's really cool flag")
-flags.Int("usefulflag", 777, "sometimes it's very useful")
-flags.SortFlags = false
-flags.PrintDefaults()
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+func main() {
+	flags := pflag.NewFlagSet("example", pflag.ContinueOnError)
+	flags.BoolP("verbose", "v", false, "verbose output")
+	flags.String("coolflag", "yeaah", "it's really cool flag")
+	flags.Int("usefulflag", 777, "sometimes it's very useful")
+	flags.SortFlags = false
+	flags.PrintDefaults()
+	fmt.Println()
+}
+```
+
+For the default `CommandLine` flag set:
+
+```go
+pflag.CommandLine.SortFlags = false
+pflag.PrintDefaults()
 ```
 **Output**:
 ```


### PR DESCRIPTION
## Summary

Fixes #456

The existing SortFlags example used `flags.SortFlags` without showing that SortFlags is a field on FlagSet, not a package-level variable. This led to confusion for users who tried to use `pflag.SortFlags` directly (`pflag.SortFlags` does not exist).

## Changes

- Updated the example to show a complete, runnable program using `NewFlagSet`
- Added a separate note for the `CommandLine` case: `pflag.CommandLine.SortFlags = false`
- Added proper imports and `main()` function