### PR TITLE
ci: bump golangci-lint to v2.13 for Go 1.27

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,4 +51,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.7
+          version: v2.13

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,11 @@ linters:
         - unconvert
         - unparam
     settings:
+        govet:
+            disable:
+                # Suggests reflect.Pointer over reflect.Ptr, which needs Go 1.18.
+                # This module still builds and tests on Go 1.12 (see go.mod).
+                - inline
         staticcheck:
             # Enable all options, with some exceptions.
             # For defaults, see https://golangci-lint.run/usage/linters/#staticcheck


### PR DESCRIPTION
Taking up @tomasaschan's "PR welcome" from #500.

## The problem

`stable` now resolves to Go 1.27, and golangci-lint v2.7 is built with an older Go, so it cannot read 1.27's export data:

```
export data version 4 is greater than maximum supported version 2
```

Every stdlib import then fails to resolve and the run collapses into a typecheck cascade — including `errors.go:44:1: missing return` for a function whose last statement is `panic(...)`. Nothing in the module is actually wrong; the `Test` jobs stay green across all six matrix entries while `Lint` goes red, which makes unrelated PRs look broken.

## The change

- `v2.7` → `v2.13`. v2.13.0 added Go 1.27 support (golangci/golangci-lint#6642) and v2.13.2 is built with `go1.27.0`.
- The bump also enables govet's new `inline` analyzer, which flags `reflect.Ptr` in `golangflag.go` and `text.go` (3 sites) in favour of `reflect.Pointer`. `reflect.Pointer` landed in Go 1.18 and `go.mod` still declares `go 1.12` — which CI genuinely exercises — so I disabled the analyzer instead of touching the call sites. Worth reverting whenever the floor moves past 1.18; I left a comment saying so.

I kept this to the version bump. #451 already proposes restructuring the matrix, and I did not want to collide with it.

## Verification

Local, golangci-lint 2.13.2:

- `golangci-lint config verify` → exit 0
- `golangci-lint run` → exit 0, `0 issues`  (on the same tree, v2.13 without the govet change reports the 3 `reflect.Ptr` findings)
- `go test -race ./...` → ok

I could not reproduce the original failure locally — it needs a Go 1.27 toolchain, which is exactly the condition CI is now in — so the export-data diagnosis comes from the CI logs on #500 and #506 rather than a local repro.
