### PR TITLE
fix: treat empty StringArray value as empty slice

### DIFF
--- a/string_array.go
+++ b/string_array.go
@@ -15,7 +15,12 @@ func newStringArrayValue(val []string, p *[]string) *stringArrayValue {
 
 func (s *stringArrayValue) Set(val string) error {
 	if !s.changed {
-		*s.value = []string{val}
+		if val == "" {
+			// Explicit empty value should mean an empty array, not [""] (#415).
+			*s.value = []string{}
+		} else {
+			*s.value = []string{val}
+		}
 		s.changed = true
 	} else {
 		*s.value = append(*s.value, val)

--- a/string_array_test.go
+++ b/string_array_test.go
@@ -254,3 +254,15 @@ func TestSAWithSquareBrackets(t *testing.T) {
 		}
 	}
 }
+
+func TestStringArrayEmptyValue(t *testing.T) {
+	var ss []string
+	f := NewFlagSet("test", ContinueOnError)
+	f.StringArrayVar(&ss, "arr", nil, "usage")
+	if err := f.Parse([]string{"--arr="}); err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 0 {
+		t.Fatalf("got %#v, want empty slice", ss)
+	}
+}


### PR DESCRIPTION
## Summary

`--arr=` (empty) produced `[]string{\"\"}` instead of an empty slice (#415).

## Fix

On first `Set`, map empty string to `[]string{}`.

## Tests

```text
go test . -count=1 -run TestStringArrayEmptyValue
# ok
```

Fixes #415