### PR TITLE
fix: trim surrounding space in duration flag values

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -2,6 +2,7 @@ package pflag
 
 import (
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -14,7 +15,7 @@ func newDurationValue(val time.Duration, p *time.Duration) *durationValue {
 }
 
 func (d *durationValue) Set(s string) error {
-	v, err := time.ParseDuration(s)
+	v, err := time.ParseDuration(strings.TrimSpace(s))
 	if err != nil {
 		return errors.New(`must be a duration like "30s" or "5m"`)
 	}
@@ -29,7 +30,7 @@ func (d *durationValue) Type() string {
 func (d *durationValue) String() string { return (*time.Duration)(d).String() }
 
 func durationConv(sval string) (interface{}, error) {
-	return time.ParseDuration(sval)
+	return time.ParseDuration(strings.TrimSpace(sval))
 }
 
 // GetDuration return the duration value of a flag with the given name

--- a/duration_trim_test.go
+++ b/duration_trim_test.go
@@ -1,0 +1,18 @@
+package pflag
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDurationTrimSpace(t *testing.T) {
+	f := NewFlagSet("test", ContinueOnError)
+	var d time.Duration
+	f.DurationVar(&d, "timeout", 0, "")
+	if err := f.Parse([]string{"--timeout", " 5s "}); err != nil {
+		t.Fatal(err)
+	}
+	if d != 5*time.Second {
+		t.Fatalf("got %v", d)
+	}
+}


### PR DESCRIPTION
## What

Duration flags accept values with leading/trailing whitespace (e.g. `" 5s "`).

## Why

Config and shell expansion often leave padding; `time.ParseDuration` does not trim.

## Test

- `TestDurationTrimSpace`