### PR TITLE
Initialize the target map when a StringToString flag has a nil default

### DIFF
--- a/string_to_string.go
+++ b/string_to_string.go
@@ -55,6 +55,9 @@ func (s *stringToStringValue) Set(val string) error {
 		}
 	}
 
+	if *s.value == nil {
+		*s.value = make(map[string]string, len(out))
+	}
 	for k, v := range out {
 		(*s.value)[k] = v
 	}

--- a/string_to_string_test.go
+++ b/string_to_string_test.go
@@ -374,6 +374,20 @@ func TestS2SWithDefault(t *testing.T) {
 	}
 }
 
+func TestS2SNilDefault(t *testing.T) {
+	var s2s map[string]string
+	f := NewFlagSet("test", ContinueOnError)
+	f.StringToStringVar(&s2s, "s2s", nil, "Command separated ls!")
+
+	arg := fmt.Sprintf("--s2s=%s", createS2SFlag(map[string]string{"a": "1", "b": "2"}))
+	if err := f.Parse([]string{arg}); err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	if s2s["a"] != "1" || s2s["b"] != "2" {
+		t.Fatalf("expected a=1,b=2 but got: %v", s2s)
+	}
+}
+
 func TestS2SCalledTwice(t *testing.T) {
 	var s2s map[string]string
 	f := setUpS2SFlagSet(&s2s)


### PR DESCRIPTION
A `StringToString` flag declared with a **nil default map** panics with `assignment to entry in nil map` the first time it's set — `stringToStringValue.Set` writes into `*s.value` without allocating it.

This allocates the map when it's nil before merging the parsed values, and adds a nil-default regression test.

Verified: the new test panics on current code and passes with the fix; the full `pflag` suite stays green.

<sub>Developed with AI assistance (Claude Code); I directed, reviewed, and verified it locally.</sub>
