### PR TITLE
fix: allow empty string to reset StringToString flag

### DIFF
--- a/string_to_string.go
+++ b/string_to_string.go
@@ -24,6 +24,14 @@ func newStringToStringValue(val map[string]string, p *map[string]string) *string
 // Set updates the flag value from the given string, adding additional mappings or updating existing ones.
 func (s *stringToStringValue) Set(val string) error {
 	var ss []string
+	// Allow empty string to reset the map to empty
+	if val == "" {
+		for k := range *s.value {
+			delete(*s.value, k)
+		}
+		s.changed = true
+		return nil
+	}
 	n := strings.Count(val, "=")
 	switch n {
 	case 0:


### PR DESCRIPTION
## Summary

Fixes #312

Currently, passing an empty string to a StringToString flag (e.g., `--flag=""`) returns an error because the parser expects a `key=value` format. This makes it impossible to override a non-empty default map with an empty one.

## Changes

Allow an empty string value to reset the flag to an empty map. When `val == ""`, the existing map entries are cleared and `changed` is set to `true`.

## Before

```go
fs := pflag.NewFlagSet("test", pflag.ExitOnError)
fs.StringToString("x", map[string]string{"a":"1"}, "")
fs.Set("x", "")  // Error: must be formatted as key=value
```

## After

```go
fs.Set("x", "")  // OK: map is now empty
```