### PR TITLE
fix: handle String() round-trip in Set() for stringToString

### DIFF
--- a/string_to_string.go
+++ b/string_to_string.go
@@ -24,6 +24,10 @@ func newStringToStringValue(val map[string]string, p *map[string]string) *string
 // Set updates the flag value from the given string, adding additional mappings or updating existing ones.
 func (s *stringToStringValue) Set(val string) error {
 	var ss []string
+	// Support round-trip from String() output like [k=v] or [k=[]]
+	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+		val = val[1 : len(val)-1]
+	}
 	n := strings.Count(val, "=")
 	switch n {
 	case 0:


### PR DESCRIPTION
Fixes #413. String() wraps output in brackets like [k=v], but Set() didn't strip them, causing round-trip failures when String() output was passed back to Set().