### PR TITLE
fix: handle String() round-trip in Set() for stringToString

### DIFF
--- a/string_to_string.go
+++ b/string_to_string.go
@@ -24,6 +24,10 @@ func newStringToStringValue(val map[string]string, p *map[string]string) *string
 // Set updates the flag value from the given string, adding additional mappings or updating existing ones.
 func (s *stringToStringValue) Set(val string) error {
 	var ss []string
+	// Support round-trip from String() output, which wraps the value in [...]
+	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+		val = val[1 : len(val)-1]
+	}
 	n := strings.Count(val, "=")
 	switch n {
 	case 0:


### PR DESCRIPTION
## Summary

Fixes #413

`String()` wraps the output in `[...]`, but `Set()` was not stripping those brackets before parsing. This caused round-trip failures when the output of `String()` (e.g., `[x=[]]`) was passed back to `Set()`, resulting in keys like `'[x'` instead of `'x'`.

## Reproduction

```go
fs := pflag.NewFlagSet("test", pflag.PanicOnError)
fs.StringToString("testflag", map[string]string{}, "")
fs.Set("testflag", "x=[]")
result, _ := fs.GetStringToString("testflag")
// Before: map[[x:[]]  (incorrect)
// After:  map[x:[]]     (correct)
```

## Changes

- Added `[...]` bracket stripping in `Set()` at the start of parsing, so the method can handle its own `String()` output