### PR TITLE
fix: preserve brackets in integer map keys

### DIFF
--- a/string_to_int.go
+++ b/string_to_int.go
@@ -66,7 +66,7 @@ func (s *stringToIntValue) String() string {
 }
 
 func stringToIntConv(val string) (interface{}, error) {
-	val = strings.Trim(val, "[]")
+	val = strings.TrimSuffix(strings.TrimPrefix(val, "["), "]")
 	// An empty string would cause an empty map
 	if len(val) == 0 {
 		return map[string]int{}, nil

--- a/string_to_int64.go
+++ b/string_to_int64.go
@@ -66,7 +66,7 @@ func (s *stringToInt64Value) String() string {
 }
 
 func stringToInt64Conv(val string) (interface{}, error) {
-	val = strings.Trim(val, "[]")
+	val = strings.TrimSuffix(strings.TrimPrefix(val, "["), "]")
 	// An empty string would cause an empty map
 	if len(val) == 0 {
 		return map[string]int64{}, nil

--- a/string_to_int64_test.go
+++ b/string_to_int64_test.go
@@ -11,6 +11,25 @@ import (
 	"testing"
 )
 
+func TestGetStringToInt64PreservesBracketKeys(t *testing.T) {
+	for _, key := range []string{"[key]", "[[key", "]key", "[]", "key"} {
+		t.Run(key, func(t *testing.T) {
+			f := NewFlagSet("test", ContinueOnError)
+			value := f.StringToInt64("map", nil, "")
+			if err := f.Parse([]string{"--map=" + key + "=42"}); err != nil {
+				t.Fatal(err)
+			}
+			got, err := f.GetStringToInt64("map")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 1 || got[key] != 42 || (*value)[key] != 42 {
+				t.Fatalf("getter = %v, bound value = %v; want key %q with value 42", got, *value, key)
+			}
+		})
+	}
+}
+
 func setUpS2I64FlagSet(s2ip *map[string]int64) *FlagSet {
 	f := NewFlagSet("test", ContinueOnError)
 	f.StringToInt64Var(s2ip, "s2i", map[string]int64{}, "Command separated ls2it!")

--- a/string_to_int_test.go
+++ b/string_to_int_test.go
@@ -55,6 +55,25 @@ func TestEmptyS2I(t *testing.T) {
 	}
 }
 
+func TestGetStringToIntPreservesBracketKeys(t *testing.T) {
+	for _, key := range []string{"[key]", "[[key", "]key", "[]", "key"} {
+		t.Run(key, func(t *testing.T) {
+			f := NewFlagSet("test", ContinueOnError)
+			value := f.StringToInt("map", nil, "")
+			if err := f.Parse([]string{"--map=" + key + "=42"}); err != nil {
+				t.Fatal(err)
+			}
+			got, err := f.GetStringToInt("map")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != 1 || got[key] != 42 || (*value)[key] != 42 {
+				t.Fatalf("getter = %v, bound value = %v; want key %q with value 42", got, *value, key)
+			}
+		})
+	}
+}
+
 func TestS2I(t *testing.T) {
 	var s2i map[string]int
 	f := setUpS2IFlagSet(&s2i)


### PR DESCRIPTION
`GetStringToInt` and `GetStringToInt64` strip every leading and trailing square bracket from the formatted map. This removes brackets that belong to the first key: parsing `--map=[key]=42` stores `[key]`, but the getter returns `key]`.

Remove only the single surrounding pair emitted by `String()`. Add table-driven regressions for bracketed keys, repeated opening brackets, a leading closing bracket, a brackets-only key, and an ordinary key. Each case checks the getter against the bound flag value.

Both getters fail the new bracket cases before the fix. Afterward, the full `go test -race ./...`, `go vet ./...`, and `golangci-lint run` pass on Go 1.27.1 (macOS arm64). Changes use APIs available under the project's Go 1.12 baseline.

Related to #413, but limited to the integer-valued map getters; the existing StringToString PRs are unaffected. Prepared with OpenAI Codex assistance, with the regression and validation commands executed locally.
