### PR TITLE
fix: honour deprecated ParseErrorsWhitelist.UnknownFlagsHandling

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -374,7 +374,7 @@ func (f *FlagSet) getUnknownFlagsHandling() UnknownFlagsHandling {
 	// then, check deprecated ParseErrorsWhitelist:
 	// if UnknownFlagsHandling is set, use it
 	if f.ParseErrorsWhitelist.UnknownFlagsHandling != ErrorOnUnknownFlag {
-		return f.ParseErrorsAllowlist.UnknownFlagsHandling
+		return f.ParseErrorsWhitelist.UnknownFlagsHandling
 	}
 
 	if f.ParseErrorsWhitelist.UnknownFlags {

--- a/flag_test.go
+++ b/flag_test.go
@@ -542,11 +542,16 @@ func testParseWithUnknownFlags(f *FlagSet, t *testing.T, setUnknownFlags func(f 
 	}
 }
 
-func testParseWithUnknownFlagsAndPassToArgs(f *FlagSet, t *testing.T) {
+func testParseWithUnknownFlagsAndPassToArgs(f *FlagSet, t *testing.T, setUp ...func(*FlagSet)) {
 	if f.Parsed() {
 		t.Fatal("f.Parse() = true before Parse")
 	}
-	f.ParseErrorsAllowlist.UnknownFlagsHandling = PassUnknownFlagToArgs
+	if len(setUp) == 0 {
+		f.ParseErrorsAllowlist.UnknownFlagsHandling = PassUnknownFlagToArgs
+	}
+	for _, s := range setUp {
+		s(f)
+	}
 	f.SetInterspersed(true)
 
 	f.BoolP("boola", "a", false, "bool value")
@@ -821,6 +826,13 @@ func TestIgnoreUnknownFlagsBackwardsCompat(t *testing.T) {
 func TestIgnoreUnknownFlagsAndPassToArgs(t *testing.T) {
 	ResetForTesting(func() { t.Error("bad parse") })
 	testParseWithUnknownFlagsAndPassToArgs(GetCommandLine(), t)
+}
+
+func TestIgnoreUnknownFlagsAndPassToArgsBackwardsCompat(t *testing.T) {
+	ResetForTesting(func() { t.Error("bad parse") })
+	testParseWithUnknownFlagsAndPassToArgs(GetCommandLine(), t, func(f *FlagSet) {
+		f.ParseErrorsWhitelist.UnknownFlagsHandling = PassUnknownFlagToArgs
+	})
 }
 func TestFlagSetParse(t *testing.T) {
 	testParse(NewFlagSet("test", ContinueOnError), t)


### PR DESCRIPTION
`getUnknownFlagsHandling` checks the deprecated `ParseErrorsWhitelist` after the current `ParseErrorsAllowlist`, but the deprecated branch returns the *Allowlist* field:

```go
// then, check deprecated ParseErrorsWhitelist:
if f.ParseErrorsWhitelist.UnknownFlagsHandling != ErrorOnUnknownFlag {
    return f.ParseErrorsAllowlist.UnknownFlagsHandling   // <- wrong struct
}
```

Control only reaches that line when `ParseErrorsAllowlist.UnknownFlagsHandling == ErrorOnUnknownFlag`, so it always returns `ErrorOnUnknownFlag` and setting the deprecated field does nothing at all. Callers still on `ParseErrorsWhitelist.UnknownFlagsHandling` silently lose the behaviour they asked for:

```go
f := pflag.NewFlagSet("t", pflag.ContinueOnError)
f.ParseErrorsWhitelist.UnknownFlagsHandling = pflag.IgnoreUnknownFlag
f.Parse([]string{"--unknown-flag", "value"})   // returns "unknown flag: --unknown-flag"
```

The neighbouring `ParseErrorsWhitelist.UnknownFlags` bool is handled correctly, and `TestIgnoreUnknownFlagsBackwardsCompat` covers it - only the `UnknownFlagsHandling` field is affected, which is why it slipped through.

One identifier changed. The test follows the existing pattern: `testParseWithUnknownFlagsAndPassToArgs` takes an optional setup func so the same body can be driven from either struct, and `TestIgnoreUnknownFlagsAndPassToArgsBackwardsCompat` mirrors the existing `TestIgnoreUnknownFlagsBackwardsCompat`. With the fix reverted that test fails; with it, the suite is green.
