### PR TITLE
fix: nil FlagSet Lookup returns nil

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -424,6 +424,9 @@ func Visit(fn func(*Flag)) {
 
 // Lookup returns the Flag structure of the named flag, returning nil if none exists.
 func (f *FlagSet) Lookup(name string) *Flag {
+	if f == nil {
+		return nil
+	}
 	return f.lookup(f.normalizeFlagName(name))
 }
 
@@ -431,6 +434,9 @@ func (f *FlagSet) Lookup(name string) *Flag {
 // returning nil if none exists.
 // It panics, if len(name) > 1.
 func (f *FlagSet) ShorthandLookup(name string) *Flag {
+	if f == nil {
+		return nil
+	}
 	if name == "" {
 		return nil
 	}
@@ -445,6 +451,9 @@ func (f *FlagSet) ShorthandLookup(name string) *Flag {
 
 // lookup returns the Flag structure of the named flag, returning nil if none exists.
 func (f *FlagSet) lookup(name NormalizedName) *Flag {
+	if f == nil {
+		return nil
+	}
 	return f.formal[name]
 }
 

--- a/nil_fs_test.go
+++ b/nil_fs_test.go
@@ -1,0 +1,18 @@
+package pflag
+
+import "testing"
+
+func TestNilFlagSetLookup(t *testing.T) {
+	var f *FlagSet
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if f.Lookup("x") != nil {
+		t.Fatal("want nil")
+	}
+	if f.ShorthandLookup("x") != nil {
+		t.Fatal("want nil")
+	}
+}


### PR DESCRIPTION
```go
var fs *pflag.FlagSet
fs.Lookup("x") // panic
```

Return nil from Lookup / ShorthandLookup when the FlagSet is nil.